### PR TITLE
Cut wake-word battery usage: gate the embedding backbone, stop the session churn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,4 @@ MARKETING_PLAYBOOK.md
 docs/benchmark
 docs/WAKE_WORD_PLAN.md
 .freebuff
+scripts/wake_battery_idle.sh

--- a/app/src/androidTest/java/com/gotcha/service/OnnxWakeWordPipelineGateTest.kt
+++ b/app/src/androidTest/java/com/gotcha/service/OnnxWakeWordPipelineGateTest.kt
@@ -1,0 +1,200 @@
+package com.gotcha.service
+
+import ai.onnxruntime.OrtEnvironment
+import ai.onnxruntime.OrtSession
+import android.content.Context
+import android.util.Log
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.math.PI
+import kotlin.math.sin
+import kotlin.random.Random
+
+/**
+ * The regression guard for the energy gate added in issue #37.
+ *
+ * The acceptance criterion for that work is "no drop in detection rate", which
+ * is normally only checkable by saying "Hey Gotcha" at a phone and trusting the
+ * result. The gate is built so it can be checked properly instead: because the
+ * mel front-end keeps running while the gate is shut, every embedding the gate
+ * skipped can be rebuilt from the mel rows that are still in the buffer. So a
+ * gated pipeline and an ungated one must emit **identical** classifier scores
+ * for every frame the gate let through — not similar, identical.
+ *
+ * If that holds, gating provably cannot change what the matcher sees, and so
+ * cannot change the detection rate. If someone later breaks the replay path,
+ * these tests fail rather than the wake word quietly getting worse in rooms
+ * that happen to be quiet.
+ *
+ * ```
+ * ./gradlew :app:connectedDebugAndroidTest \
+ *     -Pandroid.testInstrumentationRunnerArguments.class=com.gotcha.service.OnnxWakeWordPipelineGateTest
+ * ```
+ */
+@RunWith(AndroidJUnit4::class)
+class OnnxWakeWordPipelineGateTest {
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun gatedAndUngatedPipelines_produceIdenticalScores() {
+        val clip = buildClip()
+        val gated = run(clip, WakeWordGate())
+        val ungated = run(clip, WakeWordGate.alwaysOpen())
+
+        Log.i(
+            TAG,
+            "frames=${clip.size} scored: gated=${gated.scores.size} " +
+                "ungated=${ungated.scores.size} gatedOut=${gated.gatedFrames}"
+        )
+
+        assertTrue(
+            "the gate never closed, so this proved nothing — check the clip's silence level",
+            gated.gatedFrames > 0
+        )
+        assertTrue("the gate never opened", gated.scores.isNotEmpty())
+        assertEquals(
+            "the ungated baseline should score every frame it can",
+            ungated.scores.size,
+            gated.scores.size + gated.gatedFrames
+        )
+
+        for ((frame, score) in gated.scores) {
+            val baseline = ungated.scores[frame]
+                ?: error("ungated run produced no score for frame $frame")
+            assertEquals(
+                "frame $frame diverged after the gate re-armed",
+                baseline,
+                score,
+                0f
+            )
+        }
+    }
+
+    /**
+     * The case the replay exists for: the gate shuts during a long silence and
+     * has to re-arm on the first frame of the phrase. Every score from the
+     * re-arm onwards has to match the ungated baseline, because those are the
+     * frames a detection would actually come from.
+     */
+    @Test
+    fun scoresImmediatelyAfterReArming_matchTheUngatedBaseline() {
+        val clip = buildClip()
+        val gated = run(clip, WakeWordGate())
+        val ungated = run(clip, WakeWordGate.alwaysOpen())
+
+        // The first scored frame after a gap in the scored-frame sequence is a
+        // re-arm. Those are the frames the replay path is responsible for.
+        val scoredFrames = gated.scores.keys.sorted()
+        val reArms = scoredFrames.filterIndexed { index, frame ->
+            index > 0 && frame != scoredFrames[index - 1] + 1
+        }
+        Log.i(TAG, "re-arm frames: $reArms")
+        assertTrue("no re-arm happened in this clip", reArms.isNotEmpty())
+
+        for (frame in reArms) {
+            // The re-arm frame plus the rest of the classifier window after it.
+            for (offset in 0 until OnnxWakeWordPipeline.CLASSIFIER_FRAMES) {
+                val score = gated.scores[frame + offset] ?: continue
+                assertEquals(
+                    "frame ${frame + offset} (re-arm at $frame + $offset) diverged",
+                    ungated.scores.getValue(frame + offset),
+                    score,
+                    0f
+                )
+            }
+        }
+    }
+
+    private fun run(clip: List<ShortArray>, gate: WakeWordGate): Recorder {
+        val env = OrtEnvironment.getEnvironment()
+        val recorder = Recorder()
+        val mel = loadSession(env, "melspectrogram.onnx")
+        val embedding = loadSession(env, "embedding_model.onnx")
+        val classifier = loadSession(env, WakeWordDetector.CLASSIFIER_MODEL)
+        try {
+            val pipeline = OnnxWakeWordPipeline(
+                env = env,
+                melSession = mel,
+                embeddingSession = embedding,
+                classifierSession = classifier,
+                matcher = WakeWordMatcher(WakeWordMatcher.DEFAULT_SENSITIVITY),
+                gate = gate,
+                probe = recorder
+            )
+            clip.forEach { frame -> pipeline.feed(frame, frame.size) }
+        } finally {
+            classifier.close()
+            embedding.close()
+            mel.close()
+        }
+        return recorder
+    }
+
+    private fun loadSession(env: OrtEnvironment, name: String): OrtSession {
+        val bytes = context.assets
+            .open("${WakeWordDetector.MODEL_ASSET_DIR}/$name")
+            .use { it.readBytes() }
+        return OrtSession.SessionOptions().use { env.createSession(bytes, it) }
+    }
+
+    /**
+     * Room tone, then two bursts of sound separated by silences long enough to
+     * outlast the gate's hangover. Parity is a property of the plumbing, not of
+     * the audio, so this does not need to be a real "Hey Gotcha" recording — it
+     * needs to make the gate open, close, and re-arm, which it does.
+     */
+    private fun buildClip(): List<ShortArray> = buildList {
+        // The first stretch has to outlast both the 50-frame floor priming and
+        // the 38-frame hangover before the gate can close at all.
+        addAll(frames(count = 100, amplitude = QUIET))
+        addAll(frames(count = 20, amplitude = LOUD))
+        addAll(frames(count = 70, amplitude = QUIET))
+        addAll(frames(count = 25, amplitude = LOUD))
+        addAll(frames(count = 60, amplitude = QUIET))
+    }
+
+    private fun frames(count: Int, amplitude: Int): List<ShortArray> =
+        List(count) { index ->
+            val random = Random(index * 31 + amplitude)
+            ShortArray(OnnxWakeWordPipeline.FRAME_SIZE) { i ->
+                val tone = sin(2.0 * PI * 220.0 * i / OnnxWakeWordPipeline.SAMPLE_RATE)
+                ((tone * 0.6 + random.nextDouble(-0.4, 0.4)) * amplitude).toInt().toShort()
+            }
+        }
+
+    private class Recorder : OnnxWakeWordPipeline.PipelineProbe {
+        /** Frame index → classifier score. */
+        val scores = mutableMapOf<Int, Float>()
+        var gatedFrames = 0
+            private set
+
+        // computeMel() runs on every frame, gated or not, and emits rows every
+        // time — so this fires exactly once per frame and doubles as the clock.
+        private var frames = -1
+
+        override fun onMelRows(rows: Int) {
+            frames++
+        }
+
+        override fun onGated() {
+            gatedFrames++
+        }
+
+        override fun onScore(score: Float) {
+            scores[frames] = score
+        }
+    }
+
+    private companion object {
+        const val TAG = "WakeWordGateParity"
+
+        /** Below the gate's −60 dBFS floor once the noise floor has been learned. */
+        const val QUIET = 12
+        const val LOUD = 6000
+    }
+}

--- a/app/src/androidTest/java/com/gotcha/service/WakeWordDetectionDiagnosticTest.kt
+++ b/app/src/androidTest/java/com/gotcha/service/WakeWordDetectionDiagnosticTest.kt
@@ -1,0 +1,275 @@
+package com.gotcha.service
+
+import ai.onnxruntime.OrtEnvironment
+import ai.onnxruntime.OrtSession
+import android.content.Context
+import android.speech.tts.TextToSpeech
+import android.util.Log
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * Diagnostic for "Hey Gotcha stopped firing" after the issue #37 battery work.
+ *
+ * Covers the two gaps the existing tests left:
+ *
+ * 1. **Batched feeds.** Production now drains 4 frames per `AudioRecord.read`,
+ *    but every test so far fed one frame per call. `feed()` grows its scratch
+ *    buffer for the larger blocks, and nothing exercised that.
+ * 2. **An actual positive.** The parity test proves gated and ungated agree,
+ *    which says nothing about whether either one still *detects*. This drives
+ *    the pipeline with the device's own TTS saying the wake phrase — the model
+ *    was trained on synthetic TTS positives, so this is a fair probe.
+ *
+ * ```
+ * ./gradlew :app:connectedDebugAndroidTest \
+ *     -Pandroid.testInstrumentationRunnerArguments.class=com.gotcha.service.WakeWordDetectionDiagnosticTest
+ * ```
+ */
+@RunWith(AndroidJUnit4::class)
+class WakeWordDetectionDiagnosticTest {
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    /**
+     * Feeding the same audio one frame at a time and four frames at a time must
+     * be indistinguishable. This is the exact shape of the production change,
+     * and it was untested.
+     */
+    @Test
+    fun batchedFeeds_matchSingleFrameFeeds() {
+        val clip = syntheticClip()
+
+        val single = run(WakeWordGate.alwaysOpen()) { pipeline ->
+            clip.forEach { pipeline.feed(it, it.size) }
+        }
+        val batched = run(WakeWordGate.alwaysOpen()) { pipeline ->
+            clip.chunked(4).forEach { group ->
+                val block = ShortArray(group.sumOf { it.size })
+                var offset = 0
+                group.forEach { frame ->
+                    frame.copyInto(block, offset)
+                    offset += frame.size
+                }
+                pipeline.feed(block, block.size)
+            }
+        }
+
+        Log.i(TAG, "single=${single.scores.size} scores, batched=${batched.scores.size} scores")
+        assertEquals("batching changed how many frames got scored", single.scores.size, batched.scores.size)
+        for ((frame, score) in single.scores) {
+            assertEquals("frame $frame differs when fed in batches", score, batched.scores.getValue(frame), 0f)
+        }
+    }
+
+    /**
+     * The end-to-end question: does the phrase still fire the matcher, and does
+     * the gate change that answer? Both pipelines get identical audio.
+     */
+    @Test
+    fun spokenWakePhrase_stillFires() {
+        val samples = synthesizePhrase("Hey Gotcha")
+        Log.i(TAG, "phrase is ${samples.size} samples (${samples.size * 1000 / 16000} ms)")
+
+        // Lead-in and tail of near-silence: the gate needs somewhere to learn a
+        // floor and close, so this reproduces a real trigger from a quiet room.
+        val clip = framesOf(silence(90) + samples + silence(40))
+
+        val ungated = run(WakeWordGate.alwaysOpen()) { pipeline ->
+            clip.forEach { pipeline.feed(it, it.size) }
+        }
+        val gated = run(WakeWordGate()) { pipeline ->
+            clip.forEach { pipeline.feed(it, it.size) }
+        }
+
+        Log.i(
+            TAG,
+            "ungated: peak=${ungated.peak} detections=${ungated.detections} | " +
+                "gated: peak=${gated.peak} detections=${gated.detections} gatedOut=${gated.gatedFrames}"
+        )
+        Log.i(TAG, "matcher threshold at default sensitivity = ${WakeWordMatcher(WakeWordMatcher.DEFAULT_SENSITIVITY).threshold()}")
+
+        assertTrue(
+            "the pipeline never scored the phrase above 0.1 (peak=${ungated.peak}) — " +
+                "TTS may not be a usable positive on this device, so this test cannot " +
+                "tell us anything about the gate",
+            ungated.peak > 0.1f
+        )
+        assertEquals(
+            "the gate changed the peak score (ungated=${ungated.peak}, gated=${gated.peak})",
+            ungated.peak,
+            gated.peak,
+            0f
+        )
+        assertEquals(
+            "the gate changed whether the phrase fired",
+            ungated.detections,
+            gated.detections
+        )
+    }
+
+    private fun run(gate: WakeWordGate, body: (OnnxWakeWordPipeline) -> Unit): Recorder {
+        val env = OrtEnvironment.getEnvironment()
+        val recorder = Recorder()
+        val mel = loadSession(env, "melspectrogram.onnx")
+        val embedding = loadSession(env, "embedding_model.onnx")
+        val classifier = loadSession(env, WakeWordDetector.CLASSIFIER_MODEL)
+        try {
+            val pipeline = OnnxWakeWordPipeline(
+                env = env,
+                melSession = mel,
+                embeddingSession = embedding,
+                classifierSession = classifier,
+                matcher = WakeWordMatcher(WakeWordMatcher.DEFAULT_SENSITIVITY),
+                gate = gate,
+                probe = recorder
+            )
+            body(pipeline)
+        } finally {
+            classifier.close()
+            embedding.close()
+            mel.close()
+        }
+        return recorder
+    }
+
+    private fun loadSession(env: OrtEnvironment, name: String): OrtSession {
+        val bytes = context.assets
+            .open("${WakeWordDetector.MODEL_ASSET_DIR}/$name")
+            .use { it.readBytes() }
+        return OrtSession.SessionOptions().use { env.createSession(bytes, it) }
+    }
+
+    /** Renders [text] with the device TTS and returns it as 16 kHz mono PCM-16. */
+    private fun synthesizePhrase(text: String): ShortArray {
+        val ready = CountDownLatch(1)
+        var status = TextToSpeech.ERROR
+        lateinit var tts: TextToSpeech
+        tts = TextToSpeech(context) { code ->
+            status = code
+            ready.countDown()
+        }
+        assertTrue("TTS never initialised", ready.await(30, TimeUnit.SECONDS))
+        assertEquals("no TTS engine on this device", TextToSpeech.SUCCESS, status)
+
+        val out = File(context.cacheDir, "wake-probe.wav")
+        val done = CountDownLatch(1)
+        tts.setOnUtteranceProgressListener(object : android.speech.tts.UtteranceProgressListener() {
+            override fun onStart(utteranceId: String?) = Unit
+            override fun onDone(utteranceId: String?) = done.countDown()
+            @Deprecated("required override")
+            override fun onError(utteranceId: String?) = done.countDown()
+        })
+        tts.synthesizeToFile(text, null, out, "wake-probe")
+        assertTrue("TTS never produced a file", done.await(30, TimeUnit.SECONDS))
+        tts.shutdown()
+
+        return resampleTo16k(readWav(out))
+    }
+
+    /** Minimal PCM-16 WAV reader: walks the chunk list for `fmt ` and `data`. */
+    private fun readWav(file: File): Pair<Int, ShortArray> {
+        val bytes = file.readBytes()
+        val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
+        var offset = 12 // past "RIFF" <size> "WAVE"
+        var sampleRate = 0
+        var channels = 1
+        while (offset + 8 <= bytes.size) {
+            val id = String(bytes, offset, 4, Charsets.US_ASCII)
+            val size = buffer.getInt(offset + 4)
+            val body = offset + 8
+            when (id) {
+                "fmt " -> {
+                    channels = buffer.getShort(body + 2).toInt()
+                    sampleRate = buffer.getInt(body + 4)
+                }
+                "data" -> {
+                    val count = size / 2
+                    val all = ShortArray(count) { buffer.getShort(body + it * 2) }
+                    val mono = if (channels == 1) all else {
+                        ShortArray(count / channels) { all[it * channels] }
+                    }
+                    Log.i(TAG, "TTS wav: ${sampleRate}Hz, ${channels}ch, ${mono.size} samples")
+                    return sampleRate to mono
+                }
+            }
+            offset = body + size + (size % 2)
+        }
+        error("no data chunk in ${file.name}")
+    }
+
+    /** Linear resample. Good enough to ask "does this still fire"; not a codec. */
+    private fun resampleTo16k(input: Pair<Int, ShortArray>): ShortArray {
+        val (rate, samples) = input
+        if (rate == OnnxWakeWordPipeline.SAMPLE_RATE) return samples
+        val ratio = rate.toDouble() / OnnxWakeWordPipeline.SAMPLE_RATE
+        val out = ShortArray((samples.size / ratio).toInt())
+        for (i in out.indices) {
+            val at = i * ratio
+            val low = at.toInt()
+            val high = (low + 1).coerceAtMost(samples.lastIndex)
+            val frac = at - low
+            out[i] = (samples[low] * (1 - frac) + samples[high] * frac).toInt().toShort()
+        }
+        return out
+    }
+
+    private fun silence(frames: Int) =
+        ShortArray(frames * OnnxWakeWordPipeline.FRAME_SIZE) { (-6..6).random().toShort() }
+
+    private fun framesOf(samples: ShortArray): List<ShortArray> =
+        (0 until samples.size / OnnxWakeWordPipeline.FRAME_SIZE).map { index ->
+            samples.copyOfRange(
+                index * OnnxWakeWordPipeline.FRAME_SIZE,
+                (index + 1) * OnnxWakeWordPipeline.FRAME_SIZE
+            )
+        }
+
+    private fun syntheticClip(): List<ShortArray> = framesOf(
+        silence(60) + ShortArray(40 * OnnxWakeWordPipeline.FRAME_SIZE) { i ->
+            (kotlin.math.sin(2.0 * Math.PI * 300.0 * i / 16000.0) * 5000).toInt().toShort()
+        } + silence(60)
+    )
+
+    private operator fun ShortArray.plus(other: ShortArray): ShortArray {
+        val out = ShortArray(size + other.size)
+        copyInto(out)
+        other.copyInto(out, size)
+        return out
+    }
+
+    private class Recorder : OnnxWakeWordPipeline.PipelineProbe {
+        val scores = mutableMapOf<Int, Float>()
+        var gatedFrames = 0
+        var peak = 0f
+        var detections = 0
+        private var frames = -1
+
+        override fun onMelRows(rows: Int) {
+            frames++
+        }
+
+        override fun onGated() {
+            gatedFrames++
+        }
+
+        override fun onScore(score: Float) {
+            scores[frames] = score
+            if (score > peak) peak = score
+            if (score >= WakeWordMatcher(WakeWordMatcher.DEFAULT_SENSITIVITY).threshold()) detections++
+        }
+    }
+
+    private companion object {
+        const val TAG = "WakeWordDiag"
+    }
+}

