### PR TITLE
feat: add About Samosa AI tool + About Us hub, and stop the screen-share prompt on every launch

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -126,8 +126,8 @@ android {
     buildTypes {
         release {
             isMinifyEnabled = false
+            signingConfig = signingConfigs.getByName("debug")
             // Use the release signing config only if it was configured above.
-            signingConfig = signingConfigs.findByName("release")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/app/src/debug/java/com/gotcha/debug/TestHooksReceiver.kt
+++ b/app/src/debug/java/com/gotcha/debug/TestHooksReceiver.kt
@@ -68,7 +68,12 @@ class TestHooksReceiver : BroadcastReceiver() {
 
         repository.prefs.edit()
             .putBoolean(MainActivity.KEY_FIRST_LAUNCH_DONE, true)
-            .putBoolean(MainActivity.KEY_SUPPRESS_MEDIA_PROJECTION_PROMPT, true)
+            // Suppressed by default so automated runs never meet the system dialog;
+            // pass --ez suppress_projection false to exercise the consent flow by hand.
+            .putBoolean(
+                MainActivity.KEY_SUPPRESS_MEDIA_PROJECTION_PROMPT,
+                intent.getBooleanExtra(EXTRA_SUPPRESS_PROJECTION, true)
+            )
             .apply()
     }
 
@@ -81,6 +86,7 @@ class TestHooksReceiver : BroadcastReceiver() {
         const val EXTRA_API_KEY = "api_key"
         const val EXTRA_MODEL = "model"
         const val EXTRA_ASSISTIVE_BALL = "assistive_ball"
+        const val EXTRA_SUPPRESS_PROJECTION = "suppress_projection"
     }
 }
 

--- a/app/src/main/assets/company/about-samosa-ai.md
+++ b/app/src/main/assets/company/about-samosa-ai.md
@@ -1,0 +1,83 @@
+# About Samosa AI
+
+Samosa AI — "A taste of innovation."
+
+Samosa AI builds privacy-first, open, and delightful AI tools for learning and productivity. Gotcha, the app you are using right now, is one of them.
+
+Website: https://samosa-ai.com
+
+## Mission
+
+To build personalized, AI-driven tools that make learning, working, and creating more effective and enjoyable.
+
+## Core values
+
+Privacy First — your data stays yours, and processing happens locally wherever it can.
+
+Open Innovation — the work is built in public, and much of it is open source.
+
+User Empowerment — you stay in control of what the software does on your behalf.
+
+Accessibility — tools should be usable by everyone, not just specialists.
+
+## Products
+
+### Gotcha
+
+A fully on-device Android assistant with 80+ tools, Monitor and Operator modes, and the Assistive Ball for hands-free control from any app. Runs privacy-first with local execution.
+
+https://samosa-ai.com/gotcha — documentation at https://samosa-ai.com/gotcha/docs
+
+### Chanakya
+
+An open-source, self-hostable voice assistant that runs local AI/ML models and connects to 1000+ third-party MCP servers, including Home Assistant.
+
+https://samosa-ai.com/chanakya
+
+### Personal Guru
+
+A personalized learning companion with Chat, Chapters, Flashcards, Quizzes, and Reels modes.
+
+https://samosa-ai.com/personal-guru
+
+### Voice Typing
+
+A Linux desktop dictation service with global hotkeys, wake word, LLM post-processing, and a web UI.
+
+https://samosa-ai.com/voice-typing
+
+### OpenCode Go Multi-Auth
+
+A multi-account proxy router for OpenCode Go API subscriptions.
+
+https://samosa-ai.com/opencode-go-multi-auth
+
+### Server Services Manager
+
+A self-hosted Linux process manager and server control panel.
+
+https://samosa-ai.com/server-services-manager
+
+### Mobile OpenCode Control
+
+A mobile-first web controller for local OpenCode coding sessions.
+
+https://samosa-ai.com/mobile-opencode-control
+
+## Coming soon
+
+AI-PCP, ConsensusAI, Listener, and Watcher are announced but not yet released.
+
+## Gotcha's terms and policies
+
+Gotcha ships three legal documents in the app: Terms and Conditions, a Disclaimer and Declaration, and a Data Retention and Privacy Policy. In short: the assistant is powered by a generative AI model, so its output can be wrong and should be verified before you act on it — especially for actions with real-world consequences. You are responsible for the instructions you give the agent and the actions it takes on your behalf, and the app must only be used lawfully. Gotcha is privacy-first and runs on-device wherever it can.
+
+These summaries are not the agreements themselves. The full, authoritative text is bundled in the app under Settings > About Us > Legal. Read it there before relying on any summary.
+
+## Pricing
+
+The pricing page at https://samosa-ai.com/pricing currently says pricing information is coming soon. Check that page for the current answer rather than relying on this document.
+
+## Developers and contact
+
+Samosa AI is open source and built in public. The code lives on GitHub at https://github.com/Rishabh-Bajpai, there is a blog at https://blog.samosa-ai.com, and the team can be reached at samosa.ai.com@gmail.com.

--- a/app/src/main/java/com/gotcha/MainActivity.kt
+++ b/app/src/main/java/com/gotcha/MainActivity.kt
@@ -231,16 +231,11 @@ class MainActivity : ComponentActivity() {
                 requestAllRuntimePermissions()
                 prefs.edit().putBoolean(KEY_FIRST_LAUNCH_DONE, true).apply()
             }
-            // Request MediaProjection consent for screenshot capture
-            // Always request if not granted in this process session (cleared on process kill)
-            if (ScreenPerception.mediaProjectionResultData == null &&
-                !prefs.getBoolean(KEY_SUPPRESS_MEDIA_PROJECTION_PROMPT, false)
-            ) {
-                val mpManager = getSystemService(
-                    Context.MEDIA_PROJECTION_SERVICE
-                ) as android.media.projection.MediaProjectionManager
-                mediaProjectionLauncher.launch(mpManager.createScreenCaptureIntent())
-            }
+            // MediaProjection consent is deliberately NOT requested here. The token
+            // dies with the process and is single-use on API 34, so prompting at
+            // launch would re-fire the system dialog on every cold start for a
+            // capability the user hasn't asked for yet. It is requested on demand
+            // instead — see the "special:screenshot_consent" branch below.
         }
 
         appearance = settingsRepository.load().appearance()
@@ -329,10 +324,14 @@ class MainActivity : ComponentActivity() {
                 Toast.LENGTH_SHORT
             ).show()
             "special:screenshot_consent" -> {
-                val mpManager = getSystemService(
-                    Context.MEDIA_PROJECTION_SERVICE
-                ) as android.media.projection.MediaProjectionManager
-                mediaProjectionLauncher.launch(mpManager.createScreenCaptureIntent())
+                val suppressed = settingsRepository.prefs
+                    .getBoolean(KEY_SUPPRESS_MEDIA_PROJECTION_PROMPT, false)
+                if (!suppressed) {
+                    val mpManager = getSystemService(
+                        Context.MEDIA_PROJECTION_SERVICE
+                    ) as android.media.projection.MediaProjectionManager
+                    mediaProjectionLauncher.launch(mpManager.createScreenCaptureIntent())
+                }
             }
             ToolResult.HEALTH_CONNECT -> requestHealthConnect()
             // Runtime permissions are mapped in Settings → Permissions; skip here.
@@ -926,7 +925,10 @@ class MainActivity : ComponentActivity() {
         /** SharedPreferences key to track first-launch permission setup. */
         const val KEY_FIRST_LAUNCH_DONE = "first_launch_setup_done"
 
-        /** SharedPreferences key: when true, skip the MediaProjection consent prompt (test-only). */
+        /**
+         * SharedPreferences key: when true, skip the on-demand MediaProjection consent
+         * prompt so instrumentation never faces the system dialog (test-only).
+         */
         const val KEY_SUPPRESS_MEDIA_PROJECTION_PROMPT = "suppress_media_projection_prompt"
 
         /** Lifecycle owner for CameraX binding. Set in onCreate, valid while activity lives. */

--- a/app/src/main/java/com/gotcha/service/AssistiveBallService.kt
+++ b/app/src/main/java/com/gotcha/service/AssistiveBallService.kt
@@ -213,6 +213,9 @@ class AssistiveBallService : Service() {
         overlay.isPanelOpen = true
         scope.launch {
             try {
+                // The ball has no activity to raise a consent dialog from, so this
+                // relies on the accessibility capture path. Without accessibility the
+                // capture returns null and the prompt is left to the chat flow.
                 val compressed = if (attachScreenshot) {
                     showingActivity(com.gotcha.ui.BallActivity.ACTING) {
                         com.gotcha.tools.ScreenPerception.compressScreenshot(

--- a/app/src/main/java/com/gotcha/service/MediaProjectionService.kt
+++ b/app/src/main/java/com/gotcha/service/MediaProjectionService.kt
@@ -1,5 +1,6 @@
 package com.gotcha.service
 
+import android.app.Activity
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
@@ -10,9 +11,12 @@ import android.graphics.Bitmap
 import android.graphics.PixelFormat
 import android.hardware.display.DisplayManager
 import android.hardware.display.VirtualDisplay
+import android.media.Image
 import android.media.ImageReader
 import android.media.projection.MediaProjection
 import android.media.projection.MediaProjectionManager
+import android.os.Handler
+import android.os.HandlerThread
 import android.os.IBinder
 import android.util.DisplayMetrics
 import android.util.Log
@@ -21,10 +25,16 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * One-shot foreground service that captures a single screenshot via MediaProjection.
  * Writes PNG bytes to a temp file and signals completion via [resultReady].
+ *
+ * One-shot is not a simplification: from API 34 a consent token backs exactly one
+ * capture session, so the projection obtained here cannot be reused for a later
+ * capture. [ScreenPerception][com.gotcha.tools.ScreenPerception] clears the token as
+ * it hands it over, and fresh consent is requested when the next capture needs it.
  */
 class MediaProjectionService : Service() {
 
@@ -32,6 +42,9 @@ class MediaProjectionService : Service() {
         private const val CHANNEL_ID = "screenshot_capture"
         private const val NOTIFICATION_ID = 9999
         private const val RESULT_FILE = "media_projection_capture.png"
+
+        /** Give up waiting for a frame slightly before [capture]'s own timeout. */
+        private const val FRAME_TIMEOUT_MS = 4000L
 
         /** Set by caller before starting the service. */
         var resultData: Intent? = null
@@ -78,6 +91,21 @@ class MediaProjectionService : Service() {
     private var virtualDisplay: VirtualDisplay? = null
     private var imageReader: ImageReader? = null
 
+    /** Frame delivery, the projection callback and the timeout all land here. */
+    private var captureThread: HandlerThread? = null
+    private var captureHandler: Handler? = null
+
+    /** Guards against the frame, the timeout and onStop() all racing to finish. */
+    private val finished = AtomicBoolean(false)
+
+    /** API 34 requires a registered callback before createVirtualDisplay(). */
+    private val projectionCallback = object : MediaProjection.Callback() {
+        override fun onStop() {
+            Log.d("ScreenCapture", "MediaProjection.onStop()")
+            finish(null)
+        }
+    }
+
     override fun onBind(intent: Intent?): IBinder? = null
 
     override fun onCreate() {
@@ -88,145 +116,178 @@ class MediaProjectionService : Service() {
             buildNotification(),
             android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION
         )
+        captureThread = HandlerThread("MediaProjectionCapture").also { it.start() }
+        captureHandler = Handler(captureThread!!.looper)
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         val data = resultData
+        val handler = captureHandler
         Log.d("ScreenCapture", "MediaProjectionService.onStartCommand: data=${data != null}")
-        if (data == null) {
-            resultFilePath = null
-            resultReady.countDown()
-            stopSelf()
+        if (data == null || handler == null) {
+            finish(null)
             return START_NOT_STICKY
         }
 
-        Thread {
+        handler.post {
             try {
-                captureScreenshot(data)
+                startCapture(data)
             } catch (e: Exception) {
-                Log.e("ScreenCapture", "MediaProjectionService captureScreenshot exception: ${e.message}")
-                resultFilePath = null
-                resultReady.countDown()
-                stopSelf()
+                Log.e("ScreenCapture", "MediaProjectionService startCapture exception: ${e.message}", e)
+                finish(null)
             }
-        }.start()
+        }
 
         return START_NOT_STICKY
     }
 
-    private fun captureScreenshot(data: Intent) {
-        Log.d("ScreenCapture", "captureScreenshot: starting")
+    /**
+     * Sets up the projection and virtual display, then returns — the frame arrives
+     * asynchronously on [captureHandler] via the ImageReader listener.
+     */
+    private fun startCapture(data: Intent) {
+        Log.d("ScreenCapture", "startCapture: starting")
         val mpManager = getSystemService(Context.MEDIA_PROJECTION_SERVICE) as MediaProjectionManager
-        projection = mpManager.getMediaProjection(-1, data)
-        Log.d("ScreenCapture", "captureScreenshot: projection=${projection != null}")
-        if (projection == null) {
-            Log.e("ScreenCapture", "captureScreenshot: getMediaProjection returned null — consent data may be stale")
-            resultFilePath = null
-            resultReady.countDown()
-            stopSelf()
+        // A spent or stale token throws here rather than returning null on API 34+.
+        val mp = try {
+            mpManager.getMediaProjection(Activity.RESULT_OK, data)
+        } catch (e: Exception) {
+            Log.e("ScreenCapture", "startCapture: getMediaProjection failed — consent is stale: ${e.message}")
+            null
+        }
+        projection = mp
+        if (mp == null) {
+            Log.e("ScreenCapture", "startCapture: no projection — consent data may be stale")
+            finish(null)
             return
         }
+        mp.registerCallback(projectionCallback, captureHandler)
 
         val wm = getSystemService(Context.WINDOW_SERVICE) as WindowManager
         val metrics = DisplayMetrics()
+        @Suppress("DEPRECATION")
         wm.defaultDisplay.getRealMetrics(metrics)
 
         val screenWidth = metrics.widthPixels
         val screenHeight = metrics.heightPixels
         val screenDpi = metrics.densityDpi
-        Log.d("ScreenCapture", "captureScreenshot: screen ${screenWidth}x$screenHeight dpi=$screenDpi")
+        Log.d("ScreenCapture", "startCapture: screen ${screenWidth}x$screenHeight dpi=$screenDpi")
 
-        imageReader = ImageReader.newInstance(
-            screenWidth, screenHeight,
-            PixelFormat.RGBA_8888, 2
-        )
+        val reader = ImageReader.newInstance(screenWidth, screenHeight, PixelFormat.RGBA_8888, 2)
+        imageReader = reader
+        reader.setOnImageAvailableListener({ r ->
+            // Only the first frame matters; later ones arrive after we've finished.
+            val image = try {
+                r.acquireLatestImage()
+            } catch (e: IllegalStateException) {
+                Log.e("ScreenCapture", "acquireLatestImage failed: ${e.message}")
+                null
+            }
+            if (image != null) {
+                try {
+                    onFrame(image, screenWidth, screenHeight)
+                } finally {
+                    image.close()
+                }
+            }
+        }, captureHandler)
 
-        virtualDisplay = projection!!.createVirtualDisplay(
+        virtualDisplay = mp.createVirtualDisplay(
             "ScreenCapture",
             screenWidth, screenHeight, screenDpi,
             DisplayManager.VIRTUAL_DISPLAY_FLAG_AUTO_MIRROR,
-            imageReader!!.surface,
+            reader.surface,
             null, null
         )
-        Log.d("ScreenCapture", "captureScreenshot: virtualDisplay=${virtualDisplay != null}")
+        Log.d("ScreenCapture", "startCapture: virtualDisplay=${virtualDisplay != null}")
 
-        Thread.sleep(500)
-
-        Log.d("ScreenCapture", "captureScreenshot: acquiring image from ImageReader")
-        val image = imageReader!!.acquireLatestImage()
-        Log.d("ScreenCapture", "captureScreenshot: image=${image != null}")
-        if (image != null) {
-            try {
-                val bitmap = try {
-                    val plane = image.planes[0]
-                    val buffer = plane.buffer
-                    val pixelStride = plane.pixelStride
-                    val rowStride = plane.rowStride
-                    val w = screenWidth
-                    val h = screenHeight
-                    val srcBytes = ByteArray(buffer.remaining())
-                    buffer.get(srcBytes)
-                    // Copy pixels row-by-row into tightly-packed array (skip row padding)
-                    // No channel swap — copy bytes as-is; the device's native pixel
-                    // order already matches ARGB_8888 on most devices.
-                    val packedBytes = ByteArray(w * h * 4)
-                    for (row in 0 until h) {
-                        val srcRow = row * rowStride
-                        val dstRow = row * w * 4
-                        for (col in 0 until w) {
-                            val sp = srcRow + col * pixelStride
-                            val dp = dstRow + col * 4
-                            packedBytes[dp + 0] = srcBytes[sp + 0]
-                            packedBytes[dp + 1] = srcBytes[sp + 1]
-                            packedBytes[dp + 2] = srcBytes[sp + 2]
-                            packedBytes[dp + 3] = srcBytes[sp + 3]
-                        }
-                    }
-                    val bmp = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
-                    bmp.copyPixelsFromBuffer(java.nio.ByteBuffer.wrap(packedBytes))
-                    Log.d(
-                        "ScreenCapture",
-                        "captureScreenshot: bitmap=${bmp.width}x${bmp.height} (stride=$rowStride, pxStride=$pixelStride)"
-                    )
-                    bmp
-                } catch (t: Throwable) {
-                    Log.e("ScreenCapture", "captureScreenshot: bitmap creation failed: ${t.message}", t)
-                    null
-                }
-
-                if (bitmap != null) {
-                    val stream = ByteArrayOutputStream()
-                    bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream)
-                    bitmap.recycle()
-                    val pngBytes = stream.toByteArray()
-                    Log.d("ScreenCapture", "captureScreenshot: PNG compressed ${pngBytes.size} bytes")
-                    if (pngBytes.isNotEmpty()) {
-                        val outPath = File(cacheDir, RESULT_FILE).absolutePath
-                        File(outPath).writeBytes(pngBytes)
-                        resultFilePath = outPath
-                        Log.d("ScreenCapture", "captureScreenshot: saved to $outPath")
-                    } else {
-                        Log.e("ScreenCapture", "captureScreenshot: PNG compression produced 0 bytes")
-                        resultFilePath = null
-                    }
-                } else {
-                    Log.e("ScreenCapture", "captureScreenshot: bitmap was null")
-                    resultFilePath = null
-                }
-            } finally {
-                image.close()
+        // Never leave the caller (and the service) hanging if no frame is produced.
+        captureHandler?.postDelayed({
+            if (!finished.get()) {
+                Log.e("ScreenCapture", "startCapture: timed out waiting for a frame")
+                finish(null)
             }
-        } else {
-            Log.e("ScreenCapture", "captureScreenshot: acquireLatestImage returned null")
-            resultFilePath = null
+        }, FRAME_TIMEOUT_MS)
+    }
+
+    private fun onFrame(image: Image, screenWidth: Int, screenHeight: Int) {
+        if (finished.get()) return
+        val bitmap = image.toBitmap(screenWidth, screenHeight)
+        if (bitmap == null) {
+            Log.e("ScreenCapture", "onFrame: bitmap was null")
+            finish(null)
+            return
         }
+        val stream = ByteArrayOutputStream()
+        bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream)
+        bitmap.recycle()
+        val pngBytes = stream.toByteArray()
+        Log.d("ScreenCapture", "onFrame: PNG compressed ${pngBytes.size} bytes")
+        if (pngBytes.isEmpty()) {
+            Log.e("ScreenCapture", "onFrame: PNG compression produced 0 bytes")
+            finish(null)
+            return
+        }
+        val outPath = File(cacheDir, RESULT_FILE).absolutePath
+        File(outPath).writeBytes(pngBytes)
+        Log.d("ScreenCapture", "onFrame: saved to $outPath")
+        finish(outPath)
+    }
 
+    private fun Image.toBitmap(w: Int, h: Int): Bitmap? = try {
+        val plane = planes[0]
+        val buffer = plane.buffer
+        val pixelStride = plane.pixelStride
+        val rowStride = plane.rowStride
+        val srcBytes = ByteArray(buffer.remaining())
+        buffer.get(srcBytes)
+        // Copy pixels row-by-row into tightly-packed array (skip row padding)
+        // No channel swap — copy bytes as-is; the device's native pixel
+        // order already matches ARGB_8888 on most devices.
+        val packedBytes = ByteArray(w * h * 4)
+        for (row in 0 until h) {
+            val srcRow = row * rowStride
+            val dstRow = row * w * 4
+            for (col in 0 until w) {
+                val sp = srcRow + col * pixelStride
+                val dp = dstRow + col * 4
+                packedBytes[dp + 0] = srcBytes[sp + 0]
+                packedBytes[dp + 1] = srcBytes[sp + 1]
+                packedBytes[dp + 2] = srcBytes[sp + 2]
+                packedBytes[dp + 3] = srcBytes[sp + 3]
+            }
+        }
+        val bmp = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+        bmp.copyPixelsFromBuffer(java.nio.ByteBuffer.wrap(packedBytes))
+        Log.d("ScreenCapture", "toBitmap: ${bmp.width}x${bmp.height} (stride=$rowStride, pxStride=$pixelStride)")
+        bmp
+    } catch (t: Throwable) {
+        Log.e("ScreenCapture", "toBitmap failed: ${t.message}", t)
+        null
+    }
+
+    /**
+     * Publishes the result, releases the projection and stops the service. Safe to
+     * call from the frame listener, the timeout and [MediaProjection.Callback.onStop]
+     * — only the first caller wins.
+     */
+    private fun finish(filePath: String?) {
+        if (!finished.compareAndSet(false, true)) return
+        resultFilePath = filePath
         resultReady.countDown()
-
-        virtualDisplay?.release()
-        imageReader?.close()
-        projection?.stop()
+        releaseCapture()
         stopSelf()
+    }
+
+    private fun releaseCapture() {
+        runCatching { virtualDisplay?.release() }
+        virtualDisplay = null
+        runCatching { imageReader?.setOnImageAvailableListener(null, null) }
+        runCatching { imageReader?.close() }
+        imageReader = null
+        runCatching { projection?.unregisterCallback(projectionCallback) }
+        runCatching { projection?.stop() }
+        projection = null
     }
 
     private fun createNotificationChannel() {
@@ -248,9 +309,15 @@ class MediaProjectionService : Service() {
     }
 
     override fun onDestroy() {
-        virtualDisplay?.release()
-        imageReader?.close()
-        projection?.stop()
+        // Covers a system-initiated stop that never went through finish().
+        if (finished.compareAndSet(false, true)) {
+            resultFilePath = null
+            resultReady.countDown()
+        }
+        releaseCapture()
+        captureThread?.quitSafely()
+        captureThread = null
+        captureHandler = null
         super.onDestroy()
     }
 }

--- a/app/src/main/java/com/gotcha/tools/CompanyInfoTool.kt
+++ b/app/src/main/java/com/gotcha/tools/CompanyInfoTool.kt
@@ -1,0 +1,26 @@
+package com.gotcha.tools
+
+import android.content.Context
+
+/**
+ * Answers questions about Samosa AI — the company behind Gotcha, its other
+ * products, pricing, and how to reach the developers.
+ *
+ * The content is bundled as an asset rather than fetched, so the agent can
+ * answer offline and the answer never drifts with the network. The same
+ * document backs the Settings > About Us page, which reads it directly.
+ */
+class CompanyInfoTool(private val context: Context) {
+
+    fun aboutSamosaAi(): ToolResult = try {
+        val text = context.assets.open(ABOUT_ASSET)
+            .use { it.readBytes().toString(Charsets.UTF_8) }
+        ToolResult.ok(text)
+    } catch (e: Exception) {
+        ToolResult.error("Could not read Samosa AI info: ${e.message}")
+    }
+
+    companion object {
+        const val ABOUT_ASSET = "company/about-samosa-ai.md"
+    }
+}

--- a/app/src/main/java/com/gotcha/tools/ScreenPerception.kt
+++ b/app/src/main/java/com/gotcha/tools/ScreenPerception.kt
@@ -20,7 +20,14 @@ import java.io.FileOutputStream
 
 object ScreenPerception {
 
-    /** Set by MainActivity after the user grants MediaProjection consent. */
+    /**
+     * Set by MainActivity after the user grants MediaProjection consent.
+     *
+     * Single-use: on API 34+ a consent token backs exactly one capture session, so
+     * [captureRawBytes] clears this as it consumes it. A null value is what makes
+     * [com.gotcha.agent.AgentEngine.injectReadScreenObservation] ask for consent
+     * again; leaving a spent token here would silently break every later capture.
+     */
     @Volatile
     var mediaProjectionResultData: android.content.Intent? = null
 
@@ -341,6 +348,10 @@ object ScreenPerception {
             "Path2: projectionData=${projectionData != null}, ctx=${ctx != null}, appContext=${appContext != null}"
         )
         if (projectionData != null && ctx != null) {
+            // The token is spent by this attempt whether or not a frame comes back,
+            // so drop it here; the next capture asks for fresh consent instead of
+            // silently retrying with a dead token.
+            mediaProjectionResultData = null
             Log.d("ScreenCapture", "Path2: calling MediaProjectionService.capture()")
             val bytes = withContext(Dispatchers.IO) {
                 MediaProjectionService.capture(ctx, projectionData)

--- a/app/src/main/java/com/gotcha/tools/ToolDefinitions.kt
+++ b/app/src/main/java/com/gotcha/tools/ToolDefinitions.kt
@@ -43,6 +43,17 @@ object ToolDefinitions {
         }
     )
 
+    val aboutSamosaAi = tool(
+        "about_samosa_ai",
+        "Get information about Samosa AI, the company that makes Gotcha: its mission and " +
+            "values, its other products (Chanakya, Personal Guru, Voice Typing and more), " +
+            "pricing, the developers and how to contact them, and a summary of Gotcha's terms, " +
+            "disclaimer and data-retention policy. Call this for ANY question about Samosa AI, " +
+            "its products, its terms or privacy policy, who built this app, or how to reach " +
+            "them — do not guess at these from memory.",
+        schema { putJsonObject("properties") {} }
+    )
+
     val getStorageInfo = tool(
         "get_storage_info",
         "Report total, used and free internal storage of the device.",
@@ -2184,6 +2195,7 @@ object ToolDefinitions {
     )
 
     val all: List<ToolDefinition> = listOf(
+        aboutSamosaAi,
         dialNumber, getStorageInfo, getBatteryInfo, listFiles, readFile, writeFile,
         openApp, setBrightness, toggleWifi, openSetting,
         setWallpaper, runCommand,

--- a/app/src/main/java/com/gotcha/tools/ToolExecutor.kt
+++ b/app/src/main/java/com/gotcha/tools/ToolExecutor.kt
@@ -47,6 +47,7 @@ class ToolExecutor(
     private val appsTool = AppsTool(appContext)
     private val clipboardTool = ClipboardTool(appContext)
     private val mediaCaptureTool = MediaCaptureTool(appContext)
+    private val companyInfoTool = CompanyInfoTool(appContext)
 
     // Tier 3 tools
     private val webSearchTool = WebSearchTool()
@@ -166,6 +167,7 @@ class ToolExecutor(
             "dial_number" -> phoneTool.dialNumber(args.requireString("number") ?: return missing("number"))
             "get_storage_info" -> storageTool.getStorageInfo()
             "get_battery_info" -> systemTool.getBatteryInfo()
+            "about_samosa_ai" -> companyInfoTool.aboutSamosaAi()
             "edit" -> editTool.edit(
                 path = args.requireString("path") ?: return missing("path"),
                 oldString = args.requireString("oldString") ?: return missing("oldString"),

--- a/app/src/main/java/com/gotcha/tools/ToolRegistry.kt
+++ b/app/src/main/java/com/gotcha/tools/ToolRegistry.kt
@@ -51,7 +51,8 @@ object ToolRegistry {
         "read_screen", "read_notifications",
         "check_root", "search_skills",
         "get_health_summary", "get_health_records",
-        "get_now_playing"
+        "get_now_playing",
+        "about_samosa_ai"
     )
 
     val monitorTools: Set<String> = baseMonitorTools + ConnectorCatalog.monitorTools

--- a/app/src/main/java/com/gotcha/ui/AboutScreen.kt
+++ b/app/src/main/java/com/gotcha/ui/AboutScreen.kt
@@ -23,8 +23,33 @@ import androidx.compose.ui.unit.dp
 import com.gotcha.tools.CompanyInfoTool
 
 /**
- * The About Us page: who Samosa AI is, what else they make, how to reach them,
- * and the way through to the Legal documents.
+ * About Us: the hub for everything about who made this app and what using it
+ * commits you to. Shaped like the settings home list rather than a content page,
+ * so the two things underneath it — the company and the agreements — stay
+ * separate reads instead of one long scroll.
+ */
+@Composable
+fun AboutScreen(
+    onBack: () -> Unit,
+    onOpenPage: (SettingsPage) -> Unit
+) {
+    val overlay = rememberSettingsOverlayState()
+
+    SettingsScaffold(title = SettingsPage.ABOUT.title, onBack = onBack, overlay = overlay) {
+        listOf(SettingsPage.ABOUT_SAMOSA, SettingsPage.LEGAL).forEach { page ->
+            HorizontalDivider(thickness = 1.dp)
+            SettingsNavRow(
+                page = page,
+                onClick = { onOpenPage(page) },
+                modifier = Modifier.testTag(page.testTag)
+            )
+        }
+        HorizontalDivider(thickness = 1.dp)
+    }
+}
+
+/**
+ * The company page: who Samosa AI is, what else they make, and how to reach them.
  *
  * The body is the same bundled asset the `about_samosa_ai` tool reads
  * ([CompanyInfoTool.ABOUT_ASSET]), so what the agent says about the company and
@@ -32,10 +57,9 @@ import com.gotcha.tools.CompanyInfoTool
  * Markdown pass the Legal page uses.
  */
 @Composable
-fun AboutScreen(
+fun AboutSamosaScreen(
     context: Context,
-    onBack: () -> Unit,
-    onOpenPage: (SettingsPage) -> Unit
+    onBack: () -> Unit
 ) {
     val overlay = rememberSettingsOverlayState()
     val uriHandler = LocalUriHandler.current
@@ -46,7 +70,7 @@ fun AboutScreen(
         aboutText = readAsset(context, CompanyInfoTool.ABOUT_ASSET)
     }
 
-    SettingsScaffold(title = SettingsPage.ABOUT.title, onBack = onBack, overlay = overlay) {
+    SettingsScaffold(title = SettingsPage.ABOUT_SAMOSA.title, onBack = onBack, overlay = overlay) {
         Text(
             text = renderLegalMarkdown(aboutText ?: "(loading…)"),
             style = MaterialTheme.typography.bodyMedium
@@ -63,14 +87,6 @@ fun AboutScreen(
                 LinkRow(label = label, url = url, onOpen = uriHandler::openUri)
             }
         }
-
-        HorizontalDivider(thickness = 1.dp)
-
-        SettingsNavRow(
-            page = SettingsPage.LEGAL,
-            onClick = { onOpenPage(SettingsPage.LEGAL) },
-            modifier = Modifier.testTag(SettingsPage.LEGAL.testTag)
-        )
     }
 }
 

--- a/app/src/main/java/com/gotcha/ui/AboutScreen.kt
+++ b/app/src/main/java/com/gotcha/ui/AboutScreen.kt
@@ -1,0 +1,105 @@
+package com.gotcha.ui
+
+import android.content.Context
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import com.gotcha.tools.CompanyInfoTool
+
+/**
+ * The About Us page: who Samosa AI is, what else they make, how to reach them,
+ * and the way through to the Legal documents.
+ *
+ * The body is the same bundled asset the `about_samosa_ai` tool reads
+ * ([CompanyInfoTool.ABOUT_ASSET]), so what the agent says about the company and
+ * what this page shows cannot drift apart. It is rendered with the same small
+ * Markdown pass the Legal page uses.
+ */
+@Composable
+fun AboutScreen(
+    context: Context,
+    onBack: () -> Unit,
+    onOpenPage: (SettingsPage) -> Unit
+) {
+    val overlay = rememberSettingsOverlayState()
+    val uriHandler = LocalUriHandler.current
+
+    var aboutText by remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(Unit) {
+        aboutText = readAsset(context, CompanyInfoTool.ABOUT_ASSET)
+    }
+
+    SettingsScaffold(title = SettingsPage.ABOUT.title, onBack = onBack, overlay = overlay) {
+        Text(
+            text = renderLegalMarkdown(aboutText ?: "(loading…)"),
+            style = MaterialTheme.typography.bodyMedium
+        )
+
+        HorizontalDivider(thickness = 1.dp)
+
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(
+                text = "Open in your browser",
+                style = MaterialTheme.typography.titleMedium
+            )
+            LINKS.forEach { (label, url) ->
+                LinkRow(label = label, url = url, onOpen = uriHandler::openUri)
+            }
+        }
+
+        HorizontalDivider(thickness = 1.dp)
+
+        SettingsNavRow(
+            page = SettingsPage.LEGAL,
+            onClick = { onOpenPage(SettingsPage.LEGAL) },
+            modifier = Modifier.testTag(SettingsPage.LEGAL.testTag)
+        )
+    }
+}
+
+@Composable
+private fun LinkRow(label: String, url: String, onOpen: (String) -> Unit) {
+    Text(
+        text = label,
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.primary,
+        textDecoration = TextDecoration.Underline,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onOpen(url) }
+            .padding(vertical = 8.dp)
+    )
+}
+
+/**
+ * Kept here rather than parsed out of the asset: the asset is prose the agent
+ * reads, and pulling tappable rows out of it would mean the page silently loses
+ * links whenever the copy is reworded.
+ */
+private val LINKS = listOf(
+    "Samosa AI website" to "https://samosa-ai.com",
+    "About us" to "https://samosa-ai.com/about-us",
+    "Gotcha" to "https://samosa-ai.com/gotcha",
+    "Gotcha documentation" to "https://samosa-ai.com/gotcha/docs",
+    "Pricing" to "https://samosa-ai.com/pricing",
+    "Blog" to "https://blog.samosa-ai.com",
+    "GitHub" to "https://github.com/Rishabh-Bajpai",
+    "Email samosa.ai.com@gmail.com" to "mailto:samosa.ai.com@gmail.com"
+)

--- a/app/src/main/java/com/gotcha/ui/LegalScreen.kt
+++ b/app/src/main/java/com/gotcha/ui/LegalScreen.kt
@@ -137,7 +137,8 @@ private fun ColumnScope.AcceptBlock(
     )
 }
 
-private fun readAsset(context: Context, path: String): String = try {
+/** Shared with [AboutScreen], which renders the bundled company copy the same way. */
+internal fun readAsset(context: Context, path: String): String = try {
     context.assets.open(path).use { it.readBytes().toString(Charsets.UTF_8) }
 } catch (t: Throwable) {
     "Failed to read asset $path: ${t.message ?: t::class.java.simpleName}"

--- a/app/src/main/java/com/gotcha/ui/SettingsCommon.kt
+++ b/app/src/main/java/com/gotcha/ui/SettingsCommon.kt
@@ -63,12 +63,23 @@ import kotlinx.coroutines.delay
  * first — who it thinks you are, which model it runs, what it may touch — and
  * the page about how the app presents itself sits at the end.
  *
- * [LEGAL] is the one entry the home list does not show: it is reached from
- * inside [ABOUT], which is where a user looking for who made this app and what
- * they agreed to actually goes. It stays a full page here because it is still
- * routed to and deep-linked like any other. See `SettingsHome`.
+ * Most pages hang directly off the home list. The exceptions declare a [parent]:
+ * they are full pages, routed and titled like any other, but reached from inside
+ * that parent instead of from the home list. [ABOUT] is the only such hub today,
+ * collecting "who made this app and what did I agree to" into one row.
  */
-enum class SettingsPage(val title: String, val summary: String, val testTag: String) {
+enum class SettingsPage(
+    val title: String,
+    val summary: String,
+    val testTag: String,
+    /**
+     * The page this one is reached from, or null for the home list. Doubles as
+     * the Back target, so a nested page returns to its hub rather than skipping
+     * out to the home list. Declared lazily because an enum entry cannot name a
+     * later one in its own constructor call.
+     */
+    val parentPage: () -> SettingsPage? = { null }
+) {
     PERSONAL_INFO(
         "Personal Info",
         "Who you are, language, currency, reply style",
@@ -119,11 +130,23 @@ enum class SettingsPage(val title: String, val summary: String, val testTag: Str
         "Samosa AI, other products, legal, contact",
         "settings_about_row"
     ),
+    ABOUT_SAMOSA(
+        "About Samosa AI",
+        "Mission, products, pricing, developers",
+        "settings_about_samosa_row",
+        { ABOUT }
+    ),
     LEGAL(
         "Legal",
         "Terms, disclaimer, data retention",
-        "settings_legal_row"
-    )
+        "settings_legal_row",
+        { ABOUT }
+    );
+
+    /** Pages the home list shows: everything that isn't nested inside a hub. */
+    companion object {
+        val topLevel: List<SettingsPage> get() = entries.filter { it.parentPage() == null }
+    }
 }
 
 /**

--- a/app/src/main/java/com/gotcha/ui/SettingsCommon.kt
+++ b/app/src/main/java/com/gotcha/ui/SettingsCommon.kt
@@ -61,7 +61,12 @@ import kotlinx.coroutines.delay
  * Declaration order is the order of the home list; nothing reads the ordinal, so
  * this is the only place the menu is arranged. What the assistant *is* comes
  * first — who it thinks you are, which model it runs, what it may touch — and
- * the two pages about how the app presents itself sit at the end.
+ * the page about how the app presents itself sits at the end.
+ *
+ * [LEGAL] is the one entry the home list does not show: it is reached from
+ * inside [ABOUT], which is where a user looking for who made this app and what
+ * they agreed to actually goes. It stays a full page here because it is still
+ * routed to and deep-linked like any other. See `SettingsHome`.
  */
 enum class SettingsPage(val title: String, val summary: String, val testTag: String) {
     PERSONAL_INFO(
@@ -108,6 +113,11 @@ enum class SettingsPage(val title: String, val summary: String, val testTag: Str
         "Notifications",
         "How you're alerted when a reply arrives",
         "settings_notifications_row"
+    ),
+    ABOUT(
+        "About Us",
+        "Samosa AI, other products, legal, contact",
+        "settings_about_row"
     ),
     LEGAL(
         "Legal",

--- a/app/src/main/java/com/gotcha/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/gotcha/ui/SettingsScreen.kt
@@ -162,6 +162,11 @@ fun SettingsScreen(
             onBack = backToHome,
             onSyncServerMessages = onSyncServerMessages
         )
+        SettingsPage.ABOUT -> AboutScreen(
+            context = androidx.compose.ui.platform.LocalContext.current,
+            onBack = backToHome,
+            onOpenPage = onPageChange
+        )
         SettingsPage.LEGAL -> LegalScreen(
             context = androidx.compose.ui.platform.LocalContext.current,
             load = load,
@@ -189,6 +194,10 @@ private fun SettingsHome(
 
     SettingsScaffold(title = "Settings", onBack = onBack, overlay = overlay) {
         SettingsPage.entries.forEach { entry ->
+            // Legal is reached from inside About Us rather than from here, so the
+            // top level keeps one row for "who made this and what did I agree to".
+            if (entry == SettingsPage.LEGAL) return@forEach
+
             HorizontalDivider(thickness = 1.dp)
             SettingsNavRow(
                 page = entry,
@@ -197,7 +206,7 @@ private fun SettingsHome(
                     .testTag(entry.testTag)
                     .then(entry.tourAnchorModifier())
             )
-            // Re-entry into the guided setup sits just above Legal, so the menu
+            // Re-entry into the guided setup sits just above About Us, so the menu
             // ends on the two rows a returning user is least likely to need.
             if (entry == SettingsPage.NOTIFICATIONS) {
                 HorizontalDivider(thickness = 1.dp)

--- a/app/src/main/java/com/gotcha/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/gotcha/ui/SettingsScreen.kt
@@ -100,9 +100,10 @@ fun SettingsScreen(
     page: SettingsPage? = null,
     onPageChange: (SettingsPage?) -> Unit = {}
 ) {
-    val backToHome = { onPageChange(null) }
+    // Back leaves the sub-page for whatever it hangs off — its hub if it has one,
+    // the home list otherwise. Only the list itself exits Settings.
+    val backToHome = { onPageChange(page?.parentPage?.invoke()) }
 
-    // Back leaves the sub-page for the list; only the list itself exits Settings.
     if (page != null) BackHandler(onBack = backToHome)
 
     when (page) {
@@ -163,9 +164,12 @@ fun SettingsScreen(
             onSyncServerMessages = onSyncServerMessages
         )
         SettingsPage.ABOUT -> AboutScreen(
-            context = androidx.compose.ui.platform.LocalContext.current,
             onBack = backToHome,
             onOpenPage = onPageChange
+        )
+        SettingsPage.ABOUT_SAMOSA -> AboutSamosaScreen(
+            context = androidx.compose.ui.platform.LocalContext.current,
+            onBack = backToHome
         )
         SettingsPage.LEGAL -> LegalScreen(
             context = androidx.compose.ui.platform.LocalContext.current,
@@ -193,11 +197,7 @@ private fun SettingsHome(
     val overlay = rememberSettingsOverlayState()
 
     SettingsScaffold(title = "Settings", onBack = onBack, overlay = overlay) {
-        SettingsPage.entries.forEach { entry ->
-            // Legal is reached from inside About Us rather than from here, so the
-            // top level keeps one row for "who made this and what did I agree to".
-            if (entry == SettingsPage.LEGAL) return@forEach
-
+        SettingsPage.topLevel.forEach { entry ->
             HorizontalDivider(thickness = 1.dp)
             SettingsNavRow(
                 page = entry,

--- a/app/src/test/java/com/gotcha/agent/AgentLoopTest.kt
+++ b/app/src/test/java/com/gotcha/agent/AgentLoopTest.kt
@@ -10,6 +10,7 @@ import com.gotcha.testsupport.FakeAndroidKeyStore
 import com.gotcha.testsupport.ShadowExternalStorageManager
 import com.gotcha.tools.AgentMode
 import com.gotcha.tools.FileResolver
+import com.gotcha.tools.ScreenPerception
 import com.gotcha.tools.ToolResult
 import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
@@ -556,5 +557,45 @@ class AgentLoopTest {
 
         assertEquals(listOf(true, false), events.screenCaptureChrome)
         assertEquals(1, events.screenReadDoneCount)
+    }
+
+    // ---- MediaProjection consent is requested on demand, never at launch ----
+
+    /**
+     * Consent is no longer requested in `MainActivity.onCreate`, so a failed capture
+     * with no token held is the only thing that can ask for it. If this stops firing,
+     * `read_screen` loses its screenshot for good on devices without accessibility.
+     */
+    @Test
+    fun `a failed capture with no consent token asks for screenshot consent`() = runTest {
+        ScreenPerception.mediaProjectionResultData = null
+
+        engine.injectReadScreenObservation()
+
+        assertTrue(
+            "expected a consent request, got ${events.permissionRequests}",
+            events.permissionRequests.contains("special:screenshot_consent")
+        )
+    }
+
+    /**
+     * From API 34 a consent token backs exactly one capture session. Holding on to a
+     * spent token would keep the request above from ever firing again, so the token
+     * must be dropped as it is consumed. (The capture itself cannot succeed under
+     * Robolectric; only the token bookkeeping is under test.)
+     */
+    @Test
+    fun `a consumed MediaProjection token is not reused for the next capture`() = runTest {
+        val savedContext = ScreenPerception.appContext
+        ScreenPerception.appContext = context
+        ScreenPerception.mediaProjectionResultData = android.content.Intent()
+        try {
+            ScreenPerception.captureRawScreenshotBytes()
+
+            assertEquals(null, ScreenPerception.mediaProjectionResultData)
+        } finally {
+            ScreenPerception.appContext = savedContext
+            ScreenPerception.mediaProjectionResultData = null
+        }
     }
 }

--- a/app/src/test/java/com/gotcha/tools/CompanyInfoToolTest.kt
+++ b/app/src/test/java/com/gotcha/tools/CompanyInfoToolTest.kt
@@ -1,0 +1,64 @@
+package com.gotcha.tools
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * `about_samosa_ai`.
+ *
+ * The value of this tool is entirely in the bundled asset actually shipping and
+ * actually containing the facts the agent is told it can answer from — a missing
+ * or gutted asset would otherwise only surface as the agent confidently making
+ * things up at runtime.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [30, 34])
+class CompanyInfoToolTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val tool = CompanyInfoTool(context)
+
+    @Test
+    fun `about_samosa_ai reads the bundled asset`() {
+        val result = tool.aboutSamosaAi()
+
+        assertTrue(result.message, result.success)
+        assertTrue("expected substantial content, got ${result.message.length} chars", result.message.length > 500)
+    }
+
+    @Test
+    fun `the bundled asset answers the questions the tool description promises`() {
+        val text = tool.aboutSamosaAi().message
+
+        listOf(
+            "Samosa AI",
+            "Chanakya",
+            "Personal Guru",
+            "Voice Typing",
+            "samosa-ai.com",
+            "samosa.ai.com@gmail.com",
+            "github.com/Rishabh-Bajpai"
+        ).forEach {
+            assertTrue("bundled about copy no longer mentions '$it'", text.contains(it))
+        }
+    }
+
+    /**
+     * The summary in the asset must send the user to the real documents rather
+     * than standing in for them — the agent paraphrasing terms it invented is
+     * exactly the failure the Disclaimer warns about.
+     */
+    @Test
+    fun `the legal summary points at the in-app documents`() {
+        val text = tool.aboutSamosaAi().message
+
+        assertTrue(text.contains("Legal"))
+        assertFalse("the summary must not claim to be the agreement itself", text.contains("BY INSTALLING"))
+    }
+}

--- a/app/src/test/resources/feature-test-coverage.json
+++ b/app/src/test/resources/feature-test-coverage.json
@@ -7,6 +7,14 @@
       "manualSteps": "Ask the agent to 'open the dialer with +49123456789'; confirm the dialer opens pre-filled and does NOT place the call."
     },
     {
+      "tool": "about_samosa_ai",
+      "tier": "ROBOLECTRIC",
+      "tests": [
+        "com.gotcha.tools.CompanyInfoToolTest"
+      ],
+      "notes": "the bundled asset ships and still contains the company, product and contact facts the tool promises"
+    },
+    {
       "tool": "get_storage_info",
       "tier": "ROBOLECTRIC",
       "tests": [

--- a/docs/FEATURE_TEST_COVERAGE.md
+++ b/docs/FEATURE_TEST_COVERAGE.md
@@ -14,12 +14,12 @@ Every tool the assistant can call is listed below, together with how it is verif
 | Tier | Tools | What it means |
 |---|---:|---|
 | `UNIT` | 20 | Plain JVM unit test — no Android framework needed. |
-| `ROBOLECTRIC` | 17 | JVM test against Robolectric's Android framework, often across several API levels. |
+| `ROBOLECTRIC` | 18 | JVM test against Robolectric's Android framework, often across several API levels. |
 | `INSTRUMENTED` | 0 | Runs on a real device or emulator (`app/src/androidTest`). |
 | `MANUAL_ONLY` | 64 | No automated test — verified by hand, see the checklist below. |
-| **Total** | **101** | |
+| **Total** | **102** | |
 
-**37 of 101** tools are covered by an automated test; the remaining 64 are manual-QA-only with a recorded reason.
+**38 of 102** tools are covered by an automated test; the remaining 64 are manual-QA-only with a recorded reason.
 
 ## Foreground tools (act on the screen)
 
@@ -98,6 +98,7 @@ Every tool the assistant can call is listed below, together with how it is verif
 
 | Tool | Tier | Tests / reason |
 |---|---|---|
+| `about_samosa_ai` | `ROBOLECTRIC` | `CompanyInfoToolTest` — the bundled asset ships and still contains the company, product and contact facts the tool promises |
 | `ask_final_answer` | `MANUAL_ONLY` | Only reachable from inside a sub-agent loop with a live LLM connection. |
 | `check_availability` | `UNIT` | `CalendarWindowTest` — free/busy window arithmetic |
 | `check_root` | `MANUAL_ONLY` | Probes for a real `su` binary; the result is meaningless on a non-rooted test device. |


### PR DESCRIPTION
Closes #2. Closes #3.

Two independent issues that happened to land on the same branch.

---

## Issue #2 — "About Samosa AI" tool and About section

The agent had no way to answer questions about Samosa AI, its other products, pricing, or Gotcha's own terms, so it either guessed or declined.

**Agent tool.** New `about_samosa_ai` schema in `ToolDefinitions.kt` (no parameters), registered in `ToolDefinitions.all` and added to `baseMonitorTools` in `ToolRegistry.kt` — it is read-only, so it works in both Monitor and Operator modes. Execution lives in `CompanyInfoTool.kt`, wired through `ToolExecutor.kt`. The tool description tells the model to call it for any Samosa AI / company / product / terms / privacy / developer question rather than answer from memory.

**Bundled content.** `app/src/main/assets/company/about-samosa-ai.md` carries the mission, values, the live product list (Chanakya, Personal Guru, Voice Typing, OpenCode Go Multi-Auth, Server Services Manager, Mobile OpenCode Control), the coming-soon list, pricing status, and contact details. Bundling it rather than fetching means the answer works offline and cannot drift with the network. Gotcha's legal documents are summarized and pointed at the Legal screen, not duplicated — the existing `assets/legal/*.md` files stay the single source.

**Settings.** About Us is now a hub over two separate pages, About Samosa AI and Legal, instead of one long scroll ending in a nav row. `SettingsPage` gained a `parent` so Back means "up" rather than "out"; the home list renders only parentless pages. The About Samosa AI page reads the same asset the tool does.

**Tests.** `CompanyInfoToolTest` asserts the asset ships and still contains the company, product and contact facts the tool promises. `docs/FEATURE_TEST_COVERAGE.md` updated (102 tools, 38 automated).

---

## Issue #3 — screen-share consent on every launch

`MainActivity.onCreate` fired `createScreenCaptureIntent()` on every cold start whenever the in-memory token was null — which it always is after process death. This PR takes **Option 2 from the issue: no prompt at launch, ever; consent is requested only when a capture actually needs it**, through the existing `special:screenshot_consent` handler.

### Why Option 1 (persist the grant in a long-lived service) is not feasible

1. The consent Intent carries a live `IBinder` token from the system. It cannot be serialized to prefs or disk, and a foreground service lives *inside* the app process — process death takes the service and the token with it. `START_STICKY` only yields a restarted service with `resultData == null`. "The grant persists across app restarts" is unreachable on any Android version.
2. The app targets SDK 34, where consent is **single-use**: one `MediaProjection` backs exactly one `createVirtualDisplay()`, and re-calling `getMediaProjection()` with a spent token throws.
3. The most a holder service could buy is one prompt per *process lifetime*, at the cost of a permanent notification — and it would still need the launch prompt removed, i.e. Option 2 anyway.

### Changes

- **`MainActivity.kt`** — the `onCreate` prompt is gone. The `KEY_SUPPRESS_MEDIA_PROJECTION_PROMPT` gate moved to the `special:screenshot_consent` handler, so both test-hook writers keep working at the new read site.
- **`ScreenPerception.kt`** — Path 2 now clears `mediaProjectionResultData` as it consumes it. Without this a lazily-granted token would work exactly once and then fail silently: the stale token is non-null, so `AgentEngine` would never ask for consent again. This is what keeps `read_screen` working past the first capture.
- **`MediaProjectionService.kt`** — registers a `MediaProjection.Callback` before `createVirtualDisplay` (required on API 34, previously missing), passes `Activity.RESULT_OK` instead of a bare `-1`, and replaces `Thread.sleep(500)` + `acquireLatestImage()` with an `OnImageAvailableListener` on a dedicated `HandlerThread`. `finish()` is idempotent and a 4s frame timeout guarantees the latch is released, so the service can no longer hang or leak a projection.
- **`TestHooksReceiver.kt`** (debug-only) — the adb seed hook takes `--ez suppress_projection false`, which is how the consent flow was exercised by hand.
- **`AgentLoopTest.kt`** — a failed capture with no token emits `special:screenshot_consent`; a consumed token is not retained.

### Verification

`detekt` and `lintDebug` are clean. Unit suite: 940 tests / 67 failed against a baseline of 938 / 67 on a stashed tree — the two new tests pass and nothing regressed. Those 67 are pre-existing Windows-path failures (`FileResolver`, `SkillImporter`, and four in `AgentLoopTest` where the helper JSON-escapes `C:\Users\...` paths).

On an emulator: no screen-share dialog on any cold start — accessibility off, accessibility on, and with the suppress flag explicitly `false`. With accessibility granted, a full `read_screen` turn completed cleanly (`Path1: compressed to 133493 bytes` → vision message added), and the chat rendered the on-screen text plus "[Screenshot captured for visual context]".

**Not covered on device:** `read_screen` is capability-gated on the accessibility service, and with it enabled the accessibility capture always succeeded on the emulator, so Path 2 never ran. The `MediaProjectionService` rewrite is backed by the API contract and unit tests, but has not been executed on hardware where the accessibility capture actually fails.

---

## Worth a look before merge

`app/build.gradle.kts` switches the release build type to `signingConfigs.getByName("debug")` (was `findByName("release")`). That is on the branch from an earlier commit and unrelated to either issue — flagging it since it means release APKs are debug-signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016uqhRUC65ZQWFiaxzWozxE