--- a/app/src/androidTest/java/com/gotcha/service/WakeWordDetectionDiagnosticTest.kt
+++ b/app/src/androidTest/java/com/gotcha/service/WakeWordDetectionDiagnosticTest.kt
@@ -170,10 +170,15 @@ class WakeWordDetectionDiagnosticTest {
             override fun onError(utteranceId: String?) = done.countDown()
         })
         tts.synthesizeToFile(text, null, out, "wake-probe")
-        assertTrue("TTS never produced a file", done.await(30, TimeUnit.SECONDS))
-        tts.shutdown()
-
-        return resampleTo16k(readWav(out))
+        try {
+            assertTrue("TTS never produced a file", done.await(30, TimeUnit.SECONDS))
+            tts.shutdown()
+            return resampleTo16k(readWav(out))
+        } finally {
+            // A rendering of the wake phrase is not something to leave sitting
+            // in the app's cache after the test.
+            out.delete()
+        }
     }
 
     /** Minimal PCM-16 WAV reader: walks the chunk list for `fmt ` and `data`. */

--- a/app/src/androidTest/java/com/gotcha/service/WakeWordDetectorLifecycleTest.kt
+++ b/app/src/androidTest/java/com/gotcha/service/WakeWordDetectorLifecycleTest.kt
@@ -1,0 +1,136 @@
+package com.gotcha.service
+
+import android.Manifest
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.GrantPermissionRule
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Guards the pause/release split from issue #37.
+ *
+ * `AssistiveBallService` pauses the listener on every call transition *and*
+ * every TTS utterance, which before this split meant re-reading ~2.6 MB of
+ * model bytes and rebuilding three ORT sessions each time the app spoke a
+ * single sentence. The fix only holds if [WakeWordDetector.pause] genuinely
+ * keeps the sessions, so that is asserted directly rather than inferred from
+ * how long a resume takes.
+ */
+@RunWith(AndroidJUnit4::class)
+class WakeWordDetectorLifecycleTest {
+
+    @get:Rule
+    val micPermission: GrantPermissionRule = GrantPermissionRule.grant(Manifest.permission.RECORD_AUDIO)
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val error = AtomicReference<String?>(null)
+    private var started = CountDownLatch(1)
+    private var detector: WakeWordDetector? = null
+
+    @After
+    fun tearDown() {
+        detector?.release()
+        scope.cancel()
+    }
+
+    @Test
+    fun pauseKeepsTheModelsLoaded_releaseGivesThemBack() {
+        val detector = newDetector()
+
+        awaitStart(detector)
+        assertEquals("cold start should load the models once", 1, detector.sessionLoadCount)
+
+        // Three rounds of the churn a talkative session produces.
+        repeat(3) { round ->
+            detector.pause()
+            assertTrue("detector still running after pause in round $round", !detector.isRunning())
+            awaitStart(detector)
+            assertEquals(
+                "resume in round $round reloaded the models",
+                1,
+                detector.sessionLoadCount
+            )
+        }
+
+        // release() is the other half of the contract: it must actually let go,
+        // so switching the wake word off does not leave 2.6 MB of models resident.
+        detector.release()
+        awaitStart(detector)
+        assertEquals("release should force a fresh load", 2, detector.sessionLoadCount)
+        assertNull(error.get())
+    }
+
+    @Test
+    fun pauseReleasesTheMicrophone() {
+        val detector = newDetector()
+        awaitStart(detector)
+        detector.pause()
+
+        // The privacy guarantee in privacy-data-retention.md §10.3 is that the
+        // mic is handed back while the app's own TTS speaks — keeping the ONNX
+        // sessions must not have quietly weakened that. If pause() still held
+        // the recorder, this second AudioRecord could not start.
+        val probe = android.media.AudioRecord(
+            android.media.MediaRecorder.AudioSource.VOICE_RECOGNITION,
+            OnnxWakeWordPipeline.SAMPLE_RATE,
+            android.media.AudioFormat.CHANNEL_IN_MONO,
+            android.media.AudioFormat.ENCODING_PCM_16BIT,
+            OnnxWakeWordPipeline.FRAME_SIZE * 2 * 4
+        )
+        try {
+            assertEquals(
+                android.media.AudioRecord.STATE_INITIALIZED,
+                probe.state
+            )
+            probe.startRecording()
+            val buffer = ShortArray(OnnxWakeWordPipeline.FRAME_SIZE)
+            assertTrue("could not read audio after pause", probe.read(buffer, 0, buffer.size) > 0)
+        } finally {
+            try {
+                probe.stop()
+            } catch (_: IllegalStateException) {
+                // Never started.
+            }
+            probe.release()
+        }
+    }
+
+    private fun newDetector(): WakeWordDetector {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        return WakeWordDetector(
+            context = context,
+            scope = scope,
+            sensitivityProvider = { WakeWordMatcher.DEFAULT_SENSITIVITY },
+            onStarted = { started.countDown() },
+            onDetected = {},
+            onError = { message ->
+                error.set(message)
+                started.countDown()
+            }
+        ).also { detector = it }
+    }
+
+    private fun awaitStart(detector: WakeWordDetector) {
+        started = CountDownLatch(1)
+        assertTrue("start() reported a precondition failure", detector.start())
+        assertTrue(
+            "listener never started (error=${error.get()})",
+            started.await(10, TimeUnit.SECONDS)
+        )
+        assertNull("listener reported an error", error.get())
+    }
+}

--- a/app/src/androidTest/java/com/gotcha/service/WakeWordPipelineBenchmarkTest.kt
+++ b/app/src/androidTest/java/com/gotcha/service/WakeWordPipelineBenchmarkTest.kt
@@ -1,0 +1,210 @@
+package com.gotcha.service
+
+import ai.onnxruntime.OrtEnvironment
+import ai.onnxruntime.OrtSession
+import android.content.Context
+import android.util.Log
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.math.PI
+import kotlin.math.sin
+import kotlin.random.Random
+
+/**
+ * Measurement harness for issue #37 (wake-word battery drain). Not a pass/fail
+ * regression test — it exists to produce the two numbers the fix order depends
+ * on, and to keep them reproducible on a real device:
+ *
+ * 1. **The per-stage cost split.** The issue assumes the mel → embedding →
+ *    classify chain is dominated by the two large models. Whether the gate
+ *    (fix #1) or the ORT thread config (fix #2) is the bigger lever depends on
+ *    the actual ms-per-stage, so measure it rather than assume it.
+ * 2. **Mel rows emitted per 80 ms frame.** The whole pre-roll design rests on
+ *    "76 mel rows ≈ 10 frames ≈ 760 ms of audio", which was inferred from
+ *    upstream openWakeWord convention, not read out of the bundled graph.
+ *    [melRowsPerFrame_matchesTenMillisecondHop] pins it down.
+ *
+ * Run against the connected device (an emulator's timings are meaningless for
+ * a power question):
+ *
+ * ```
+ * ./gradlew :app:connectedDebugAndroidTest \
+ *     -Pandroid.testInstrumentationRunnerArguments.class=com.gotcha.service.WakeWordPipelineBenchmarkTest
+ * ```
+ *
+ * Then read the numbers out of logcat: `adb logcat -s WakeWordBench`.
+ */
+@RunWith(AndroidJUnit4::class)
+class WakeWordPipelineBenchmarkTest {
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    /**
+     * Times each stage under both the shipped default [OrtSession.SessionOptions]
+     * and the single-threaded/no-spin config proposed as fix #2, so the two are
+     * compared on the same device in the same run.
+     */
+    @Test
+    fun perStageCost_defaultVsTunedSessionOptions() {
+        val default = measure("default options") { OrtSession.SessionOptions() }
+        val tuned = measure("tuned options") { tunedOptions() }
+
+        Log.i(TAG, "=== summary (median ms per 80 ms frame) ===")
+        Log.i(TAG, "default: total=${default.medianTotalMs()} $default")
+        Log.i(TAG, "tuned:   total=${tuned.medianTotalMs()} $tuned")
+        Log.i(
+            TAG,
+            "duty cycle @12.5 fps — default=${dutyCycle(default)}%, tuned=${dutyCycle(tuned)}%"
+        )
+
+        // The harness is only useful if it actually exercised the full chain.
+        assertTrue("no classify samples recorded", default.classify.isNotEmpty())
+        assertTrue("no classify samples recorded", tuned.classify.isNotEmpty())
+    }
+
+    /**
+     * Confirms the mel front-end emits ~8 rows per 80 ms frame (a 10 ms hop),
+     * which is what makes a cold `melBuffer` need ~10 frames / 760 ms to refill
+     * the 76-row embedding window. If this ever changes, the pre-roll size in
+     * [OnnxWakeWordPipeline] has to change with it.
+     */
+    @Test
+    fun melRowsPerFrame_matchesTenMillisecondHop() {
+        val stats = measure("mel rows") { tunedOptions() }
+        val steady = stats.melRows.drop(WARMUP_FRAMES)
+        assertTrue("no mel runs recorded", steady.isNotEmpty())
+
+        val distinct = steady.distinct().sorted()
+        Log.i(TAG, "mel rows per frame (steady state): $distinct")
+        val rows = distinct.single()
+        val framesToFillEmbeddingWindow =
+            (OnnxWakeWordPipeline.MEL_EMBEDDING_WINDOW + rows - 1) / rows
+        Log.i(
+            TAG,
+            "$rows rows/frame → ${framesToFillEmbeddingWindow} frames " +
+                "(${framesToFillEmbeddingWindow * 80} ms) to refill a cold mel buffer"
+        )
+
+        // 1760-sample window, 400-sample analysis window, 160-sample (10 ms) hop.
+        assertEquals(8, rows)
+    }
+
+    private fun measure(label: String, options: () -> OrtSession.SessionOptions): Stats {
+        val env = OrtEnvironment.getEnvironment()
+        val stats = Stats()
+        val mel = loadSession(env, "melspectrogram.onnx", options())
+        val embedding = loadSession(env, "embedding_model.onnx", options())
+        val classifier = loadSession(env, WakeWordDetector.CLASSIFIER_MODEL, options())
+        try {
+            val pipeline = OnnxWakeWordPipeline(
+                env = env,
+                melSession = mel,
+                embeddingSession = embedding,
+                classifierSession = classifier,
+                matcher = WakeWordMatcher(WakeWordMatcher.DEFAULT_SENSITIVITY),
+                probe = stats
+            )
+            val frame = ShortArray(OnnxWakeWordPipeline.FRAME_SIZE)
+            repeat(WARMUP_FRAMES + MEASURED_FRAMES) { index ->
+                fillSpeechLike(frame, index)
+                pipeline.feed(frame, frame.size)
+                if (index == WARMUP_FRAMES - 1) stats.resetTimings()
+            }
+            Log.i(TAG, "$label → $stats")
+        } finally {
+            classifier.close()
+            embedding.close()
+            mel.close()
+        }
+        return stats
+    }
+
+    private fun loadSession(
+        env: OrtEnvironment,
+        name: String,
+        options: OrtSession.SessionOptions
+    ): OrtSession {
+        val bytes = context.assets
+            .open("${WakeWordDetector.MODEL_ASSET_DIR}/$name")
+            .use { it.readBytes() }
+        return options.use { env.createSession(bytes, it) }
+    }
+
+    private fun tunedOptions() = OrtSession.SessionOptions().apply {
+        setIntraOpNumThreads(1)
+        setInterOpNumThreads(1)
+        setExecutionMode(OrtSession.SessionOptions.ExecutionMode.SEQUENTIAL)
+        addConfigEntry("session.intra_op.allow_spinning", "0")
+        addConfigEntry("session.inter_op.allow_spinning", "0")
+    }
+
+    /**
+     * Band-limited noise at roughly speech level. Stage timings are shape-driven,
+     * not content-driven — every ONNX input here is a fixed size regardless of
+     * what the audio contains — so synthetic audio measures the same cost real
+     * speech would, without shipping a WAV fixture.
+     */
+    private fun fillSpeechLike(frame: ShortArray, frameIndex: Int) {
+        val random = Random(frameIndex)
+        var phase = frameIndex * frame.size.toDouble()
+        for (i in frame.indices) {
+            val tone = sin(2.0 * PI * 220.0 * phase / OnnxWakeWordPipeline.SAMPLE_RATE)
+            val noise = random.nextDouble(-0.3, 0.3)
+            frame[i] = ((tone * 0.4 + noise) * 8000).toInt().toShort()
+            phase += 1.0
+        }
+    }
+
+    private fun dutyCycle(stats: Stats): Int =
+        (stats.medianTotalMs() / 80.0 * 100).toInt()
+
+    private class Stats : OnnxWakeWordPipeline.PipelineProbe {
+        val mel = mutableListOf<Long>()
+        val embed = mutableListOf<Long>()
+        val classify = mutableListOf<Long>()
+        val melRows = mutableListOf<Int>()
+
+        override fun onStage(stage: OnnxWakeWordPipeline.PipelineProbe.Stage, nanos: Long) {
+            when (stage) {
+                OnnxWakeWordPipeline.PipelineProbe.Stage.MEL -> mel += nanos
+                OnnxWakeWordPipeline.PipelineProbe.Stage.EMBEDDING -> embed += nanos
+                OnnxWakeWordPipeline.PipelineProbe.Stage.CLASSIFY -> classify += nanos
+            }
+        }
+
+        override fun onMelRows(rows: Int) {
+            melRows += rows
+        }
+
+        /** Drops the warm-up samples; the first runs pay one-off lazy-init costs. */
+        fun resetTimings() {
+            mel.clear()
+            embed.clear()
+            classify.clear()
+        }
+
+        fun medianTotalMs(): Double = ms(mel, 50) + ms(embed, 50) + ms(classify, 50)
+
+        override fun toString(): String =
+            "mel p50=${ms(mel, 50)}ms p95=${ms(mel, 95)}ms, " +
+                "embed p50=${ms(embed, 50)}ms p95=${ms(embed, 95)}ms, " +
+                "classify p50=${ms(classify, 50)}ms p95=${ms(classify, 95)}ms"
+
+        private fun ms(samples: List<Long>, percentile: Int): Double {
+            if (samples.isEmpty()) return 0.0
+            val sorted = samples.sorted()
+            val index = (sorted.size * percentile / 100).coerceIn(0, sorted.lastIndex)
+            return Math.round(sorted[index] / 1_000.0) / 1_000.0
+        }
+    }
+
+    private companion object {
+        const val TAG = "WakeWordBench"
+        const val WARMUP_FRAMES = 30
+        const val MEASURED_FRAMES = 500
+    }
+}

--- a/app/src/main/java/com/gotcha/MainActivity.kt
+++ b/app/src/main/java/com/gotcha/MainActivity.kt
@@ -518,7 +518,16 @@ class MainActivity : ComponentActivity() {
 
     private fun persistAssistiveBall(enabled: Boolean) {
         val current = settingsRepository.load()
-        settingsRepository.save(current.copy(assistiveBallEnabled = enabled))
+        // The wake word runs inside the ball service, so switching the ball off
+        // must also switch the wake word off — otherwise the wake-word setting
+        // stays on and silently inert while the ball is off.
+        settingsRepository.save(
+            if (enabled) {
+                current.copy(assistiveBallEnabled = true)
+            } else {
+                current.copy(assistiveBallEnabled = false, wakeWordEnabled = false)
+            }
+        )
     }
 
     /** Any Samosa 401 (LLM or audio) clears the session and refreshes the

--- a/app/src/main/java/com/gotcha/data/SettingsRepository.kt
+++ b/app/src/main/java/com/gotcha/data/SettingsRepository.kt
@@ -5,6 +5,32 @@ import android.content.SharedPreferences
 import com.gotcha.BuildConfig
 import com.gotcha.audio.AudioProvider
 
+/**
+ * When the wake-word listener is allowed to run, relative to the screen state.
+ *
+ * The listener's idle cost (issue #37, `docs/benchmark/wake-word-idle.md`) is
+ * dominated by holding the microphone — the `AudioIn` wake lock, not the
+ * inference. These modes trade how much of the day that happens for where the
+ * user is most likely to want a hands-free trigger.
+ */
+enum class WakeWordListeningMode {
+    /** Listen regardless of screen state — the original always-on behaviour. */
+    ALWAYS,
+
+    /** Listen only while the screen is on, so the mic LED is off when it is not. */
+    SCREEN_ON,
+
+    /** Listen only while the screen is off, for hands-free use away from the app. */
+    SCREEN_OFF;
+
+    /** Whether the listener should run given the current screen interactivity. */
+    fun allows(screenInteractive: Boolean): Boolean = when (this) {
+        ALWAYS -> true
+        SCREEN_ON -> screenInteractive
+        SCREEN_OFF -> !screenInteractive
+    }
+}
+
 data class Settings(
     // Which LLM backend is active. Defaults to the Samosa AI flow.
     val provider: LlmProvider = LlmProvider.SAMOSA_AI,
@@ -54,6 +80,7 @@ data class Settings(
     val assistiveBallEnabled: Boolean = false,
     val wakeWordEnabled: Boolean = false,
     val wakeWordSensitivity: Float = 0.75f,
+    val wakeWordListeningMode: WakeWordListeningMode = WakeWordListeningMode.ALWAYS,
     /** Server-driven notifications from `<SAMOSA_API_URL>/v1/gotcha/notifications`. */
     val serverMessagesEnabled: Boolean = true,
     /** Epoch millis of the last successful server-messages fetch. 0 = never. */
@@ -356,6 +383,9 @@ class SettingsRepository(context: Context) : SettingsStore {
         assistiveBallEnabled = prefs.getBoolean(KEY_ASSISTIVE_BALL, false),
         wakeWordEnabled = prefs.getBoolean(KEY_WAKE_WORD_ENABLED, false),
         wakeWordSensitivity = prefs.getFloat(KEY_WAKE_WORD_SENSITIVITY, 0.75f),
+        wakeWordListeningMode = runCatching {
+            WakeWordListeningMode.valueOf(string(KEY_WAKE_WORD_LISTENING_MODE, "ALWAYS"))
+        }.getOrDefault(WakeWordListeningMode.ALWAYS),
         serverMessagesEnabled = prefs.getBoolean(KEY_SERVER_MESSAGES_ENABLED, true),
         serverMessagesLastFetchedAt = prefs.getLong(KEY_SERVER_MESSAGES_LAST_FETCHED, 0L),
         serverMessagesEtag = string(KEY_SERVER_MESSAGES_ETAG),
@@ -417,6 +447,7 @@ class SettingsRepository(context: Context) : SettingsStore {
             .putBoolean(KEY_ASSISTIVE_BALL, settings.assistiveBallEnabled)
             .putBoolean(KEY_WAKE_WORD_ENABLED, settings.wakeWordEnabled)
             .putFloat(KEY_WAKE_WORD_SENSITIVITY, settings.wakeWordSensitivity)
+            .putString(KEY_WAKE_WORD_LISTENING_MODE, settings.wakeWordListeningMode.name)
             .putBoolean(KEY_SERVER_MESSAGES_ENABLED, settings.serverMessagesEnabled)
             .putLong(KEY_SERVER_MESSAGES_LAST_FETCHED, settings.serverMessagesLastFetchedAt)
             .putString(KEY_SERVER_MESSAGES_ETAG, settings.serverMessagesEtag)
@@ -523,6 +554,7 @@ class SettingsRepository(context: Context) : SettingsStore {
         const val KEY_ASSISTIVE_BALL = "assistive_ball_enabled"
         const val KEY_WAKE_WORD_ENABLED = "wake_word_enabled"
         const val KEY_WAKE_WORD_SENSITIVITY = "wake_word_sensitivity"
+        const val KEY_WAKE_WORD_LISTENING_MODE = "wake_word_listening_mode"
         const val KEY_SERVER_MESSAGES_ENABLED = "server_messages_enabled"
         const val KEY_SERVER_MESSAGES_LAST_FETCHED = "server_messages_last_fetched"
         const val KEY_SERVER_MESSAGES_ETAG = "server_messages_etag"

--- a/app/src/main/java/com/gotcha/service/AssistiveBallService.kt
+++ b/app/src/main/java/com/gotcha/service/AssistiveBallService.kt
@@ -5,18 +5,23 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.Service
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.content.SharedPreferences
 import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.IBinder
+import android.os.PowerManager
+import androidx.core.content.ContextCompat
 import com.gotcha.MainActivity
 import com.gotcha.audio.AudioProvider
 import com.gotcha.audio.SttEngine
 import com.gotcha.audio.TtsEngine
 import com.gotcha.data.ChatHistoryRepository
 import com.gotcha.data.SettingsRepository
+import com.gotcha.data.WakeWordListeningMode
 import com.gotcha.data.settingsChangeNotifier
 import com.gotcha.i18n.Language
 import com.gotcha.ui.AssistiveBallOverlay
@@ -83,16 +88,39 @@ class AssistiveBallService : Service() {
             return@OnSharedPreferenceChangeListener
         }
         // The key arrives encrypted; compare the value read back instead (see
-        // settingsChangeNotifier's note). Restarting with a new threshold only
-        // makes sense while idle — the state collector stops the detector
-        // whenever a call becomes active anyway.
-        if (s.wakeWordSensitivity != appliedWakeWordSensitivity &&
-            callController.state.value == CallState.IDLE
-        ) {
+        // settingsChangeNotifier's note). Restarting with a new threshold or a
+        // new listening mode only makes sense while idle — the state collector
+        // stops the detector whenever a call becomes active anyway.
+        val settingsChanged = s.wakeWordSensitivity != appliedWakeWordSensitivity ||
+            s.wakeWordListeningMode != appliedWakeWordMode
+        if (settingsChanged && callController.state.value == CallState.IDLE) {
             maybeStartWakeWord()
         }
     }
     private var appliedWakeWordSensitivity: Float? = null
+    private var appliedWakeWordMode: WakeWordListeningMode? = null
+
+    /**
+     * Re-evaluates the listener when the screen toggles, so the SCREEN_ON /
+     * SCREEN_OFF listening modes track the display instead of waiting for a
+     * settings edit or a call transition to re-arm.
+     *
+     * Guarded like the call-state and TTS collectors: a screen toggle must
+     * never re-arm the listener while a call is active or the app is speaking
+     * — those pauses are deliberate, and an unconditional re-arm here would
+     * grab the microphone out from under the call's STT or from the app's own
+     * voice.
+     */
+    private val screenStateReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            when (intent.action) {
+                Intent.ACTION_SCREEN_ON, Intent.ACTION_SCREEN_OFF ->
+                    if (callController.state.value == CallState.IDLE && !ttsEngine.isSpeaking.value) {
+                        maybeStartWakeWord()
+                    }
+            }
+        }
+    }
     private lateinit var screenCompanionController: ScreenCompanionController
     private lateinit var screenCompanionPanel: com.gotcha.ui.ScreenCompanionPanelOverlay
     private lateinit var screenLensController: ScreenLensController
@@ -159,6 +187,7 @@ class AssistiveBallService : Service() {
 
         settingsPrefs = settingsChangeNotifier(applicationContext)
         settingsPrefs.registerOnSharedPreferenceChangeListener(wakeWordSettingsWatcher)
+        registerScreenStateReceiver()
 
         // Floating call buttons (shown during a call, hidden otherwise)
         chatWindow = CallChatWindow(this).apply {
@@ -909,7 +938,9 @@ class AssistiveBallService : Service() {
 
     private fun maybeStartWakeWord() {
         val settings = settingsRepository.load()
-        if (settings.wakeWordEnabled && settings.assistiveBallEnabled && hasMicPermission()) {
+        if (settings.wakeWordEnabled && settings.assistiveBallEnabled && hasMicPermission() &&
+            settings.wakeWordListeningMode.allows(isScreenInteractive())
+        ) {
             // A running detector skips its own start() (see WakeWordDetector),
             // so a live sensitivity change would otherwise never reach the
             // matcher. Stop first to force a rebuild whenever the threshold
@@ -920,11 +951,36 @@ class AssistiveBallService : Service() {
                 wakeWordDetector.pause()
             }
             appliedWakeWordSensitivity = settings.wakeWordSensitivity
+            appliedWakeWordMode = settings.wakeWordListeningMode
             wakeWordDetector.start()
         } else {
-            // Switched off, or no mic grant: give the models back.
+            // Switched off, no mic grant, or the listening mode does not allow
+            // the current screen state: give the models back.
             wakeWordDetector.release()
         }
+    }
+
+    /** Whether the display is on and usable. Defaults to true when unknown. */
+    private fun isScreenInteractive(): Boolean {
+        val powerManager = getSystemService(PowerManager::class.java) ?: return true
+        return powerManager.isInteractive
+    }
+
+    /**
+     * Screen on/off re-arm for the SCREEN_ON / SCREEN_OFF listening modes.
+     * Registered once in [onCreate] and unregistered alongside the settings
+     * watcher in [stopBall] and [onDestroy].
+     */
+    private fun registerScreenStateReceiver() {
+        ContextCompat.registerReceiver(
+            this,
+            screenStateReceiver,
+            IntentFilter().apply {
+                addAction(Intent.ACTION_SCREEN_ON)
+                addAction(Intent.ACTION_SCREEN_OFF)
+            },
+            ContextCompat.RECEIVER_NOT_EXPORTED
+        )
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -952,6 +1008,7 @@ class AssistiveBallService : Service() {
         if (::settingsPrefs.isInitialized) {
             settingsPrefs.unregisterOnSharedPreferenceChangeListener(wakeWordSettingsWatcher)
         }
+        runCatching { unregisterReceiver(screenStateReceiver) }
         callController.endCall()
         chatWindow.hide()
         screenCompanionPanel.dismiss()
@@ -1035,10 +1092,13 @@ class AssistiveBallService : Service() {
         if (::settingsPrefs.isInitialized) {
             settingsPrefs.unregisterOnSharedPreferenceChangeListener(wakeWordSettingsWatcher)
         }
+        runCatching { unregisterReceiver(screenStateReceiver) }
         callController.endCall()
         chatWindow.hide()
         screenCompanionPanel.dismiss()
-        settingsRepository.save(settingsRepository.load().copy(assistiveBallEnabled = false))
+        settingsRepository.save(
+            settingsRepository.load().copy(assistiveBallEnabled = false, wakeWordEnabled = false)
+        )
         _isRunning.value = false
         overlay.dismiss()
         stopForeground(STOP_FOREGROUND_REMOVE)

--- a/app/src/main/java/com/gotcha/service/AssistiveBallService.kt
+++ b/app/src/main/java/com/gotcha/service/AssistiveBallService.kt
@@ -79,7 +79,7 @@ class AssistiveBallService : Service() {
     private val wakeWordSettingsWatcher = SharedPreferences.OnSharedPreferenceChangeListener { _, _ ->
         val s = settingsRepository.load()
         if (!s.wakeWordEnabled || !s.assistiveBallEnabled) {
-            wakeWordDetector.stop()
+            wakeWordDetector.release()
             return@OnSharedPreferenceChangeListener
         }
         // The key arrives encrypted; compare the value read back instead (see
@@ -227,7 +227,9 @@ class AssistiveBallService : Service() {
             callController.state.collect { state ->
                 val active = state != CallState.IDLE && state != CallState.ENDING
                 if (active) {
-                    wakeWordDetector.stop()
+                    // Pause, not release: a call ends and we re-arm within
+                    // seconds, so keep the models loaded across it.
+                    wakeWordDetector.pause()
                 } else if (state == CallState.IDLE) {
                     maybeStartWakeWord()
                 }
@@ -247,10 +249,14 @@ class AssistiveBallService : Service() {
         // post-detection isSpeaking guard in onWakeWordDetected is a second
         // line of defence against self-triggering, but stopping the listener
         // here closes the race at the source — see privacy-data-retention.md §10.3.
+        // pause() still hands the microphone back in full; it keeps only the
+        // loaded ONNX models, which hold no audio. The privacy guarantee is
+        // unchanged — what goes away is reloading 2.6 MB of models every time
+        // the app speaks a sentence.
         scope.launch {
             ttsEngine.isSpeaking.collect { speaking ->
                 if (speaking) {
-                    wakeWordDetector.stop()
+                    wakeWordDetector.pause()
                 } else if (callController.state.value == CallState.IDLE) {
                     maybeStartWakeWord()
                 }
@@ -864,7 +870,7 @@ class AssistiveBallService : Service() {
         ) == android.content.pm.PackageManager.PERMISSION_GRANTED
 
     private fun onWakeWordDetected() {
-        wakeWordDetector.stop()
+        wakeWordDetector.pause()
         if (ttsEngine.isSpeaking.value) {
             // The app was reading something aloud (e.g. a screen read-aloud that
             // happened to contain "gotcha") — never start a call from our own
@@ -894,12 +900,13 @@ class AssistiveBallService : Service() {
             if (appliedWakeWordSensitivity != settings.wakeWordSensitivity &&
                 wakeWordDetector.isRunning()
             ) {
-                wakeWordDetector.stop()
+                wakeWordDetector.pause()
             }
             appliedWakeWordSensitivity = settings.wakeWordSensitivity
             wakeWordDetector.start()
         } else {
-            wakeWordDetector.stop()
+            // Switched off, or no mic grant: give the models back.
+            wakeWordDetector.release()
         }
     }
 
@@ -924,7 +931,7 @@ class AssistiveBallService : Service() {
     override fun onDestroy() {
         if (instance === this) instance = null
         _isRunning.value = false
-        wakeWordDetector.stop()
+        wakeWordDetector.release()
         if (::settingsPrefs.isInitialized) {
             settingsPrefs.unregisterOnSharedPreferenceChangeListener(wakeWordSettingsWatcher)
         }
@@ -1007,7 +1014,7 @@ class AssistiveBallService : Service() {
     // ---- Lifecycle helpers ----
 
     private fun stopBall() {
-        wakeWordDetector.stop()
+        wakeWordDetector.release()
         if (::settingsPrefs.isInitialized) {
             settingsPrefs.unregisterOnSharedPreferenceChangeListener(wakeWordSettingsWatcher)
         }

--- a/app/src/main/java/com/gotcha/service/AssistiveBallService.kt
+++ b/app/src/main/java/com/gotcha/service/AssistiveBallService.kt
@@ -874,8 +874,13 @@ class AssistiveBallService : Service() {
         if (ttsEngine.isSpeaking.value) {
             // The app was reading something aloud (e.g. a screen read-aloud that
             // happened to contain "gotcha") — never start a call from our own
-            // voice. Resume listening instead.
-            maybeStartWakeWord()
+            // voice.
+            //
+            // Deliberately does not re-arm here. Doing so put the listener back
+            // on the mic *while the app was still talking*, so the rest of the
+            // utterance could trigger this path again and again. The isSpeaking
+            // collector re-arms as soon as the app goes quiet, which is the
+            // moment listening should resume.
             return
         }
         val s = settingsRepository.load()

--- a/app/src/main/java/com/gotcha/service/AssistiveBallService.kt
+++ b/app/src/main/java/com/gotcha/service/AssistiveBallService.kt
@@ -887,7 +887,19 @@ class AssistiveBallService : Service() {
         // The call hides the ball almost immediately, so the visual ack has to
         // be kicked off before it starts — see AssistiveBallOverlay.playWakeAnimation.
         overlay.playWakeAnimation()
-        callController.startWakeWordCall()
+        if (!callController.startWakeWordCall()) {
+            // The call was refused before it began — no provider configured, no
+            // API key, the mic grant gone. startCall() reports that through
+            // onError() and leaves the state machine in IDLE, so the collector
+            // that normally re-arms the listener never fires: a StateFlow that
+            // does not change does not emit.
+            //
+            // Without this the wake word is dead until the ball is restarted,
+            // and the failure looks permanent to the user — they fix the thing
+            // the error told them to fix, say "Hey Gotcha" again, and nothing
+            // happens. Re-arm here so the next attempt reaches the new config.
+            maybeStartWakeWord()
+        }
     }
 
     private fun maybeStartWakeWord() {

--- a/app/src/main/java/com/gotcha/service/OnnxWakeWordPipeline.kt
+++ b/app/src/main/java/com/gotcha/service/OnnxWakeWordPipeline.kt
@@ -50,6 +50,9 @@ import java.nio.FloatBuffer
  * and the classifier input. The mel rows and embeddings are recycled through
  * [melRowPool] and [featurePool] as they fall out of their bounded buffers.
  *
+ * [WakeWordGate] holds the same line: its noise floor is a sorted percentile,
+ * but over reused scratch and refreshed on a schedule rather than per frame.
+ *
  * What still allocates per frame: the `OnnxTensor` wrappers and whatever ORT
  * hands back from `run()`. Both are ORT's to own. This is not "zero
  * allocation" — keep the claim honest, a profiler is the arbiter.
@@ -251,7 +254,9 @@ internal class OnnxWakeWordPipeline(
         if (!timed(PipelineProbe.Stage.MEL) { computeMel() }) return false
 
         if (!open) {
-            if (gatedFrames < CLASSIFIER_FRAMES) gatedFrames++
+            // Capped at what a replay can actually use; anything older has
+            // already fallen out of the classifier's window.
+            if (gatedFrames < CLASSIFIER_FRAMES - 1) gatedFrames++
             probe?.onGated()
             return false
         }

--- a/app/src/main/java/com/gotcha/service/OnnxWakeWordPipeline.kt
+++ b/app/src/main/java/com/gotcha/service/OnnxWakeWordPipeline.kt
@@ -41,12 +41,18 @@ import java.nio.FloatBuffer
  * longer than ~1.3 s. `WakeWordGate`'s hangover is what keeps gaps that short
  * from re-arming at all.
  *
- * The hot path avoids per-frame GC pressure: the raw PCM ring buffer, the
- * combined feed buffer, the frame buffer, and the mel window are all
- * pre-allocated once and reused. The per-row mel arrays, `toList()` snapshots,
- * and ONNX tensor inputs are still allocated each frame (~37.5/s), which is
- * acceptable — keep this from drifting into the comment-free "zero allocation"
- * territory that a profiler would disprove.
+ * ## Allocation
+ *
+ * The hot path is close to allocation-free, which matters on a path that runs
+ * for as long as the phone is on. Pre-allocated and reused: the raw PCM ring,
+ * the combined feed buffer, the frame buffer, the mel window, the embedding
+ * input (`[1][76][32][1]` — this one was 2432 one-element arrays per frame),
+ * and the classifier input. The mel rows and embeddings are recycled through
+ * [melRowPool] and [featurePool] as they fall out of their bounded buffers.
+ *
+ * What still allocates per frame: the `OnnxTensor` wrappers and whatever ORT
+ * hands back from `run()`. Both are ORT's to own. This is not "zero
+ * allocation" — keep the claim honest, a profiler is the arbiter.
  */
 @Suppress("UNCHECKED_CAST")
 internal class OnnxWakeWordPipeline(
@@ -104,6 +110,32 @@ internal class OnnxWakeWordPipeline(
     private val featureBuffer = ArrayDeque<FloatArray>()
 
     /**
+     * Mel rows that fell out of [melBuffer], kept for reuse. The buffer is
+     * bounded, so in the steady state every row appended can take the storage
+     * of one that was just evicted and the hot path stops allocating.
+     */
+    private val melRowPool = ArrayDeque<FloatArray>()
+
+    /** The same idea as [melRowPool], for the 96-dim embeddings. */
+    private val featurePool = ArrayDeque<FloatArray>()
+
+    /**
+     * Reused embedding input, `[1][76][32][1]`. Allocating this per frame meant
+     * 2432 one-element FloatArrays every 80 ms — by a wide margin the largest
+     * source of garbage on a path that runs forever. Every element is written
+     * before the tensor is built, and the tensor is closed before the next fill.
+     */
+    private val embeddingInput =
+        Array(1) { Array(MEL_EMBEDDING_WINDOW) { Array(MEL_BINS) { FloatArray(1) } } }
+
+    /**
+     * Reused classifier input, `[1][16][96]`. The rows are references into
+     * [featureBuffer], replaced wholesale each call, so the placeholder they
+     * start out pointing at is never read.
+     */
+    private val classifierInput = Array(1) { Array(CLASSIFIER_FRAMES) { EMPTY_FEATURE } }
+
+    /**
      * Rows appended to [melBuffer] by each of the last [CLASSIFIER_FRAMES]
      * frames. Re-arming after the gate closes has to rebuild the embeddings for
      * a run of earlier frames, and that means knowing where each of those
@@ -152,6 +184,8 @@ internal class OnnxWakeWordPipeline(
         gatedFrames = 0
         melBuffer.clear()
         featureBuffer.clear()
+        melRowPool.clear()
+        featurePool.clear()
         matcher.reset()
         gate.reset()
         prefillFeatures()
@@ -258,9 +292,11 @@ internal class OnnxWakeWordPipeline(
         if (rows.isEmpty()) return false
         probe?.onMelRows(rows.size)
         for (row in rows) {
-            melBuffer.addLast(FloatArray(MEL_BINS) { row[it] / 10f + 2f })
+            val stored = melRowPool.removeLastOrNull() ?: FloatArray(MEL_BINS)
+            for (bin in 0 until MEL_BINS) stored[bin] = row[bin] / 10f + 2f
+            melBuffer.addLast(stored)
         }
-        while (melBuffer.size > MEL_BUFFER_MAX) melBuffer.removeFirst()
+        while (melBuffer.size > MEL_BUFFER_MAX) melRowPool.addLast(melBuffer.removeFirst())
         recordRowCount(rows.size)
         return true
     }
@@ -290,28 +326,35 @@ internal class OnnxWakeWordPipeline(
         val end = melBuffer.size - rowsBack
         val base = end - MEL_EMBEDDING_WINDOW
         if (base < 0) return false
-        val x = Array(1) { Array(MEL_EMBEDDING_WINDOW) { Array(MEL_BINS) { FloatArray(1) } } }
+        val x = embeddingInput
         for (k in 0 until MEL_EMBEDDING_WINDOW) {
             val row = melBuffer[base + k]
-            for (w in 0 until MEL_BINS) x[0][k][w][0] = row[w]
+            val slot = x[0][k]
+            for (w in 0 until MEL_BINS) slot[w][0] = row[w]
         }
 
         val tensor = OnnxTensor.createTensor(env, x)
         val embedding = try {
             embeddingSession.run(mapOf(embeddingSession.inputNames.first() to tensor)).use { result ->
-                (result.get(0).value as Array<Array<Array<FloatArray>>>)[0][0][0].copyOf()
+                val out = (result.get(0).value as Array<Array<Array<FloatArray>>>)[0][0][0]
+                // Recycled rather than copyOf()'d. Safe because classify()
+                // refills every slot of classifierInput before it reads them,
+                // so no evicted row is ever read after being handed back.
+                val stored = featurePool.removeLastOrNull() ?: FloatArray(FEATURE_DIM)
+                out.copyInto(stored)
+                stored
             }
         } finally {
             tensor.close()
         }
         featureBuffer.addLast(embedding)
-        while (featureBuffer.size > FEATURE_BUFFER_MAX) featureBuffer.removeFirst()
+        while (featureBuffer.size > FEATURE_BUFFER_MAX) featurePool.addLast(featureBuffer.removeFirst())
         return true
     }
 
     private fun classify(): Float? {
         if (featureBuffer.size < CLASSIFIER_FRAMES) return null
-        val x = Array(1) { Array(CLASSIFIER_FRAMES) { FloatArray(FEATURE_DIM) } }
+        val x = classifierInput
         val base = featureBuffer.size - CLASSIFIER_FRAMES
         for (k in 0 until CLASSIFIER_FRAMES) x[0][k] = featureBuffer[base + k]
 
@@ -374,5 +417,8 @@ internal class OnnxWakeWordPipeline(
          */
         private const val MEL_BUFFER_MAX = 240
         private const val FEATURE_BUFFER_MAX = 32
+
+        /** Placeholder for [classifierInput]'s rows; overwritten before every read. */
+        private val EMPTY_FEATURE = FloatArray(FEATURE_DIM)
     }
 }

--- a/app/src/main/java/com/gotcha/service/OnnxWakeWordPipeline.kt
+++ b/app/src/main/java/com/gotcha/service/OnnxWakeWordPipeline.kt
@@ -35,8 +35,23 @@ internal class OnnxWakeWordPipeline(
     private val melSession: OrtSession,
     private val embeddingSession: OrtSession,
     private val classifierSession: OrtSession,
-    private val matcher: WakeWordMatcher
+    private val matcher: WakeWordMatcher,
+    private val probe: PipelineProbe? = null
 ) {
+    /**
+     * Optional measurement hook. Off (null) in production; the instrumented
+     * benchmark passes one in to get the per-stage cost split that decides how
+     * much of the wake-word CPU budget each ONNX model actually owns.
+     */
+    internal interface PipelineProbe {
+        fun onStage(stage: Stage, nanos: Long) {}
+
+        /** Number of mel rows one `melspectrogram.onnx` run emitted. */
+        fun onMelRows(rows: Int) {}
+
+        enum class Stage { MEL, EMBEDDING, CLASSIFY }
+    }
+
     /** Ring buffer of the most recent raw PCM samples. Size caps at [MEL_WINDOW]. */
     private val rawSamples = ShortArray(MEL_WINDOW)
     private var rawStart = 0
@@ -136,9 +151,9 @@ internal class OnnxWakeWordPipeline(
             if (rawCount < MEL_WINDOW) rawCount++
         }
 
-        if (!computeMel()) return false
-        if (!computeEmbedding()) return false
-        val score = classify() ?: return false
+        if (!timed(PipelineProbe.Stage.MEL) { computeMel() }) return false
+        if (!timed(PipelineProbe.Stage.EMBEDDING) { computeEmbedding() }) return false
+        val score = timed(PipelineProbe.Stage.CLASSIFY) { classify() } ?: return false
 
         scoredFrames++
         if (scoredFrames <= WARMUP_FRAMES) return false
@@ -174,6 +189,7 @@ internal class OnnxWakeWordPipeline(
             tensor.close()
         }
         if (rows.isEmpty()) return false
+        probe?.onMelRows(rows.size)
         for (row in rows) {
             melBuffer.addLast(FloatArray(MEL_BINS) { row[it] / 10f + 2f })
         }
@@ -218,6 +234,17 @@ internal class OnnxWakeWordPipeline(
             }
         } finally {
             tensor.close()
+        }
+    }
+
+    /** Times [body] only when a [probe] is attached, so production stays free of the clock reads. */
+    private inline fun <T> timed(stage: PipelineProbe.Stage, body: () -> T): T {
+        val active = probe ?: return body()
+        val startedAt = System.nanoTime()
+        try {
+            return body()
+        } finally {
+            active.onStage(stage, System.nanoTime() - startedAt)
         }
     }
 

--- a/app/src/main/java/com/gotcha/service/OnnxWakeWordPipeline.kt
+++ b/app/src/main/java/com/gotcha/service/OnnxWakeWordPipeline.kt
@@ -81,6 +81,14 @@ internal class OnnxWakeWordPipeline(
         /** The classifier's output for a frame that made it past the gate. */
         fun onScore(score: Float) {}
 
+        /**
+         * Summary statistics of one stage's output. Used to bisect where a
+         * detection failure lives — if the mel values match a working run but
+         * the embeddings do not, the audio is fine and the model is not, and
+         * vice versa. Statistics only: these could not reconstruct speech.
+         */
+        fun onStageStats(stage: Stage, min: Float, mean: Float, max: Float) {}
+
         enum class Stage { MEL, EMBEDDING, CLASSIFY }
     }
 
@@ -291,6 +299,24 @@ internal class OnnxWakeWordPipeline(
         }
         if (rows.isEmpty()) return false
         probe?.onMelRows(rows.size)
+        probe?.let { active ->
+            var min = Float.MAX_VALUE
+            var max = -Float.MAX_VALUE
+            var sum = 0.0
+            for (row in rows) {
+                for (value in row) {
+                    if (value < min) min = value
+                    if (value > max) max = value
+                    sum += value
+                }
+            }
+            active.onStageStats(
+                PipelineProbe.Stage.MEL,
+                min,
+                (sum / (rows.size * MEL_BINS)).toFloat(),
+                max
+            )
+        }
         for (row in rows) {
             val stored = melRowPool.removeLastOrNull() ?: FloatArray(MEL_BINS)
             for (bin in 0 until MEL_BINS) stored[bin] = row[bin] / 10f + 2f
@@ -346,6 +372,22 @@ internal class OnnxWakeWordPipeline(
             }
         } finally {
             tensor.close()
+        }
+        probe?.let { active ->
+            var min = Float.MAX_VALUE
+            var max = -Float.MAX_VALUE
+            var sum = 0.0
+            for (value in embedding) {
+                if (value < min) min = value
+                if (value > max) max = value
+                sum += value
+            }
+            active.onStageStats(
+                PipelineProbe.Stage.EMBEDDING,
+                min,
+                (sum / embedding.size).toFloat(),
+                max
+            )
         }
         featureBuffer.addLast(embedding)
         while (featureBuffer.size > FEATURE_BUFFER_MAX) featurePool.addLast(featureBuffer.removeFirst())

--- a/app/src/main/java/com/gotcha/service/OnnxWakeWordPipeline.kt
+++ b/app/src/main/java/com/gotcha/service/OnnxWakeWordPipeline.kt
@@ -22,6 +22,25 @@ import java.nio.FloatBuffer
  * The first [WARMUP_FRAMES] scored frames are ignored so the feature buffers
  * fill up before anything can be detected.
  *
+ * ## Energy gating (issue #37)
+ *
+ * Steps 1 and 2 above are ~8% of a frame's cost; step 3 is the rest. So the
+ * mel front-end runs on every frame and [WakeWordGate] decides whether to pay
+ * for the embedding backbone. When the room is quiet the pipeline is doing
+ * mel + an RMS, and nothing else.
+ *
+ * Re-arming is **exact**, not approximate. Because `melBuffer` kept filling
+ * while the gate was shut, [replayGatedEmbeddings] can rebuild the skipped
+ * embeddings from the real audio that produced them, so the classifier sees
+ * bit-for-bit the window an ungated run would have handed it. That is what
+ * `OnnxWakeWordPipelineGateTest` asserts, and it is why gating cannot cost a
+ * detection — including when the gate closes mid-phrase.
+ *
+ * The one thing gating trades away is CPU in a *choppy* room: each re-arm
+ * replays up to 15 embeddings, which only pays for itself if the quiet gap was
+ * longer than ~1.3 s. `WakeWordGate`'s hangover is what keeps gaps that short
+ * from re-arming at all.
+ *
  * The hot path avoids per-frame GC pressure: the raw PCM ring buffer, the
  * combined feed buffer, the frame buffer, and the mel window are all
  * pre-allocated once and reused. The per-row mel arrays, `toList()` snapshots,
@@ -36,6 +55,7 @@ internal class OnnxWakeWordPipeline(
     private val embeddingSession: OrtSession,
     private val classifierSession: OrtSession,
     private val matcher: WakeWordMatcher,
+    private val gate: WakeWordGate = WakeWordGate(),
     private val probe: PipelineProbe? = null
 ) {
     /**
@@ -49,6 +69,12 @@ internal class OnnxWakeWordPipeline(
         /** Number of mel rows one `melspectrogram.onnx` run emitted. */
         fun onMelRows(rows: Int) {}
 
+        /** A frame whose embedding stage was skipped by [WakeWordGate]. */
+        fun onGated() {}
+
+        /** The classifier's output for a frame that made it past the gate. */
+        fun onScore(score: Float) {}
+
         enum class Stage { MEL, EMBEDDING, CLASSIFY }
     }
 
@@ -59,11 +85,13 @@ internal class OnnxWakeWordPipeline(
 
     /**
      * Scratch buffer that holds the current feed's samples plus whatever was
-     * carried over from the previous feed. Bounded by
-     * [MEL_WINDOW] + [FRAME_SIZE], which is the worst case when [feed] is
-     * called with a full [FRAME_SIZE] shortly after a remainder was kept.
+     * carried over from the previous feed. [feed] takes whatever the caller's
+     * `AudioRecord.read` returned — several frames at a time, since the reads
+     * were batched to cut wakeups — so this grows to fit the largest feed seen
+     * and is then reused. The carried-over remainder is always shorter than
+     * [FRAME_SIZE].
      */
-    private val combined = ShortArray(MEL_WINDOW + FRAME_SIZE)
+    private var combined = ShortArray(MEL_WINDOW + FRAME_SIZE)
     private var combinedLength = 0
 
     /** Reused destination for each extracted 80 ms frame. */
@@ -74,6 +102,20 @@ internal class OnnxWakeWordPipeline(
 
     private val melBuffer = ArrayDeque<FloatArray>()
     private val featureBuffer = ArrayDeque<FloatArray>()
+
+    /**
+     * Rows appended to [melBuffer] by each of the last [CLASSIFIER_FRAMES]
+     * frames. Re-arming after the gate closes has to rebuild the embeddings for
+     * a run of earlier frames, and that means knowing where each of those
+     * frames ended in [melBuffer]. Measured to be a flat 8 rows per frame, but
+     * recording it beats hardcoding a number the bundled graph could change.
+     */
+    private val rowCounts = IntArray(CLASSIFIER_FRAMES)
+    private var rowCountHead = 0
+    private var rowCountFilled = 0
+
+    /** Consecutive frames whose embedding was skipped because the gate was shut. */
+    private var gatedFrames = 0
 
     private var remainder = ShortArray(0)
     private var scoredFrames = 0
@@ -105,9 +147,13 @@ internal class OnnxWakeWordPipeline(
         combinedLength = 0
         remainder = ShortArray(0)
         scoredFrames = 0
+        rowCountHead = 0
+        rowCountFilled = 0
+        gatedFrames = 0
         melBuffer.clear()
         featureBuffer.clear()
         matcher.reset()
+        gate.reset()
         prefillFeatures()
     }
 
@@ -116,6 +162,8 @@ internal class OnnxWakeWordPipeline(
         var detected = false
 
         // Concatenate remainder + new samples into the reusable combined buffer.
+        val needed = remainder.size + count
+        if (combined.size < needed) combined = ShortArray(needed)
         combinedLength = 0
         if (remainder.isNotEmpty()) {
             System.arraycopy(remainder, 0, combined, 0, remainder.size)
@@ -151,9 +199,28 @@ internal class OnnxWakeWordPipeline(
             if (rawCount < MEL_WINDOW) rawCount++
         }
 
+        val open = gate.onFrame(frame, FRAME_SIZE)
+
+        // The mel front-end runs unconditionally even while the gate is shut.
+        // It is ~8% of the chain's cost, and keeping it warm is what makes
+        // re-arming exact: every mel row the embedding stage skipped is still
+        // in melBuffer, so the classifier window can be rebuilt from real audio
+        // instead of from whatever silence-shaped stand-in was available.
         if (!timed(PipelineProbe.Stage.MEL) { computeMel() }) return false
+
+        if (!open) {
+            if (gatedFrames < CLASSIFIER_FRAMES) gatedFrames++
+            probe?.onGated()
+            return false
+        }
+        if (gatedFrames > 0) {
+            replayGatedEmbeddings(gatedFrames)
+            gatedFrames = 0
+        }
+
         if (!timed(PipelineProbe.Stage.EMBEDDING) { computeEmbedding() }) return false
         val score = timed(PipelineProbe.Stage.CLASSIFY) { classify() } ?: return false
+        probe?.onScore(score)
 
         scoredFrames++
         if (scoredFrames <= WARMUP_FRAMES) return false
@@ -194,16 +261,38 @@ internal class OnnxWakeWordPipeline(
             melBuffer.addLast(FloatArray(MEL_BINS) { row[it] / 10f + 2f })
         }
         while (melBuffer.size > MEL_BUFFER_MAX) melBuffer.removeFirst()
+        recordRowCount(rows.size)
         return true
     }
 
-    private fun computeEmbedding(): Boolean {
-        if (melBuffer.size < MEL_EMBEDDING_WINDOW) return false
-        val mels = melBuffer.toList()
+    /**
+     * Rebuilds the embeddings for the [missedFrames] frames the gate skipped,
+     * oldest first, so the classifier sees the same 16-embedding window it
+     * would have seen had the gate never closed.
+     *
+     * Only the last [CLASSIFIER_FRAMES] − 1 matter: anything older has already
+     * fallen out of the classifier's window, and the entries still sitting in
+     * [featureBuffer] from before the gate closed are exactly the ones an
+     * ungated run would have there.
+     */
+    private fun replayGatedEmbeddings(missedFrames: Int) {
+        val replay = minOf(missedFrames, CLASSIFIER_FRAMES - 1, rowCountFilled - 1)
+        for (framesBack in replay downTo 1) {
+            timed(PipelineProbe.Stage.EMBEDDING) { computeEmbedding(rowsInLast(framesBack)) }
+        }
+    }
+
+    /**
+     * Runs the embedding model over the 76 mel rows ending [rowsBack] rows
+     * before the end of [melBuffer]. [rowsBack] of 0 is the current frame.
+     */
+    private fun computeEmbedding(rowsBack: Int = 0): Boolean {
+        val end = melBuffer.size - rowsBack
+        val base = end - MEL_EMBEDDING_WINDOW
+        if (base < 0) return false
         val x = Array(1) { Array(MEL_EMBEDDING_WINDOW) { Array(MEL_BINS) { FloatArray(1) } } }
-        val base = mels.size - MEL_EMBEDDING_WINDOW
         for (k in 0 until MEL_EMBEDDING_WINDOW) {
-            val row = mels[base + k]
+            val row = melBuffer[base + k]
             for (w in 0 until MEL_BINS) x[0][k][w][0] = row[w]
         }
 
@@ -222,10 +311,9 @@ internal class OnnxWakeWordPipeline(
 
     private fun classify(): Float? {
         if (featureBuffer.size < CLASSIFIER_FRAMES) return null
-        val features = featureBuffer.toList()
         val x = Array(1) { Array(CLASSIFIER_FRAMES) { FloatArray(FEATURE_DIM) } }
-        val base = features.size - CLASSIFIER_FRAMES
-        for (k in 0 until CLASSIFIER_FRAMES) x[0][k] = features[base + k]
+        val base = featureBuffer.size - CLASSIFIER_FRAMES
+        for (k in 0 until CLASSIFIER_FRAMES) x[0][k] = featureBuffer[base + k]
 
         val tensor = OnnxTensor.createTensor(env, x)
         return try {
@@ -235,6 +323,21 @@ internal class OnnxWakeWordPipeline(
         } finally {
             tensor.close()
         }
+    }
+
+    private fun recordRowCount(rows: Int) {
+        rowCounts[rowCountHead] = rows
+        rowCountHead = (rowCountHead + 1) % CLASSIFIER_FRAMES
+        if (rowCountFilled < CLASSIFIER_FRAMES) rowCountFilled++
+    }
+
+    /** Rows appended by the most recent [frames] frames, current frame included. */
+    private fun rowsInLast(frames: Int): Int {
+        var total = 0
+        for (k in 1..frames) {
+            total += rowCounts[(rowCountHead - k + CLASSIFIER_FRAMES) % CLASSIFIER_FRAMES]
+        }
+        return total
     }
 
     /** Times [body] only when a [probe] is attached, so production stays free of the clock reads. */
@@ -261,7 +364,15 @@ internal class OnnxWakeWordPipeline(
         const val FEATURE_DIM = 96
         const val CLASSIFIER_FRAMES = 16
         private const val WARMUP_FRAMES = 5
-        private const val MEL_BUFFER_MAX = 120
+
+        /**
+         * Mel rows kept around. Re-arming after the gate closes has to rebuild
+         * the embeddings for up to [CLASSIFIER_FRAMES] − 1 earlier frames, and
+         * the oldest of those still needs a full [MEL_EMBEDDING_WINDOW] of rows
+         * behind it: 76 + 15 × 8 = 196 at the measured 8 rows per frame. 240
+         * leaves headroom without mattering (240 × 32 floats ≈ 30 KB).
+         */
+        private const val MEL_BUFFER_MAX = 240
         private const val FEATURE_BUFFER_MAX = 32
     }
 }

--- a/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
+++ b/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
@@ -79,7 +79,21 @@ class WakeWordDetector(
         val embedding: OrtSession,
         val classifier: OrtSession
     ) {
+        private val closed = AtomicBoolean(false)
+
+        /**
+         * Idempotent. The reference count should make a second close
+         * unreachable — but ORT throws on one, and an ownership mistake here
+         * should not be the thing that takes down a user's assistant. In debug
+         * builds it complains loudly so the mistake still gets found.
+         */
         fun close() {
+            if (!closed.compareAndSet(false, true)) {
+                if (BuildConfig.DEBUG) {
+                    Log.w(TAG, "Sessions closed twice", Throwable("second close from"))
+                }
+                return
+            }
             mel.close()
             embedding.close()
             classifier.close()
@@ -188,13 +202,37 @@ class WakeWordDetector(
     @SuppressLint("MissingPermission")
     private suspend fun initializeAndListen(generation: Int) {
         val env = OrtEnvironment.getEnvironment()
-        var loadedSessions: Sessions? = null
+        /** Sessions this run holds a use-claim on; released in the finally. */
+        var claimed: Sessions? = null
         var createdRecorder: AudioRecord? = null
         try {
-            // Reuse the sessions from a previous run when this is a resume
-            // after pause(); only a cold start pays the ~2.6 MB model load.
-            val cached = synchronized(stateLock) { sessions }
-            val active = cached ?: loadSessions(env).also { loadedSessions = it }
+            // Claim cached sessions under the very lock that reads them. Reading
+            // first and claiming later leaves a window where sessionUsers is 0,
+            // and a release() landing in that window frees the models this run
+            // is about to adopt — which is exactly how it went wrong.
+            synchronized(stateLock) {
+                if (!running.get() || generation != this.generation) return
+                sessions?.let {
+                    claimed = it
+                    sessionUsers++
+                }
+            }
+            if (claimed == null) {
+                // Cold start. The load is slow, so it happens off the lock; the
+                // result is unpublished until the block below, so nothing else
+                // can see it and no claim is needed yet.
+                val loaded = loadSessions(env)
+                synchronized(stateLock) {
+                    if (!running.get() || generation != this.generation) {
+                        loaded.close()
+                        return
+                    }
+                    sessions = loaded
+                    claimed = loaded
+                    sessionUsers++
+                }
+            }
+            val active = claimed ?: return
             // Bytes, not samples: 16-bit mono. A minimum-size buffer forces a
             // wakeup every 80 ms and leaves no room to absorb the burst of work
             // that re-arming the gate can cost, so ask for ~1.3 s instead. The
@@ -217,34 +255,29 @@ class WakeWordDetector(
 
             synchronized(stateLock) {
                 if (!running.get() || generation != this.generation) {
-                    // Stopped while loading. Only discard sessions this run
-                    // created — a cached set belongs to whoever comes next.
-                    loadedSessions?.close()
+                    // Stopped while starting up. The claim is dropped by the
+                    // finally below, which closes the models if a release()
+                    // was waiting on this run to let go of them.
                     createdRecorder.release()
                     return
                 }
-                sessions = active
                 recorder = createdRecorder
-                // Claim the models for as long as this loop runs, so a
-                // concurrent release() defers closing them rather than pulling
-                // them out from under an in-flight inference.
-                sessionUsers++
             }
             scope.launch(Dispatchers.Main) { onStarted() }
-            try {
-                listen(
-                    generation = generation,
-                    env = env,
-                    localRecorder = createdRecorder,
-                    localSessions = active
-                )
-            } finally {
-                releaseSessionUse()
-            }
+            listen(
+                generation = generation,
+                env = env,
+                localRecorder = createdRecorder,
+                localSessions = active
+            )
         } catch (e: Exception) {
-            loadedSessions?.close()
+            // Deliberately does not close the sessions: once published they are
+            // owned by the reference count, and closing them here raced with a
+            // concurrent run that had legitimately adopted them.
             createdRecorder?.release()
             fail(startupError(e), e, generation)
+        } finally {
+            if (claimed != null) releaseSessionUse()
         }
     }
 

--- a/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
+++ b/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
@@ -9,6 +9,7 @@ import android.content.pm.PackageManager
 import android.media.AudioFormat
 import android.media.AudioRecord
 import android.media.MediaRecorder
+import android.os.Process
 import android.util.Log
 import androidx.core.content.ContextCompat
 import kotlinx.coroutines.CoroutineScope
@@ -285,6 +286,12 @@ class WakeWordDetector(
             classifierSession = localSessions.classifier,
             matcher = matcher
         )
+        // An audio capture loop should be scheduled like one. At the default
+        // priority of a Dispatchers.IO thread this loop competes with ordinary
+        // background work, and a preempted read is a dropped frame. Restored
+        // afterwards because the thread goes back to the shared IO pool.
+        val callerPriority = Process.getThreadPriority(Process.myTid())
+        Process.setThreadPriority(Process.THREAD_PRIORITY_AUDIO)
         try {
             localRecorder.startRecording()
             while (running.get()) {
@@ -318,6 +325,8 @@ class WakeWordDetector(
             }
         } catch (e: Exception) {
             if (running.get()) fail("Wake word listening stopped unexpectedly.", e, generation)
+        } finally {
+            Process.setThreadPriority(callerPriority)
         }
     }
 

--- a/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
+++ b/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
@@ -117,11 +117,15 @@ class WakeWordDetector(
             createdMel = loadSession(env, "$modelAssetDir/melspectrogram.onnx")
             createdEmbedding = loadSession(env, "$modelAssetDir/embedding_model.onnx")
             createdClassifier = loadSession(env, "$modelAssetDir/$classifierModel")
+            // Bytes, not samples: 16-bit mono. A minimum-size buffer forces a
+            // wakeup every 80 ms and leaves no room to absorb the burst of work
+            // that re-arming the gate can cost, so ask for ~1.3 s instead. The
+            // memory is irrelevant (~40 KB); the wakeup rate is not.
             val bufferSize = AudioRecord.getMinBufferSize(
                 OnnxWakeWordPipeline.SAMPLE_RATE,
                 AudioFormat.CHANNEL_IN_MONO,
                 AudioFormat.ENCODING_PCM_16BIT
-            ).coerceAtLeast(OnnxWakeWordPipeline.FRAME_SIZE * 2)
+            ).coerceAtLeast(OnnxWakeWordPipeline.FRAME_SIZE * 2 * BUFFER_FRAMES)
             createdRecorder = AudioRecord(
                 MediaRecorder.AudioSource.VOICE_RECOGNITION,
                 OnnxWakeWordPipeline.SAMPLE_RATE,
@@ -173,7 +177,10 @@ class WakeWordDetector(
         localEmbedding: OrtSession,
         localClassifier: OrtSession
     ) {
-        val frame = ShortArray(OnnxWakeWordPipeline.FRAME_SIZE)
+        // Read several 80 ms frames per wakeup rather than one. The pipeline
+        // splits whatever it is handed back into frames, so this changes only
+        // how often the CPU is woken: 3.1 times a second instead of 12.5.
+        val block = ShortArray(OnnxWakeWordPipeline.FRAME_SIZE * READ_FRAMES)
         val pipeline = OnnxWakeWordPipeline(
             env = env,
             melSession = localMel,
@@ -184,19 +191,25 @@ class WakeWordDetector(
         try {
             localRecorder.startRecording()
             while (running.get()) {
-                val count = localRecorder.read(frame, 0, frame.size)
+                val count = localRecorder.read(block, 0, block.size)
                 if (count < 0) {
                     if (running.get()) throw IOException("AudioRecord read failed: $count")
                     return
                 }
-                if (count == 0) continue
+                // A blocking read should never come back empty, but returning
+                // to the top on 0 would spin the loop at full tilt if one ever
+                // did. Wait out a frame instead.
+                if (count == 0) {
+                    Thread.sleep(FRAME_DURATION_MS)
+                    continue
+                }
 
                 var detected = false
                 synchronized(stateLock) {
                     if (!running.get() || recorder !== localRecorder || generation != this.generation) {
                         return
                     }
-                    if (pipeline.feed(frame, count)) {
+                    if (pipeline.feed(block, count)) {
                         detected = true
                         running.set(false)
                     }
@@ -238,5 +251,17 @@ class WakeWordDetector(
         const val MODEL_ASSET_DIR = "openwakeword"
         const val CLASSIFIER_MODEL = "hey_gotcha.onnx"
         private const val TAG = "WakeWordDetector"
+
+        /**
+         * 80 ms frames drained per `AudioRecord.read`. Four cuts the wakeup
+         * rate by 4× and costs up to 320 ms of extra trigger latency, on top of
+         * the matcher's existing 160 ms patience.
+         */
+        private const val READ_FRAMES = 4
+
+        /** ~1.3 s of audio: enough headroom that a slow frame cannot overrun the buffer. */
+        private const val BUFFER_FRAMES = 16
+
+        private const val FRAME_DURATION_MS = 80L
     }
 }

--- a/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
+++ b/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
@@ -164,9 +164,41 @@ class WakeWordDetector(
         }
     }
 
+    /**
+     * Loads one model with a thread configuration suited to a 12.5 Hz duty
+     * cycle (issue #37). ONNX Runtime's defaults are tuned for throughput on a
+     * busy server, and both of them are wrong here:
+     *
+     * - The intra-op thread count defaults to the core count, so three sessions
+     *   spin up three pools and each 80 ms tick wakes several cores for a few
+     *   milliseconds of work that fits comfortably on one.
+     * - The pools busy-spin waiting for the next `run()`. At this duty cycle
+     *   that is mostly burning CPU doing nothing, and it stops the SoC dropping
+     *   to a low-power state between frames.
+     *
+     * Measured wall time barely moves (4.14 ms → 4.41 ms per frame at the
+     * median), while p95 on the embedding stage improves a lot (11.35 ms →
+     * 4.21 ms). That is expected — wall time is not core time, and this trades
+     * a little median latency for far less total core time and no spinning.
+     * The battery half of the claim needs batterystats, not the benchmark.
+     *
+     * Deliberately not set: `setOptimizationLevel(ORT_ENABLE_ALL)`, which is
+     * already the default and would be a no-op. XNNPACK remains an untested
+     * lever — contrary to a common claim it is *not* the default CPU EP in the
+     * Android AAR (the shipped 1.26.0 exposes `addXnnpack` as explicit opt-in
+     * and defaults to MLAS), so it is worth trying, but as its own measured
+     * experiment.
+     */
     private fun loadSession(env: OrtEnvironment, assetPath: String): OrtSession {
         val bytes = appContext.assets.open(assetPath).use { it.readBytes() }
-        return env.createSession(bytes)
+        return OrtSession.SessionOptions().use { options ->
+            options.setIntraOpNumThreads(1)
+            options.setInterOpNumThreads(1)
+            options.setExecutionMode(OrtSession.SessionOptions.ExecutionMode.SEQUENTIAL)
+            options.addConfigEntry("session.intra_op.allow_spinning", "0")
+            options.addConfigEntry("session.inter_op.allow_spinning", "0")
+            env.createSession(bytes, options)
+        }
     }
 
     private fun listen(

--- a/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
+++ b/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
@@ -12,6 +12,7 @@ import android.media.MediaRecorder
 import android.os.Process
 import android.util.Log
 import androidx.core.content.ContextCompat
+import com.gotcha.BuildConfig
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -87,6 +88,7 @@ class WakeWordDetector(
             matcher = WakeWordMatcher(sensitivityProvider().coerceIn(0f, 1f))
             running.set(true)
             val startGeneration = generation
+            if (BuildConfig.DEBUG) Log.d(TAG, "start(): generation=$startGeneration")
             job = scope.launch(Dispatchers.IO) { initializeAndListen(startGeneration) }
         }
         return true
@@ -122,6 +124,9 @@ class WakeWordDetector(
     }
 
     private fun teardown(closeSessions: Boolean) {
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, if (closeSessions) "release()" else "pause()", Throwable("called from"))
+        }
         val oldRecorder: AudioRecord?
         val oldSessions: Sessions?
         val oldJob: Job?
@@ -279,13 +284,37 @@ class WakeWordDetector(
         // splits whatever it is handed back into frames, so this changes only
         // how often the CPU is woken: 3.1 times a second instead of 12.5.
         val block = ShortArray(OnnxWakeWordPipeline.FRAME_SIZE * READ_FRAMES)
+        // Debug builds get a running account of what the listener is hearing.
+        // "The wake word stopped working" is otherwise unfalsifiable from the
+        // outside: a listener that holds the mic and scores nothing looks
+        // exactly like one that is reading silence.
+        val telemetry = if (BuildConfig.DEBUG) ListenTelemetry() else null
         val pipeline = OnnxWakeWordPipeline(
             env = env,
             melSession = localSessions.mel,
             embeddingSession = localSessions.embedding,
             classifierSession = localSessions.classifier,
-            matcher = matcher
+            matcher = matcher,
+            probe = telemetry
         )
+        telemetry?.let {
+            // The listener can be running, holding the mic and reading
+            // plausible levels while still being fed the wrong thing — a
+            // different physical mic, or a stream mangled by voice-comm
+            // processing left behind by a call. Record what we actually got.
+            val audio = appContext.getSystemService(android.content.Context.AUDIO_SERVICE)
+                as android.media.AudioManager
+            Log.d(
+                TAG,
+                "listening: threshold=${matcher.threshold()} readFrames=$READ_FRAMES " +
+                    "rate=${localRecorder.sampleRate} ch=${localRecorder.channelCount} " +
+                    "session=${localRecorder.audioSessionId} " +
+                    "route=${describeRoute(localRecorder)} " +
+                    "audioMode=${audio.mode} " +
+                    "micMute=${audio.isMicrophoneMute} " +
+                    "bufFrames=${localRecorder.bufferSizeInFrames}"
+            )
+        }
         // An audio capture loop should be scheduled like one. At the default
         // priority of a Dispatchers.IO thread this loop competes with ordinary
         // background work, and a preempted read is a dropped frame. Restored
@@ -308,6 +337,8 @@ class WakeWordDetector(
                     continue
                 }
 
+                telemetry?.onRead(WakeWordGate.rmsDb(block, count))
+
                 var detected = false
                 synchronized(stateLock) {
                     if (!running.get() || recorder !== localRecorder || generation != this.generation) {
@@ -327,6 +358,100 @@ class WakeWordDetector(
             if (running.get()) fail("Wake word listening stopped unexpectedly.", e, generation)
         } finally {
             Process.setThreadPriority(callerPriority)
+        }
+    }
+
+    private fun describeRoute(recorder: AudioRecord): String {
+        val device = recorder.routedDevice ?: return "none"
+        val effects = buildList {
+            if (android.media.audiofx.AcousticEchoCanceler.isAvailable()) add("aec-avail")
+            if (android.media.audiofx.NoiseSuppressor.isAvailable()) add("ns-avail")
+            if (android.media.audiofx.AutomaticGainControl.isAvailable()) add("agc-avail")
+        }
+        return "type=${device.type} product=${device.productName} address=${device.address} " +
+            "effects=${effects.joinToString("|")}"
+    }
+
+    /**
+     * Debug-only running summary of what the listener hears. Reports levels and
+     * scores, never audio — nothing here could reconstruct what was said.
+     */
+    private class ListenTelemetry : OnnxWakeWordPipeline.PipelineProbe {
+        private var reads = 0
+        private var frames = 0
+        private var gated = 0
+        private var scored = 0
+        private var peakScore = 0f
+        private var peakRms = -200f
+        private var quietestRms = 200f
+        private var melMin = Float.MAX_VALUE
+        private var melMax = -Float.MAX_VALUE
+        private var melMean = 0f
+        private var embMin = Float.MAX_VALUE
+        private var embMax = -Float.MAX_VALUE
+        private var embMean = 0f
+
+        override fun onStageStats(
+            stage: OnnxWakeWordPipeline.PipelineProbe.Stage,
+            min: Float,
+            mean: Float,
+            max: Float
+        ) {
+            when (stage) {
+                OnnxWakeWordPipeline.PipelineProbe.Stage.MEL -> {
+                    if (min < melMin) melMin = min
+                    if (max > melMax) melMax = max
+                    melMean = mean
+                }
+                OnnxWakeWordPipeline.PipelineProbe.Stage.EMBEDDING -> {
+                    if (min < embMin) embMin = min
+                    if (max > embMax) embMax = max
+                    embMean = mean
+                }
+                else -> Unit
+            }
+        }
+
+        fun onRead(rmsDb: Float) {
+            reads++
+            if (rmsDb > peakRms) peakRms = rmsDb
+            if (rmsDb < quietestRms) quietestRms = rmsDb
+            if (reads % REPORT_EVERY_READS != 0) return
+            Log.d(
+                TAG,
+                "heard: rms ${"%.1f".format(quietestRms)}..${"%.1f".format(peakRms)} dBFS, " +
+                    "frames=$frames scored=$scored gated=$gated peakScore=${"%.3f".format(peakScore)} " +
+                    "mel[${"%.2f".format(melMin)}..${"%.2f".format(melMax)} avg ${"%.2f".format(melMean)}] " +
+                    "emb[${"%.2f".format(embMin)}..${"%.2f".format(embMax)} avg ${"%.2f".format(embMean)}]"
+            )
+            melMin = Float.MAX_VALUE
+            melMax = -Float.MAX_VALUE
+            embMin = Float.MAX_VALUE
+            embMax = -Float.MAX_VALUE
+            peakRms = -200f
+            quietestRms = 200f
+            peakScore = 0f
+            frames = 0
+            scored = 0
+            gated = 0
+        }
+
+        override fun onMelRows(rows: Int) {
+            frames++
+        }
+
+        override fun onGated() {
+            gated++
+        }
+
+        override fun onScore(score: Float) {
+            scored++
+            if (score > peakScore) peakScore = score
+        }
+
+        private companion object {
+            /** ~3 s at 4 frames per read. */
+            const val REPORT_EVERY_READS = 10
         }
     }
 

--- a/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
+++ b/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
@@ -54,6 +54,23 @@ class WakeWordDetector(
      * [release] closes them — see [pause] for why.
      */
     private var sessions: Sessions? = null
+
+    /**
+     * How many listen loops are currently running inference against [sessions].
+     * Normally 0 or 1; briefly 2 when a stale loop has not yet noticed it was
+     * superseded. Guarded by [stateLock].
+     *
+     * This exists so the inference itself does not have to hold [stateLock].
+     * A `run()` on the embedding model, plus the burst a gate re-arm can
+     * trigger, is tens of milliseconds — long enough that holding the lock
+     * across it would stall any main-thread `pause()`/`release()` behind it.
+     * Instead the lock is held only for the state checks, and the models are
+     * kept alive by whoever is using them.
+     */
+    private var sessionUsers = 0
+
+    /** Sessions a [release] wanted to close while a listen loop still held them. */
+    private var pendingClose: Sessions? = null
     private var matcher = WakeWordMatcher(WakeWordMatcher.DEFAULT_SENSITIVITY)
     private var generation = 0
 
@@ -128,7 +145,7 @@ class WakeWordDetector(
             Log.d(TAG, if (closeSessions) "release()" else "pause()", Throwable("called from"))
         }
         val oldRecorder: AudioRecord?
-        val oldSessions: Sessions?
+        var oldSessions: Sessions? = null
         val oldJob: Job?
         synchronized(stateLock) {
             running.set(false)
@@ -136,10 +153,23 @@ class WakeWordDetector(
             matcher.reset()
             oldRecorder = recorder
             oldJob = job
-            oldSessions = if (closeSessions) sessions else null
             recorder = null
             job = null
-            if (closeSessions) sessions = null
+            if (closeSessions) {
+                val doomed = sessions
+                sessions = null
+                if (doomed != null) {
+                    if (sessionUsers > 0) {
+                        // A listen loop is mid-inference against these. Closing
+                        // them here would free models out from under a running
+                        // OrtSession.run() — hand the close to whoever finishes
+                        // last instead.
+                        pendingClose = doomed
+                    } else {
+                        oldSessions = doomed
+                    }
+                }
+            }
         }
         oldRecorder?.let {
             try {
@@ -195,14 +225,22 @@ class WakeWordDetector(
                 }
                 sessions = active
                 recorder = createdRecorder
+                // Claim the models for as long as this loop runs, so a
+                // concurrent release() defers closing them rather than pulling
+                // them out from under an in-flight inference.
+                sessionUsers++
             }
             scope.launch(Dispatchers.Main) { onStarted() }
-            listen(
-                generation = generation,
-                env = env,
-                localRecorder = createdRecorder,
-                localSessions = active
-            )
+            try {
+                listen(
+                    generation = generation,
+                    env = env,
+                    localRecorder = createdRecorder,
+                    localSessions = active
+                )
+            } finally {
+                releaseSessionUse()
+            }
         } catch (e: Exception) {
             loadedSessions?.close()
             createdRecorder?.release()
@@ -219,6 +257,19 @@ class WakeWordDetector(
     @Volatile
     internal var sessionLoadCount = 0
         private set
+
+    /**
+     * Drops this loop's claim on the models, closing them if a [release]
+     * asked for that while the loop was still running.
+     */
+    private fun releaseSessionUse() {
+        val toClose: Sessions?
+        synchronized(stateLock) {
+            sessionUsers--
+            toClose = if (sessionUsers == 0) pendingClose.also { pendingClose = null } else null
+        }
+        toClose?.close()
+    }
 
     /** Loads all three models, closing any that succeeded if a later one fails. */
     private fun loadSessions(env: OrtEnvironment): Sessions {
@@ -346,20 +397,29 @@ class WakeWordDetector(
                     telemetry.onRead(WakeWordGate.rmsDb(block, count))
                 }
 
-                var detected = false
-                synchronized(stateLock) {
-                    if (!running.get() || recorder !== localRecorder || generation != this.generation) {
-                        return
-                    }
-                    if (pipeline.feed(block, count)) {
-                        detected = true
+                // The state check is under the lock; the inference is not. A
+                // batch of four frames, plus the replay a gate re-arm can
+                // trigger, is tens of milliseconds of ONNX — long enough that
+                // running it under the lock would stall a main-thread pause()
+                // or release() behind it. The models cannot be closed while
+                // this loop runs (see sessionUsers), so dropping the lock here
+                // is safe.
+                if (isStale(localRecorder, generation)) return
+                if (!pipeline.feed(block, count)) continue
+
+                // Re-check before acting: the listener may have been paused
+                // while that batch was being processed, in which case this
+                // detection belongs to a listener that no longer exists.
+                val fire = synchronized(stateLock) {
+                    if (isStaleLocked(localRecorder, generation)) {
+                        false
+                    } else {
                         running.set(false)
+                        true
                     }
                 }
-                if (detected) {
-                    scope.launch(Dispatchers.Main) { onDetected() }
-                    return
-                }
+                if (fire) scope.launch(Dispatchers.Main) { onDetected() }
+                return
             }
         } catch (e: Exception) {
             if (running.get()) fail("Wake word listening stopped unexpectedly.", e, generation)
@@ -467,6 +527,13 @@ class WakeWordDetector(
             const val REPORT_EVERY_READS = 10
         }
     }
+
+    private fun isStale(localRecorder: AudioRecord, generation: Int): Boolean =
+        synchronized(stateLock) { isStaleLocked(localRecorder, generation) }
+
+    /** Caller must hold [stateLock]. */
+    private fun isStaleLocked(localRecorder: AudioRecord, generation: Int): Boolean =
+        !running.get() || recorder !== localRecorder || generation != this.generation
 
     private fun fail(message: String, cause: Exception? = null, generation: Int) {
         synchronized(stateLock) {

--- a/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
+++ b/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
@@ -337,7 +337,14 @@ class WakeWordDetector(
                     continue
                 }
 
-                telemetry?.onRead(WakeWordGate.rmsDb(block, count))
+                // Spelled out rather than `telemetry?.onRead(rmsDb(...))`. Both
+                // skip the RMS scan in release — a safe call does not evaluate
+                // its arguments when the receiver is null — but that is a
+                // subtlety one refactor away from being lost, and this is a
+                // per-frame path in an always-on listener.
+                if (telemetry != null) {
+                    telemetry.onRead(WakeWordGate.rmsDb(block, count))
+                }
 
                 var detected = false
                 synchronized(stateLock) {

--- a/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
+++ b/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
@@ -202,7 +202,7 @@ class WakeWordDetector(
     @SuppressLint("MissingPermission")
     private suspend fun initializeAndListen(generation: Int) {
         val env = OrtEnvironment.getEnvironment()
-        /** Sessions this run holds a use-claim on; released in the finally. */
+        // Sessions this run holds a use-claim on; released in the finally.
         var claimed: Sessions? = null
         var createdRecorder: AudioRecord? = null
         try {

--- a/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
+++ b/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
@@ -25,6 +25,11 @@ import java.util.concurrent.atomic.AtomicBoolean
  * The three ONNX models are read from assets and loaded on an IO coroutine —
  * model load takes tens of milliseconds, so doing it on the service's main
  * thread would show up as a ball-service freeze right after start.
+ *
+ * There are two ways to stop it, and the difference is the point:
+ * [pause] gives up the microphone but keeps the loaded models, for the
+ * constant interruptions of ordinary use; [release] gives up everything, for
+ * when the feature is switched off or the service is going away.
  */
 class WakeWordDetector(
     context: Context,
@@ -41,11 +46,26 @@ class WakeWordDetector(
     private val running = AtomicBoolean(false)
     private var job: Job? = null
     private var recorder: AudioRecord? = null
-    private var melSession: OrtSession? = null
-    private var embeddingSession: OrtSession? = null
-    private var classifierSession: OrtSession? = null
+
+    /**
+     * The three ORT sessions, cached across [pause]/[start] cycles. Only
+     * [release] closes them — see [pause] for why.
+     */
+    private var sessions: Sessions? = null
     private var matcher = WakeWordMatcher(WakeWordMatcher.DEFAULT_SENSITIVITY)
     private var generation = 0
+
+    private class Sessions(
+        val mel: OrtSession,
+        val embedding: OrtSession,
+        val classifier: OrtSession
+    ) {
+        fun close() {
+            mel.close()
+            embedding.close()
+            classifier.close()
+        }
+    }
 
     @Volatile
     var lastError: String? = null
@@ -71,26 +91,49 @@ class WakeWordDetector(
         return true
     }
 
-    fun stop() {
+    /**
+     * Stops listening and **fully releases the microphone**, but keeps the ONNX
+     * sessions loaded for the next [start].
+     *
+     * This is the right call for every transient interruption — a call starting
+     * or ending, the app's own TTS speaking. Those happen constantly: the
+     * service pauses the listener on every single TTS utterance, and before
+     * this split that meant re-reading ~2.6 MB of model bytes out of assets and
+     * rebuilding three ORT sessions each time the app said one sentence.
+     *
+     * The mic is still released here, not merely stopped. That matters beyond
+     * battery: pausing while TTS speaks is a privacy guarantee, not an
+     * optimisation (privacy-data-retention.md §10.3), and "we kept the mic open
+     * but promise we ignored it" is not the same guarantee. Keeping sessions is
+     * safe because a loaded model holds no audio.
+     */
+    fun pause() {
+        teardown(closeSessions = false)
+    }
+
+    /**
+     * Stops listening and frees everything, sessions included. For when the
+     * wake word is switched off or the service is going away — not for the
+     * pause/resume churn of ordinary use.
+     */
+    fun release() {
+        teardown(closeSessions = true)
+    }
+
+    private fun teardown(closeSessions: Boolean) {
         val oldRecorder: AudioRecord?
-        val oldMel: OrtSession?
-        val oldEmbedding: OrtSession?
-        val oldClassifier: OrtSession?
+        val oldSessions: Sessions?
         val oldJob: Job?
         synchronized(stateLock) {
             running.set(false)
             generation++
             matcher.reset()
             oldRecorder = recorder
-            oldMel = melSession
-            oldEmbedding = embeddingSession
-            oldClassifier = classifierSession
             oldJob = job
+            oldSessions = if (closeSessions) sessions else null
             recorder = null
-            melSession = null
-            embeddingSession = null
-            classifierSession = null
             job = null
+            if (closeSessions) sessions = null
         }
         oldRecorder?.let {
             try {
@@ -100,7 +143,7 @@ class WakeWordDetector(
             }
             it.release()
         }
-        closeSessions(oldMel, oldEmbedding, oldClassifier)
+        oldSessions?.close()
         oldJob?.cancel()
     }
 
@@ -109,14 +152,13 @@ class WakeWordDetector(
     @SuppressLint("MissingPermission")
     private suspend fun initializeAndListen(generation: Int) {
         val env = OrtEnvironment.getEnvironment()
-        var createdMel: OrtSession? = null
-        var createdEmbedding: OrtSession? = null
-        var createdClassifier: OrtSession? = null
+        var loadedSessions: Sessions? = null
         var createdRecorder: AudioRecord? = null
         try {
-            createdMel = loadSession(env, "$modelAssetDir/melspectrogram.onnx")
-            createdEmbedding = loadSession(env, "$modelAssetDir/embedding_model.onnx")
-            createdClassifier = loadSession(env, "$modelAssetDir/$classifierModel")
+            // Reuse the sessions from a previous run when this is a resume
+            // after pause(); only a cold start pays the ~2.6 MB model load.
+            val cached = synchronized(stateLock) { sessions }
+            val active = cached ?: loadSessions(env).also { loadedSessions = it }
             // Bytes, not samples: 16-bit mono. A minimum-size buffer forces a
             // wakeup every 80 ms and leaves no room to absorb the burst of work
             // that re-arming the gate can cost, so ask for ~1.3 s instead. The
@@ -139,13 +181,13 @@ class WakeWordDetector(
 
             synchronized(stateLock) {
                 if (!running.get() || generation != this.generation) {
-                    closeSessions(createdMel, createdEmbedding, createdClassifier)
+                    // Stopped while loading. Only discard sessions this run
+                    // created — a cached set belongs to whoever comes next.
+                    loadedSessions?.close()
                     createdRecorder.release()
                     return
                 }
-                melSession = createdMel
-                embeddingSession = createdEmbedding
-                classifierSession = createdClassifier
+                sessions = active
                 recorder = createdRecorder
             }
             scope.launch(Dispatchers.Main) { onStarted() }
@@ -153,14 +195,39 @@ class WakeWordDetector(
                 generation = generation,
                 env = env,
                 localRecorder = createdRecorder,
-                localMel = createdMel,
-                localEmbedding = createdEmbedding,
-                localClassifier = createdClassifier
+                localSessions = active
             )
         } catch (e: Exception) {
-            closeSessions(createdMel, createdEmbedding, createdClassifier)
+            loadedSessions?.close()
             createdRecorder?.release()
             fail(startupError(e), e, generation)
+        }
+    }
+
+    /**
+     * How many times all three models have been read out of assets and turned
+     * into ORT sessions. The whole point of [pause] is that this does not climb
+     * with ordinary use, and a count is the only way to assert that from a test
+     * — the alternative is timing a resume, which is inherently flaky.
+     */
+    @Volatile
+    internal var sessionLoadCount = 0
+        private set
+
+    /** Loads all three models, closing any that succeeded if a later one fails. */
+    private fun loadSessions(env: OrtEnvironment): Sessions {
+        var mel: OrtSession? = null
+        var embedding: OrtSession? = null
+        try {
+            mel = loadSession(env, "$modelAssetDir/melspectrogram.onnx")
+            embedding = loadSession(env, "$modelAssetDir/embedding_model.onnx")
+            val loaded = Sessions(mel, embedding, loadSession(env, "$modelAssetDir/$classifierModel"))
+            sessionLoadCount++
+            return loaded
+        } catch (e: Exception) {
+            mel?.close()
+            embedding?.close()
+            throw e
         }
     }
 
@@ -205,9 +272,7 @@ class WakeWordDetector(
         generation: Int,
         env: OrtEnvironment,
         localRecorder: AudioRecord,
-        localMel: OrtSession,
-        localEmbedding: OrtSession,
-        localClassifier: OrtSession
+        localSessions: Sessions
     ) {
         // Read several 80 ms frames per wakeup rather than one. The pipeline
         // splits whatever it is handed back into frames, so this changes only
@@ -215,9 +280,9 @@ class WakeWordDetector(
         val block = ShortArray(OnnxWakeWordPipeline.FRAME_SIZE * READ_FRAMES)
         val pipeline = OnnxWakeWordPipeline(
             env = env,
-            melSession = localMel,
-            embeddingSession = localEmbedding,
-            classifierSession = localClassifier,
+            melSession = localSessions.mel,
+            embeddingSession = localSessions.embedding,
+            classifierSession = localSessions.classifier,
             matcher = matcher
         )
         try {
@@ -262,7 +327,9 @@ class WakeWordDetector(
         }
         lastError = message
         if (cause != null) Log.w(TAG, message, cause)
-        stop()
+        // Full release, not pause: a failure here can mean a session that never
+        // loaded or one that broke mid-run, so nothing cached is worth keeping.
+        release()
         scope.launch(Dispatchers.Main) { onError(message) }
     }
 
@@ -270,12 +337,6 @@ class WakeWordDetector(
         is SecurityException -> "Microphone permission is not available."
         is IOException -> "The bundled wake-word model could not be loaded."
         else -> "Wake word could not start."
-    }
-
-    private fun closeSessions(mel: OrtSession?, embedding: OrtSession?, classifier: OrtSession?) {
-        mel?.close()
-        embedding?.close()
-        classifier?.close()
     }
 
     companion object {

--- a/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
+++ b/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
@@ -424,12 +424,15 @@ class WakeWordDetector(
             if (rmsDb > peakRms) peakRms = rmsDb
             if (rmsDb < quietestRms) quietestRms = rmsDb
             if (reads % REPORT_EVERY_READS != 0) return
+            // Locale.ROOT, not the default: on a decimal-comma device these
+            // become "-70,5" and stop being greppable, which is the whole point
+            // of the line.
             Log.d(
                 TAG,
-                "heard: rms ${"%.1f".format(quietestRms)}..${"%.1f".format(peakRms)} dBFS, " +
-                    "frames=$frames scored=$scored gated=$gated peakScore=${"%.3f".format(peakScore)} " +
-                    "mel[${"%.2f".format(melMin)}..${"%.2f".format(melMax)} avg ${"%.2f".format(melMean)}] " +
-                    "emb[${"%.2f".format(embMin)}..${"%.2f".format(embMax)} avg ${"%.2f".format(embMean)}]"
+                "heard: rms ${fmt(quietestRms, 1)}..${fmt(peakRms, 1)} dBFS, " +
+                    "frames=$frames scored=$scored gated=$gated peakScore=${fmt(peakScore, 3)} " +
+                    "mel[${fmt(melMin, 2)}..${fmt(melMax, 2)} avg ${fmt(melMean, 2)}] " +
+                    "emb[${fmt(embMin, 2)}..${fmt(embMax, 2)} avg ${fmt(embMean, 2)}]"
             )
             melMin = Float.MAX_VALUE
             melMax = -Float.MAX_VALUE
@@ -455,6 +458,9 @@ class WakeWordDetector(
             scored++
             if (score > peakScore) peakScore = score
         }
+
+        private fun fmt(value: Float, decimals: Int): String =
+            String.format(java.util.Locale.ROOT, "%.${decimals}f", value)
 
         private companion object {
             /** ~3 s at 4 frames per read. */

--- a/app/src/main/java/com/gotcha/service/WakeWordGate.kt
+++ b/app/src/main/java/com/gotcha/service/WakeWordGate.kt
@@ -1,0 +1,149 @@
+package com.gotcha.service
+
+import kotlin.math.log10
+import kotlin.math.sqrt
+
+/**
+ * Cheap energy gate in front of the wake-word embedding stage (issue #37).
+ *
+ * The listener runs 12.5 frames a second forever, and a measured ~85% of each
+ * frame's cost is the embedding backbone. Almost every real-world frame is
+ * silence, so the fix is to only pay for that backbone when there is something
+ * to hear. This class answers exactly one question per 80 ms frame — "is there
+ * energy above the room's noise floor?" — for a few microseconds of RMS.
+ *
+ * It deliberately does **not** reuse [com.gotcha.audio.SilenceDetector]:
+ *
+ * - That is a conversational state machine (accept-streak, "user stopped
+ *   talking", "user never spoke") built for the STT turn. Its `Decision` values
+ *   have no meaning per frame.
+ * - Its `rmsDb` clamps its return at −50 dBFS, so a gate built on it has no
+ *   resolution below −50 and cannot be tuned for a quiet room. [rmsDb] here is
+ *   unclamped.
+ *
+ * Behaviour:
+ *
+ * - The noise floor is a low percentile over the last [FLOOR_WINDOW] frames, so
+ *   a loud room raises the bar instead of holding the gate permanently open.
+ *   Unlike `SilenceDetector` the floor keeps updating while the gate is open:
+ *   re-arming is exact (see [OnnxWakeWordPipeline]), so a gate that closes
+ *   mid-phrase costs a little CPU but never costs a detection, and that makes
+ *   "never let the floor go stale" the safer trade.
+ * - A **single** frame above the threshold opens the gate — no accept-streak.
+ *   A spurious open costs milliseconds; a missed onset costs a detection.
+ * - Once open it stays open for [hangoverFrames] after energy drops. This is
+ *   what keeps an intermittently noisy room from flapping the gate: each
+ *   re-arm replays the classifier window, and that replay only pays for itself
+ *   if the quiet gap was longer than ~1.3 s.
+ * - It starts open and stays open until the floor window is primed, so the
+ *   first seconds after start can never be gated against an unlearned floor.
+ */
+internal class WakeWordGate(
+    private val marginDb: Float = SPEECH_MARGIN_DB,
+    private val minThresholdDb: Float = MIN_THRESHOLD_DB,
+    private val hangoverFrames: Int = HANGOVER_FRAMES,
+    private val alwaysOpen: Boolean = false
+) {
+    private val recentRms = FloatArray(FLOOR_WINDOW)
+    private var recentCount = 0
+    private var recentStart = 0
+    private var framesSinceEnergy = 0
+
+    /** The level a frame must exceed to open the gate, in dBFS. */
+    val thresholdDb: Float
+        get() = maxOf(minThresholdDb, noiseFloorEstimate + marginDb)
+
+    /** True while the floor window is still filling; the gate is forced open. */
+    val priming: Boolean
+        get() = recentCount < FLOOR_WINDOW
+
+    /** Returns true when [frame] should be run through the embedding stage. */
+    fun onFrame(frame: ShortArray, count: Int): Boolean = onLevel(rmsDb(frame, count))
+
+    /** [onFrame] split out from the PCM, so tests can drive levels directly. */
+    fun onLevel(frameRmsDb: Float): Boolean {
+        if (alwaysOpen) return true
+        val open = priming || frameRmsDb > thresholdDb
+
+        recentRms[recentStart] = frameRmsDb
+        recentStart = (recentStart + 1) % FLOOR_WINDOW
+        if (recentCount < FLOOR_WINDOW) recentCount++
+
+        if (open) {
+            framesSinceEnergy = 0
+            return true
+        }
+        // Saturate rather than overflow: this counter runs for as long as the
+        // room is quiet, which on a 24/7 listener is a very long time.
+        if (framesSinceEnergy <= hangoverFrames) framesSinceEnergy++
+        return framesSinceEnergy <= hangoverFrames
+    }
+
+    fun reset() {
+        recentCount = 0
+        recentStart = 0
+        framesSinceEnergy = 0
+    }
+
+    private val noiseFloorEstimate: Float
+        get() {
+            if (recentCount < FLOOR_WINDOW) return INITIAL_NOISE_FLOOR_DB
+            val sorted = recentRms.copyOf(FLOOR_WINDOW).apply { sort() }
+            val index = (sorted.size * FLOOR_QUANTILE).toInt().coerceIn(0, sorted.lastIndex)
+            return sorted[index]
+        }
+
+    companion object {
+        /**
+         * A gate that never closes — i.e. the pre-#37 behaviour, where every
+         * frame paid for the embedding backbone. The parity tests run one
+         * pipeline behind this and one behind a real gate, and require the two
+         * to produce identical classifier scores.
+         */
+        fun alwaysOpen(): WakeWordGate = WakeWordGate(alwaysOpen = true)
+
+        /** How far above the noise floor a frame has to be to count as sound. */
+        private const val SPEECH_MARGIN_DB = 6f
+
+        /**
+         * Absolute lower bound on the threshold. Well below
+         * `SilenceDetector.ABSOLUTE_FLOOR_DB` (−50) on purpose: a quiet bedroom
+         * at night sits below −50 dBFS, and a gate that cannot be set quieter
+         * than the room never closes.
+         */
+        private const val MIN_THRESHOLD_DB = -60f
+
+        private const val INITIAL_NOISE_FLOOR_DB = -70f
+
+        /**
+         * ~3 s. Long enough that a pause inside a sentence does not re-arm the
+         * pipeline, which matters because each re-arm costs a replay of the
+         * 16-frame classifier window.
+         */
+        private const val HANGOVER_FRAMES = 38
+
+        /** ~4 s of frames. Long enough that continuous speech cannot lift the floor to its own level. */
+        private const val FLOOR_WINDOW = 50
+
+        private const val FLOOR_QUANTILE = 0.2f
+
+        /** Level reported for digital silence, where the log is undefined. */
+        const val SILENT_DB = -120f
+
+        /**
+         * RMS of [count] 16-bit PCM samples in dBFS. Unlike
+         * `SilenceDetector.rmsDb` this is **not** clamped at −50 dBFS.
+         */
+        fun rmsDb(samples: ShortArray, count: Int): Float {
+            if (count <= 0) return SILENT_DB
+            var sum = 0L
+            for (i in 0 until count) {
+                val sample = samples[i].toInt()
+                sum += sample.toLong() * sample
+            }
+            val rms = sqrt(sum.toDouble() / count)
+            if (rms <= 0.0) return SILENT_DB
+            return maxOf(20.0 * log10(rms / 32768.0), SILENT_DB.toDouble()).toFloat()
+        }
+    }
+}

--- a/app/src/main/java/com/gotcha/service/WakeWordGate.kt
+++ b/app/src/main/java/com/gotcha/service/WakeWordGate.kt
@@ -45,13 +45,26 @@ internal class WakeWordGate(
     private val alwaysOpen: Boolean = false
 ) {
     private val recentRms = FloatArray(FLOOR_WINDOW)
+
+    /** Reused scratch for the percentile sort, so the floor costs no allocation. */
+    private val floorScratch = FloatArray(FLOOR_WINDOW)
     private var recentCount = 0
     private var recentStart = 0
     private var framesSinceEnergy = 0
+    private var framesSinceFloorRefresh = 0
 
-    /** The level a frame must exceed to open the gate, in dBFS. */
-    val thresholdDb: Float
-        get() = maxOf(minThresholdDb, noiseFloorEstimate + marginDb)
+    /**
+     * The level a frame must exceed to open the gate, in dBFS.
+     *
+     * Cached rather than recomputed per frame. The floor is a percentile over
+     * four seconds of history — it moves slowly by construction, so refreshing
+     * it every [FLOOR_REFRESH_FRAMES] tracks it just as well while keeping the
+     * sort off a path that runs 12.5 times a second for as long as the phone is
+     * on. Recomputing it per frame made the gate the only remaining per-frame
+     * allocation in the listener.
+     */
+    var thresholdDb: Float = maxOf(minThresholdDb, INITIAL_NOISE_FLOOR_DB + marginDb)
+        private set
 
     /** True while the floor window is still filling; the gate is forced open. */
     val priming: Boolean
@@ -67,7 +80,17 @@ internal class WakeWordGate(
 
         recentRms[recentStart] = frameRmsDb
         recentStart = (recentStart + 1) % FLOOR_WINDOW
-        if (recentCount < FLOOR_WINDOW) recentCount++
+        val wasPriming = recentCount < FLOOR_WINDOW
+        if (wasPriming) recentCount++
+
+        // Refresh on the frame that completes priming — the first real floor is
+        // worth having immediately — and periodically after that.
+        framesSinceFloorRefresh++
+        if ((wasPriming && recentCount == FLOOR_WINDOW) ||
+            framesSinceFloorRefresh >= FLOOR_REFRESH_FRAMES
+        ) {
+            refreshThreshold()
+        }
 
         if (open) {
             framesSinceEnergy = 0
@@ -83,15 +106,24 @@ internal class WakeWordGate(
         recentCount = 0
         recentStart = 0
         framesSinceEnergy = 0
+        framesSinceFloorRefresh = 0
+        recentRms.fill(0f)
+        thresholdDb = maxOf(minThresholdDb, INITIAL_NOISE_FLOOR_DB + marginDb)
     }
 
-    private val noiseFloorEstimate: Float
-        get() {
-            if (recentCount < FLOOR_WINDOW) return INITIAL_NOISE_FLOOR_DB
-            val sorted = recentRms.copyOf(FLOOR_WINDOW).apply { sort() }
-            val index = (sorted.size * FLOOR_QUANTILE).toInt().coerceIn(0, sorted.lastIndex)
-            return sorted[index]
-        }
+    private fun refreshThreshold() {
+        framesSinceFloorRefresh = 0
+        thresholdDb = maxOf(minThresholdDb, noiseFloorEstimate() + marginDb)
+    }
+
+    private fun noiseFloorEstimate(): Float {
+        if (recentCount < FLOOR_WINDOW) return INITIAL_NOISE_FLOOR_DB
+        recentRms.copyInto(floorScratch)
+        floorScratch.sort()
+        val index = (floorScratch.size * FLOOR_QUANTILE).toInt()
+            .coerceIn(0, floorScratch.lastIndex)
+        return floorScratch[index]
+    }
 
     companion object {
         /**
@@ -126,6 +158,9 @@ internal class WakeWordGate(
         private const val FLOOR_WINDOW = 50
 
         private const val FLOOR_QUANTILE = 0.2f
+
+        /** ~1 s. The floor spans 4 s of history, so this loses nothing. */
+        private const val FLOOR_REFRESH_FRAMES = 12
 
         /** Level reported for digital silence, where the log is undefined. */
         const val SILENT_DB = -120f

--- a/app/src/main/java/com/gotcha/ui/AssistiveBallScreen.kt
+++ b/app/src/main/java/com/gotcha/ui/AssistiveBallScreen.kt
@@ -10,21 +10,29 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.gotcha.data.Settings
+import com.gotcha.data.WakeWordListeningMode
 import android.provider.Settings as AndroidSettings
 
 /**
@@ -48,8 +56,22 @@ fun AssistiveBallScreen(
 ) {
     val overlay = rememberSettingsOverlayState()
     val initial = remember { load() }
+    val ballEnabled = enabled
     var wakeWordEnabled by remember { mutableStateOf(initial.wakeWordEnabled) }
     var wakeWordSensitivity by remember { mutableStateOf(initial.wakeWordSensitivity) }
+    var wakeWordListeningMode by remember { mutableStateOf(initial.wakeWordListeningMode) }
+
+    // The wake word runs inside the ball service, so it cannot be on while the
+    // ball is off. When the ball is switched off here (or this screen is opened
+    // with the ball already off and a leftover ON), reset the wake word to off
+    // in both the local state and the saved setting — not merely disable the
+    // toggle, which would leave it visually on but inert.
+    LaunchedEffect(ballEnabled) {
+        if (!ballEnabled && wakeWordEnabled) {
+            wakeWordEnabled = false
+            onSave { settings -> settings.copy(wakeWordEnabled = false) }
+        }
+    }
 
     SettingsScaffold(title = SettingsPage.ASSISTIVE_BALL.title, onBack = onBack, overlay = overlay) {
         SettingsToggleRow(
@@ -74,6 +96,11 @@ fun AssistiveBallScreen(
         SettingsToggleRow(
             label = "Wake word: Hey Gotcha",
             checked = wakeWordEnabled,
+            // The listener runs inside the Assistive Ball service, so the wake
+            // word cannot be turned on while the ball is off. Turning the ball
+            // off also switches the wake word off (see LaunchedEffect above),
+            // so this toggle is simply locked to the ball state.
+            enabled = ballEnabled,
             onCheckedChange = {
                 wakeWordEnabled = it
                 onSave { settings -> settings.copy(wakeWordEnabled = it) }
@@ -85,6 +112,14 @@ fun AssistiveBallScreen(
                 "Turn on Hey Gotcha wake word"
             }
         )
+        if (!ballEnabled) {
+            Text(
+                "The wake word requires the Assistive Ball to be on — turn on " +
+                    "\"Show Assistive Ball\" to use it.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
         Text(
             "Says \"Hey Gotcha\" — the bundled OpenWakeWord model runs on-device while " +
                 "the assistive ball is on and no call is active. Keep microphone " +
@@ -93,6 +128,35 @@ fun AssistiveBallScreen(
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
         if (wakeWordEnabled) {
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                "When to listen",
+                style = MaterialTheme.typography.bodyMedium
+            )
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .selectableGroup()
+                    .testTag("settings_wake_word_mode")
+            ) {
+                WakeWordListeningMode.entries.forEach { mode ->
+                    WakeWordModeRow(
+                        mode = mode,
+                        selected = wakeWordListeningMode == mode,
+                        onSelect = {
+                            wakeWordListeningMode = mode
+                            onSave { settings -> settings.copy(wakeWordListeningMode = mode) }
+                        }
+                    )
+                }
+            }
+            Text(
+                "The listener is only active while the screen matches the chosen " +
+                    "state, so the microphone and its indicator are off the rest of " +
+                    "the time.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
             Spacer(modifier = Modifier.height(8.dp))
             Row(
                 modifier = Modifier.fillMaxWidth()
@@ -152,6 +216,52 @@ private fun sensitivityLabel(sensitivity: Float): String = when {
     sensitivity < 0.185f -> "High precision"
     sensitivity < 0.741f -> "Balanced"
     else -> "High sensitivity"
+}
+
+/** One selectable row of the "When to listen" wake-word mode group. */
+@Composable
+private fun WakeWordModeRow(
+    mode: WakeWordListeningMode,
+    selected: Boolean,
+    onSelect: () -> Unit
+) {
+    val label: String
+    val summary: String
+    when (mode) {
+        WakeWordListeningMode.ALWAYS -> {
+            label = "Always"
+            summary = "Listen with the screen on or off. Full hands-free, highest battery use."
+        }
+        WakeWordListeningMode.SCREEN_ON -> {
+            label = "Only while the screen is on"
+            summary = "Saves battery — the microphone and its indicator are off while the screen is off."
+        }
+        WakeWordListeningMode.SCREEN_OFF -> {
+            label = "Only while the screen is off"
+            summary = "Hands-free when you are not already looking at the phone; the screen being on means the mic is off."
+        }
+    }
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .selectable(
+                selected = selected,
+                role = Role.RadioButton,
+                onClick = onSelect
+            )
+            .testTag("settings_wake_word_mode_${mode.name.lowercase()}")
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            RadioButton(selected = selected, onClick = null)
+            Text(label, style = MaterialTheme.typography.bodyMedium)
+        }
+        Text(
+            summary,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(start = 40.dp, bottom = 4.dp)
+        )
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/gotcha/ui/SettingsCommon.kt
+++ b/app/src/main/java/com/gotcha/ui/SettingsCommon.kt
@@ -387,6 +387,10 @@ fun SamosaAuthSection(
  * toggleable and no-op silently. [switchContentDescription] names the `Switch`
  * for the same reason — it is what a UiAutomator/Maestro flow, which cannot see
  * test tags, has to aim at.
+ *
+ * [enabled] disables the `Switch` (greyed out, no tap effect) for a row whose
+ * action depends on a prerequisite the user has not met yet; the caller should
+ * also explain the prerequisite nearby.
  */
 @Composable
 fun SettingsToggleRow(
@@ -394,6 +398,7 @@ fun SettingsToggleRow(
     checked: Boolean,
     onCheckedChange: (Boolean) -> Unit,
     isLarge: Boolean = false,
+    enabled: Boolean = true,
     switchTestTag: String? = null,
     switchContentDescription: String? = null,
     modifier: Modifier = Modifier
@@ -405,11 +410,17 @@ fun SettingsToggleRow(
     ) {
         Text(
             label,
-            style = if (isLarge) MaterialTheme.typography.bodyLarge else MaterialTheme.typography.bodyMedium
+            style = if (isLarge) MaterialTheme.typography.bodyLarge else MaterialTheme.typography.bodyMedium,
+            color = if (enabled) {
+                MaterialTheme.colorScheme.onSurface
+            } else {
+                MaterialTheme.colorScheme.onSurfaceVariant
+            }
         )
         Switch(
             checked = checked,
             onCheckedChange = onCheckedChange,
+            enabled = enabled,
             modifier = Modifier
                 .then(if (switchTestTag != null) Modifier.testTag(switchTestTag) else Modifier)
                 .then(

--- a/app/src/test/java/com/gotcha/data/SettingsTest.kt
+++ b/app/src/test/java/com/gotcha/data/SettingsTest.kt
@@ -2,6 +2,8 @@ package com.gotcha.data
 
 import com.gotcha.audio.AudioProvider
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class SettingsTest {
@@ -324,5 +326,36 @@ class SettingsTest {
         assertEquals(0.35f, enabled.wakeWordSensitivity, 0.001f)
         // Untouched fields stay at their defaults.
         assertEquals(false, enabled.assistiveBallEnabled)
+    }
+
+    @Test
+    fun `wake word listening mode defaults to always`() {
+        val defaults = Settings()
+        assertEquals(WakeWordListeningMode.ALWAYS, defaults.wakeWordListeningMode)
+    }
+
+    @Test
+    fun `wake word listening mode is an independent field on copy`() {
+        val defaults = Settings()
+        val screenOn = defaults.copy(wakeWordListeningMode = WakeWordListeningMode.SCREEN_ON)
+        assertEquals(WakeWordListeningMode.SCREEN_ON, screenOn.wakeWordListeningMode)
+        // Untouched fields stay at their defaults.
+        assertEquals(false, screenOn.wakeWordEnabled)
+        assertEquals(0.75f, screenOn.wakeWordSensitivity, 0.001f)
+    }
+
+    @Test
+    fun `wake word listening mode gates on screen interactivity`() {
+        val always = WakeWordListeningMode.ALWAYS
+        assertTrue(always.allows(screenInteractive = true))
+        assertTrue(always.allows(screenInteractive = false))
+
+        val screenOn = WakeWordListeningMode.SCREEN_ON
+        assertTrue(screenOn.allows(screenInteractive = true))
+        assertFalse(screenOn.allows(screenInteractive = false))
+
+        val screenOff = WakeWordListeningMode.SCREEN_OFF
+        assertFalse(screenOff.allows(screenInteractive = true))
+        assertTrue(screenOff.allows(screenInteractive = false))
     }
 }

--- a/app/src/test/java/com/gotcha/service/WakeWordGateTest.kt
+++ b/app/src/test/java/com/gotcha/service/WakeWordGateTest.kt
@@ -1,0 +1,156 @@
+package com.gotcha.service
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The gate is the one piece of the battery work that can be tested off-device:
+ * it is pure arithmetic over frame levels, with no ONNX and no Android.
+ */
+class WakeWordGateTest {
+
+    /** Enough frames to prime the floor window; the gate is forced open until then. */
+    private fun WakeWordGate.prime(levelDb: Float = QUIET_ROOM_DB) {
+        repeat(PRIMING_FRAMES) { onLevel(levelDb) }
+    }
+
+    @Test
+    fun beforeTheFloorIsLearned_theGateStaysOpen() {
+        val gate = WakeWordGate()
+        // Digital silence, the most gate-able input there is — but with no
+        // learned floor, closing would be a guess, and a wrong guess drops the
+        // first seconds of listening.
+        repeat(PRIMING_FRAMES) { assertTrue(gate.onLevel(WakeWordGate.SILENT_DB)) }
+        assertFalse(gate.priming)
+    }
+
+    @Test
+    fun quietRoom_closesTheGateOnceTheHangoverExpires() {
+        val gate = WakeWordGate()
+        gate.prime()
+
+        // The hangover has to run out first — it is armed by the priming phase.
+        repeat(HANGOVER_FRAMES) { assertTrue(gate.onLevel(QUIET_ROOM_DB)) }
+        assertFalse(gate.onLevel(QUIET_ROOM_DB))
+        assertFalse(gate.onLevel(QUIET_ROOM_DB))
+    }
+
+    @Test
+    fun quietRoomFloor_sitsWellBelowSilenceDetectorsClamp() {
+        val gate = WakeWordGate()
+        gate.prime(levelDb = -72f)
+
+        // SilenceDetector.rmsDb bottoms out at -50 dBFS, so a gate built on it
+        // could never close in a room this quiet. This one can.
+        assertTrue(
+            "threshold ${gate.thresholdDb} should be below -50 dBFS in a quiet room",
+            gate.thresholdDb < -50f
+        )
+        repeat(HANGOVER_FRAMES + 1) { gate.onLevel(-72f) }
+        assertFalse(gate.onLevel(-72f))
+        assertTrue(gate.onLevel(-40f))
+    }
+
+    @Test
+    fun aSingleLoudFrame_opensTheGateImmediately() {
+        val gate = WakeWordGate()
+        gate.prime()
+        repeat(HANGOVER_FRAMES + 1) { gate.onLevel(QUIET_ROOM_DB) }
+        assertFalse(gate.onLevel(QUIET_ROOM_DB))
+
+        // No accept-streak, deliberately: a spurious open costs milliseconds of
+        // CPU, a missed onset costs the user their wake word.
+        assertTrue(gate.onLevel(SPEECH_DB))
+    }
+
+    @Test
+    fun afterSpeechStops_theGateHoldsOpenForTheHangover() {
+        val gate = WakeWordGate()
+        gate.prime()
+        assertTrue(gate.onLevel(SPEECH_DB))
+
+        // A pause inside a sentence must not re-arm the pipeline: each re-arm
+        // replays the classifier window.
+        repeat(HANGOVER_FRAMES) { index ->
+            assertTrue("closed $index frames into the hangover", gate.onLevel(QUIET_ROOM_DB))
+        }
+        assertFalse(gate.onLevel(QUIET_ROOM_DB))
+    }
+
+    @Test
+    fun aLoudRoom_raisesTheThresholdWithIt() {
+        val quiet = WakeWordGate().apply { prime(levelDb = -70f) }
+        val loud = WakeWordGate().apply { prime(levelDb = -30f) }
+
+        assertTrue(
+            "a loud room should demand a louder frame (${quiet.thresholdDb} vs ${loud.thresholdDb})",
+            loud.thresholdDb > quiet.thresholdDb
+        )
+        // Ambient chatter at the room's own level is not an onset.
+        repeat(HANGOVER_FRAMES + 1) { loud.onLevel(-30f) }
+        assertFalse(loud.onLevel(-30f))
+    }
+
+    @Test
+    fun sustainedSpeech_cannotDragTheFloorUpToItsOwnLevel() {
+        val gate = WakeWordGate()
+        gate.prime(levelDb = -70f)
+
+        // Ten seconds of talking. Real speech is not a flat level — syllables,
+        // word gaps and breaths put a good fraction of frames far below the
+        // peaks, and the floor is a low percentile precisely so it tracks those
+        // dips rather than the speech itself.
+        val syllable = listOf(SPEECH_DB, -30f, -58f, SPEECH_DB, -34f, -62f, -40f, SPEECH_DB)
+        repeat(125) { index -> gate.onLevel(syllable[index % syllable.size]) }
+
+        assertTrue(
+            "threshold ${gate.thresholdDb} climbed to speech level",
+            gate.thresholdDb < SPEECH_DB
+        )
+        assertTrue(gate.onLevel(SPEECH_DB))
+    }
+
+    @Test
+    fun anUnbrokenConstantTone_becomesTheFloorAndIsGatedOut() {
+        val gate = WakeWordGate()
+        gate.prime(levelDb = -70f)
+
+        // A fan, a hum, a held note: once it has filled the whole floor window
+        // it *is* the room's ambient level, and gating it out is the point.
+        // Safe to do because re-arming replays the classifier window from
+        // retained mel rows, so even if this were speech, closing the gate
+        // costs CPU on the next onset and never costs a detection.
+        repeat(PRIMING_FRAMES + HANGOVER_FRAMES + 1) { gate.onLevel(-25f) }
+        assertFalse(gate.onLevel(-25f))
+
+        // Anything that rises above the new ambient still gets through.
+        assertTrue(gate.onLevel(-15f))
+    }
+
+    @Test
+    fun rmsDb_isUnclampedAndTracksLevel() {
+        val fullScale = ShortArray(160) { Short.MAX_VALUE }
+        assertEquals(0f, WakeWordGate.rmsDb(fullScale, fullScale.size), 0.1f)
+
+        assertEquals(WakeWordGate.SILENT_DB, WakeWordGate.rmsDb(ShortArray(160), 160), 0.001f)
+        assertEquals(WakeWordGate.SILENT_DB, WakeWordGate.rmsDb(fullScale, 0), 0.001f)
+
+        // The point of not reusing SilenceDetector.rmsDb: this keeps resolving
+        // below -50 dBFS instead of flattening out there.
+        val veryQuiet = ShortArray(160) { 20 }
+        val quieter = ShortArray(160) { 5 }
+        assertTrue(WakeWordGate.rmsDb(veryQuiet, 160) < -50f)
+        assertTrue(WakeWordGate.rmsDb(quieter, 160) < WakeWordGate.rmsDb(veryQuiet, 160))
+    }
+
+    private companion object {
+        /** Mirrors WakeWordGate.FLOOR_WINDOW / HANGOVER_FRAMES (both private). */
+        const val PRIMING_FRAMES = 50
+        const val HANGOVER_FRAMES = 38
+
+        const val QUIET_ROOM_DB = -70f
+        const val SPEECH_DB = -25f
+    }
+}

--- a/app/src/test/java/com/gotcha/service/WakeWordGateTest.kt
+++ b/app/src/test/java/com/gotcha/service/WakeWordGateTest.kt
@@ -130,6 +130,30 @@ class WakeWordGateTest {
     }
 
     @Test
+    fun theThresholdKeepsTrackingTheRoomAfterPriming() {
+        val gate = WakeWordGate()
+        gate.prime(levelDb = -70f)
+        val quietThreshold = gate.thresholdDb
+
+        // The floor is cached and refreshed periodically rather than recomputed
+        // per frame. A cache that never refreshed would leave the gate judging
+        // a loud room against a silent one's threshold forever, so pin that it
+        // still moves — one refresh window is well inside 60 frames.
+        repeat(60) { gate.onLevel(-30f) }
+        assertTrue(
+            "threshold froze at $quietThreshold after the room got louder (now ${gate.thresholdDb})",
+            gate.thresholdDb > quietThreshold
+        )
+
+        // And back down again when the room goes quiet.
+        repeat(60) { gate.onLevel(-70f) }
+        assertTrue(
+            "threshold stayed high (${gate.thresholdDb}) after the room went quiet",
+            gate.thresholdDb < -50f
+        )
+    }
+
+    @Test
     fun rmsDb_isUnclampedAndTracksLevel() {
         val fullScale = ShortArray(160) { Short.MAX_VALUE }
         assertEquals(0f, WakeWordGate.rmsDb(fullScale, fullScale.size), 0.1f)

--- a/docs/wake-word.md
+++ b/docs/wake-word.md
@@ -31,6 +31,9 @@ Per 80 ms (1280-sample) frame @ 16 kHz mono PCM-16, the
 3. **Classification** — the last 16 embeddings → `hey_gotcha.onnx` → a score
    in [0, 1].
 
+Step 1 runs on every frame. Steps 2 and 3 run only when `WakeWordGate` hears
+something — see [Battery](#battery-and-reliability) below.
+
 A `WakeWordMatcher` then maps the user-facing sensitivity slider to the
 score threshold (`threshold = 0.70 − 0.27 × sensitivity`) and requires two
 consecutive qualifying frames before firing. The default sensitivity of 0.75
@@ -81,6 +84,40 @@ have enough bright pixels/variance to still be sent.
 OEM battery managers may kill the always-on listener. The Assistive Ball
 settings page offers a one-tap link to Android's battery-optimization
 exemption request when the wake word is on.
+
+### What the listener does to stay cheap
+
+Measured on a physical device, one 80 ms frame through the full chain costs
+~4.4 ms, of which the embedding backbone is ~85% and the mel front-end ~8%.
+Five things follow from that (issue #37):
+
+- **The embedding stage is gated on energy.** `WakeWordGate` tracks the room's
+  noise floor from the frame RMS and lets the expensive stages run only when
+  something rises above it, with a ~3 s hangover so a pause mid-sentence does
+  not re-arm the pipeline. In a quiet room the listener is doing a mel run and
+  an RMS, nothing more.
+- **Gating cannot cost a detection.** The mel front-end keeps running while the
+  gate is shut, so the embeddings that were skipped are rebuilt from the mel
+  rows that produced them. The classifier sees exactly the window it would have
+  seen ungated — asserted, not assumed, by `OnnxWakeWordPipelineGateTest`.
+- **The ONNX sessions are single-threaded and do not spin** between runs. ORT's
+  defaults size a thread pool per session to the core count and busy-wait,
+  which suits a busy server and not a 12.5 Hz duty cycle.
+- **The sessions stay loaded across pauses.** The listener is paused on every
+  call transition and every TTS utterance; reloading ~2.6 MB of models each
+  time the app spoke a sentence was pure waste. `pause()` keeps the models and
+  still releases the microphone in full — see §10.3 of the privacy doc.
+- **The microphone is read in 320 ms batches** into a ~1.3 s buffer, waking the
+  CPU 3.1×/s instead of 12.5×/s, at the cost of up to 320 ms of extra trigger
+  latency.
+
+Two things are deliberately still open: the idle-hour `batterystats` figure
+that would quantify all of the above, and `SoundTrigger`/DSP hotword offload,
+which is the only way for the application processor to sleep at all while
+listening.
+
+`WakeWordPipelineBenchmarkTest` regenerates the per-stage numbers on a
+connected device; see its KDoc for the command.
 
 ## Play Store disclosure
 


### PR DESCRIPTION
Closes #37.

The always-on listener ran all three ONNX models on every 80 ms frame, forever, whether or not there was anything to hear — plus it rebuilt those models every time the app spoke a sentence. This gates the expensive stage behind an energy check, keeps the models loaded across pauses, and tunes the ONNX Runtime threading for a 12.5 Hz duty cycle.

## Measured results

Real data from a physical device (A059, Android 16). The frame counts come from 28,952 frames of live logcat — ~38.6 minutes of audio, not a simulation.

| Metric | Before | After | Source |
| :--- | :--- | :--- | :--- |
| Inference CPU per gated frame | 4.42 ms | 0.37 ms | per-stage benchmark |
| Frames gated, live session | 0% | **34.1%** | 28,952 frames of logcat |
| Frames gated, quiet windows | 0% | **100%** (200 of 729 windows) | same |
| CPU wakeups | 12.5/s | 3.1/s | by construction |
| Arrays allocated per frame | 2,432 | 0 | code |
| Model reloads per TTS utterance | 3 sessions, ~2.6 MB | 0 | `sessionLoadCount` test |

Inference CPU in a quiet room drops **~91.6%** (0.37 ms replaces 4.42 ms per frame). The 34.1% figure is a deliberate worst case — that session was active debugging with someone talking beside the phone. The 200 fully-gated windows are what an idle hour looks like.

**This is not a battery number, and this PR does not claim one.** Two gaps, stated plainly:

1. CPU time is not energy — core choice and clock frequency matter, and wall-time benchmarking cannot see them.
2. More importantly, `AudioRecord` holds the application processor awake regardless. If holding the mic costs 30 mW and inference cost 3 mW, then cutting inference by 91% saves ~9% of the feature's drain, not 91%. **That ratio is unmeasured**, and it decides whether this is a large win or a modest one.

So: most of the CPU work the listener did is gone. How much of the wake word's battery cost that CPU *was* still needs the `batterystats` A/B in the acceptance criteria of #37. Left undone deliberately rather than guessed at.

## The design changed after measuring — on purpose

Step 0 of the plan was a benchmark, and it overturned the approach proposed in the issue. The issue suggested gating the whole chain behind a VAD, with a raw-PCM pre-roll to survive the 800 ms a cold mel buffer needs to refill. Measurement showed the mel front-end is only ~8% of a frame's cost (0.37 ms of 4.42 ms) — the embedding backbone is nearly all of it.

So the mel front-end runs unconditionally and **only the embedding stage is gated**. This is better on every axis:

- **No pre-roll, and no replaying of audio.** `melBuffer` keeps filling while the gate is shut, so the skipped embeddings are rebuilt from the very mel rows that produced them.
- **Re-arming is exact.** The classifier sees bit-for-bit the window it would have seen ungated, so gating *cannot* cost a detection — including when the gate closes mid-phrase.
- **Cheaper worst case.** Re-arm replays at most 15 embeddings (~65 ms) instead of ~32 full-chain frames (~140 ms), so the break-even quiet gap is ~1.3 s rather than ~2.6 s. This matters: in a choppy room a gate that flaps can cost more than no gate at all, which is what the 3 s hangover prevents.

Also confirmed empirically: **8 mel rows per frame**, so a cold buffer needs 10 frames / 800 ms. That was previously inferred from upstream openWakeWord convention, and the pre-roll sizing depended on it.

`WakeWordGate` deliberately does **not** reuse `SilenceDetector`: that is a conversational state machine whose `Decision` values are meaningless per frame, and its `rmsDb` clamps at −50 dBFS — a floor louder than a quiet bedroom, so a gate built on it could never close where it matters most.

## How "no detection regression" is verified

That criterion was previously only checkable by saying "Hey Gotcha" at a phone. It is now a test:

- **`OnnxWakeWordPipelineGateTest`** runs a gated and an ungated pipeline over the same clip and asserts **identical** scores. On device: 275 frames, 66 gated out, two re-arms, every score equal at delta 0.
- **`WakeWordDetectionDiagnosticTest`** drives the pipeline with the device's own TTS speaking the wake phrase — peak **0.96** against a 0.497 threshold, gated and ungated identical. It fails loudly if the peak is too low to conclude anything, rather than passing vacuously.
- **`WakeWordDetectorLifecycleTest`** asserts three pause/resume rounds keep `sessionLoadCount` at 1, that `release()` forces it to 2, and that a second `AudioRecord` can open and read after `pause()`.
- **`WakeWordGateTest`** — 9 JVM tests covering the gate as pure arithmetic.

Batched feeds also get coverage: production drains 4 frames per read, and every earlier test fed one frame per call, so the scratch-buffer growth in `feed()` was untested. Now asserted indistinguishable from single-frame feeds.

## Also in here

**A real bug fix** (`16a83b5`), found while investigating a report and unrelated to the battery work: with no LLM provider configured, one "Hey Gotcha" left the listener **permanently dead** until the ball was restarted. `onWakeWordDetected()` pauses the listener and then discards the return value of `startWakeWordCall()`; when `startCall()` refuses it reports through `onError()` and leaves `_state` in `IDLE`, and everything that re-arms the listener hangs off a transition *to* `IDLE` — a `StateFlow` that does not change does not emit. So the user fixes exactly what the error told them to fix, says the wake word again, and nothing happens. This predates the battery work; `stop()` had the same hole.

**Debug-only telemetry** (`da8c552`, `5a2d7d5`): levels, scored/gated counts, peak score, mel and embedding statistics, and lifecycle transitions with caller stack traces. Statistics only — no audio is captured, and nothing logged could reconstruct speech. `BuildConfig.DEBUG` generates as a compile-time `false`, so this is folded out of release builds entirely; that matters here because the release build sets `isMinifyEnabled = false`, so the elimination comes from the compiler rather than R8.

The telemetry earned its place immediately: during a "Hey Gotcha stopped responding" investigation it exonerated this battery work, showing the listener restarted correctly, read normal levels, and scored every frame (`gated=0`) in the failing state.

## Privacy

`pause()` still releases the microphone in full — it keeps only the loaded models, which hold no audio. Pausing while TTS speaks is a privacy guarantee rather than an optimisation (privacy-data-retention.md §10.3), and "the mic stayed open but we ignored it" is not that guarantee.

## Not included, deliberately

- **The `batterystats` baseline** (step 0c of #37) — needs roughly two hours of a phone sitting idle.
- **SoundTrigger / DSP hotword offload** — the only way for the AP to sleep at all while listening. Deserves its own spike.
- **XNNPACK** — left as a measured experiment. Worth recording that it is *not* the Android AAR's default CPU EP: the shipped 1.26.0 exposes `addXnnpack` as explicit opt-in and defaults to MLAS.
- **`setOptimizationLevel(ORT_ENABLE_ALL)`** — already ORT's default, so it would be a no-op.

## Testing

- 9 new JVM tests and 4 new instrumented test classes, all passing on a physical device.
- Full JVM suite: `AgentLoopTest` and `SkillImporterTest` fail — confirmed pre-existing by stashing these changes and re-running on a clean tree.
- Connected UI tests fail with "No compose hierarchies found" when the device screen is locked; this also reproduces on a clean tree.

## Reviewer notes

- The ORT threading change (`1892983`) cannot be proven a battery win by this harness — wall time is not core time, and run-to-run variance is large (the defaults measured 4.14 ms per frame in one run and 6.69 ms in another). It is included because the work it removes is real and the risk is nil; confirmation belongs to the `batterystats` run.
- The thread-priority change (`e8ed44d`) is justified by scheduling determinism for an audio capture loop, **not** by the CPU-frequency-boost theory in the issue, which this harness cannot test.
- One pre-existing leak fixed in passing: if the second or third model failed to load, the ones already loaded were dropped without being closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ucujogVfNVVdasB74bxoE
