### PR TITLE
perf(wakeword) & feat(ux): Wake-word battery/latency optimizations, screen-aware listening, and UX refinements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,4 @@ MARKETING_PLAYBOOK.md
 docs/benchmark
 docs/WAKE_WORD_PLAN.md
 .freebuff
+scripts/wake_battery_idle.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to Gotcha are documented here.
 
 ## [Unreleased]
 
+### Changed — Release builds ship none of the debug logging (#38)
+
+- **Debug log calls are compile-time no-ops in release.** A new `GotchaLog`
+  facade gates every `Log.d`/`Log.v` call behind `BuildConfig.DEBUG`, and all
+  83 call sites route through it. Clipboard text and the copied URL, the first
+  100 chars of a sub-agent's response, and the audio-provider endpoint/reply
+  previews no longer reach logcat in release — and their message strings are
+  never built there.
+- **OkHttp request/response tracing is off in release.** The
+  `HttpLoggingInterceptor` in `LLMClient`, `AudioApi`, `SamosaAuthApi` and
+  `NotificationApi` is gated on `BuildConfig.DEBUG`, so no full prompts, LLM
+  replies or request URLs are written to logcat (`LLMClient` ran at
+  `Level.BODY` before).
+- **A `NoRawDebugLog` detekt rule** fails the build on any new raw
+  `Log.d`/`Log.v` call outside `GotchaLog` itself, so the migration cannot
+  silently regress.
+
 ### Added — Document attachments in chat (#24)
 
 - **Attach more than images.** The composer's "+" now opens a picker that accepts

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -392,6 +392,7 @@ dependencies {
 
     // Static analysis
     detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.6")
+    detektPlugins(project(":detekt-rules"))
 
     // Debug
     debugImplementation("androidx.compose.ui:ui-tooling")

--- a/app/src/androidTest/java/com/gotcha/service/OnnxWakeWordPipelineGateTest.kt
+++ b/app/src/androidTest/java/com/gotcha/service/OnnxWakeWordPipelineGateTest.kt
@@ -1,0 +1,200 @@
+package com.gotcha.service
+
+import ai.onnxruntime.OrtEnvironment
+import ai.onnxruntime.OrtSession
+import android.content.Context
+import android.util.Log
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.math.PI
+import kotlin.math.sin
+import kotlin.random.Random
+
+/**
+ * The regression guard for the energy gate added in issue #37.
+ *
+ * The acceptance criterion for that work is "no drop in detection rate", which
+ * is normally only checkable by saying "Hey Gotcha" at a phone and trusting the
+ * result. The gate is built so it can be checked properly instead: because the
+ * mel front-end keeps running while the gate is shut, every embedding the gate
+ * skipped can be rebuilt from the mel rows that are still in the buffer. So a
+ * gated pipeline and an ungated one must emit **identical** classifier scores
+ * for every frame the gate let through — not similar, identical.
+ *
+ * If that holds, gating provably cannot change what the matcher sees, and so
+ * cannot change the detection rate. If someone later breaks the replay path,
+ * these tests fail rather than the wake word quietly getting worse in rooms
+ * that happen to be quiet.
+ *
+ * ```
+ * ./gradlew :app:connectedDebugAndroidTest \
+ *     -Pandroid.testInstrumentationRunnerArguments.class=com.gotcha.service.OnnxWakeWordPipelineGateTest
+ * ```
+ */
+@RunWith(AndroidJUnit4::class)
+class OnnxWakeWordPipelineGateTest {
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun gatedAndUngatedPipelines_produceIdenticalScores() {
+        val clip = buildClip()
+        val gated = run(clip, WakeWordGate())
+        val ungated = run(clip, WakeWordGate.alwaysOpen())
+
+        Log.i(
+            TAG,
+            "frames=${clip.size} scored: gated=${gated.scores.size} " +
+                "ungated=${ungated.scores.size} gatedOut=${gated.gatedFrames}"
+        )
+
+        assertTrue(
+            "the gate never closed, so this proved nothing — check the clip's silence level",
+            gated.gatedFrames > 0
+        )
+        assertTrue("the gate never opened", gated.scores.isNotEmpty())
+        assertEquals(
+            "the ungated baseline should score every frame it can",
+            ungated.scores.size,
+            gated.scores.size + gated.gatedFrames
+        )
+
+        for ((frame, score) in gated.scores) {
+            val baseline = ungated.scores[frame]
+                ?: error("ungated run produced no score for frame $frame")
+            assertEquals(
+                "frame $frame diverged after the gate re-armed",
+                baseline,
+                score,
+                0f
+            )
+        }
+    }
+
+    /**
+     * The case the replay exists for: the gate shuts during a long silence and
+     * has to re-arm on the first frame of the phrase. Every score from the
+     * re-arm onwards has to match the ungated baseline, because those are the
+     * frames a detection would actually come from.
+     */
+    @Test
+    fun scoresImmediatelyAfterReArming_matchTheUngatedBaseline() {
+        val clip = buildClip()
+        val gated = run(clip, WakeWordGate())
+        val ungated = run(clip, WakeWordGate.alwaysOpen())
+
+        // The first scored frame after a gap in the scored-frame sequence is a
+        // re-arm. Those are the frames the replay path is responsible for.
+        val scoredFrames = gated.scores.keys.sorted()
+        val reArms = scoredFrames.filterIndexed { index, frame ->
+            index > 0 && frame != scoredFrames[index - 1] + 1
+        }
+        Log.i(TAG, "re-arm frames: $reArms")
+        assertTrue("no re-arm happened in this clip", reArms.isNotEmpty())
+
+        for (frame in reArms) {
+            // The re-arm frame plus the rest of the classifier window after it.
+            for (offset in 0 until OnnxWakeWordPipeline.CLASSIFIER_FRAMES) {
+                val score = gated.scores[frame + offset] ?: continue
+                assertEquals(
+                    "frame ${frame + offset} (re-arm at $frame + $offset) diverged",
+                    ungated.scores.getValue(frame + offset),
+                    score,
+                    0f
+                )
+            }
+        }
+    }
+
+    private fun run(clip: List<ShortArray>, gate: WakeWordGate): Recorder {
+        val env = OrtEnvironment.getEnvironment()
+        val recorder = Recorder()
+        val mel = loadSession(env, "melspectrogram.onnx")
+        val embedding = loadSession(env, "embedding_model.onnx")
+        val classifier = loadSession(env, WakeWordDetector.CLASSIFIER_MODEL)
+        try {
+            val pipeline = OnnxWakeWordPipeline(
+                env = env,
+                melSession = mel,
+                embeddingSession = embedding,
+                classifierSession = classifier,
+                matcher = WakeWordMatcher(WakeWordMatcher.DEFAULT_SENSITIVITY),
+                gate = gate,
+                probe = recorder
+            )
+            clip.forEach { frame -> pipeline.feed(frame, frame.size) }
+        } finally {
+            classifier.close()
+            embedding.close()
+            mel.close()
+        }
+        return recorder
+    }
+
+    private fun loadSession(env: OrtEnvironment, name: String): OrtSession {
+        val bytes = context.assets
+            .open("${WakeWordDetector.MODEL_ASSET_DIR}/$name")
+            .use { it.readBytes() }
+        return OrtSession.SessionOptions().use { env.createSession(bytes, it) }
+    }
+
+    /**
+     * Room tone, then two bursts of sound separated by silences long enough to
+     * outlast the gate's hangover. Parity is a property of the plumbing, not of
+     * the audio, so this does not need to be a real "Hey Gotcha" recording — it
+     * needs to make the gate open, close, and re-arm, which it does.
+     */
+    private fun buildClip(): List<ShortArray> = buildList {
+        // The first stretch has to outlast both the 50-frame floor priming and
+        // the 38-frame hangover before the gate can close at all.
+        addAll(frames(count = 100, amplitude = QUIET))
+        addAll(frames(count = 20, amplitude = LOUD))
+        addAll(frames(count = 70, amplitude = QUIET))
+        addAll(frames(count = 25, amplitude = LOUD))
+        addAll(frames(count = 60, amplitude = QUIET))
+    }
+
+    private fun frames(count: Int, amplitude: Int): List<ShortArray> =
+        List(count) { index ->
+            val random = Random(index * 31 + amplitude)
+            ShortArray(OnnxWakeWordPipeline.FRAME_SIZE) { i ->
+                val tone = sin(2.0 * PI * 220.0 * i / OnnxWakeWordPipeline.SAMPLE_RATE)
+                ((tone * 0.6 + random.nextDouble(-0.4, 0.4)) * amplitude).toInt().toShort()
+            }
+        }
+
+    private class Recorder : OnnxWakeWordPipeline.PipelineProbe {
+        /** Frame index → classifier score. */
+        val scores = mutableMapOf<Int, Float>()
+        var gatedFrames = 0
+            private set
+
+        // computeMel() runs on every frame, gated or not, and emits rows every
+        // time — so this fires exactly once per frame and doubles as the clock.
+        private var frames = -1
+
+        override fun onMelRows(rows: Int) {
+            frames++
+        }
+
+        override fun onGated() {
+            gatedFrames++
+        }
+
+        override fun onScore(score: Float) {
+            scores[frames] = score
+        }
+    }
+
+    private companion object {
+        const val TAG = "WakeWordGateParity"
+
+        /** Below the gate's −60 dBFS floor once the noise floor has been learned. */
+        const val QUIET = 12
+        const val LOUD = 6000
+    }
+}

--- a/app/src/androidTest/java/com/gotcha/service/WakeWordDetectionDiagnosticTest.kt
+++ b/app/src/androidTest/java/com/gotcha/service/WakeWordDetectionDiagnosticTest.kt
@@ -1,0 +1,275 @@
+package com.gotcha.service
+
+import ai.onnxruntime.OrtEnvironment
+import ai.onnxruntime.OrtSession
+import android.content.Context
+import android.speech.tts.TextToSpeech
+import android.util.Log
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * Diagnostic for "Hey Gotcha stopped firing" after the issue #37 battery work.
+ *
+ * Covers the two gaps the existing tests left:
+ *
+ * 1. **Batched feeds.** Production now drains 4 frames per `AudioRecord.read`,
+ *    but every test so far fed one frame per call. `feed()` grows its scratch
+ *    buffer for the larger blocks, and nothing exercised that.
+ * 2. **An actual positive.** The parity test proves gated and ungated agree,
+ *    which says nothing about whether either one still *detects*. This drives
+ *    the pipeline with the device's own TTS saying the wake phrase — the model
+ *    was trained on synthetic TTS positives, so this is a fair probe.
+ *
+ * ```
+ * ./gradlew :app:connectedDebugAndroidTest \
+ *     -Pandroid.testInstrumentationRunnerArguments.class=com.gotcha.service.WakeWordDetectionDiagnosticTest
+ * ```
+ */
+@RunWith(AndroidJUnit4::class)
+class WakeWordDetectionDiagnosticTest {
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    /**
+     * Feeding the same audio one frame at a time and four frames at a time must
+     * be indistinguishable. This is the exact shape of the production change,
+     * and it was untested.
+     */
+    @Test
+    fun batchedFeeds_matchSingleFrameFeeds() {
+        val clip = syntheticClip()
+
+        val single = run(WakeWordGate.alwaysOpen()) { pipeline ->
+            clip.forEach { pipeline.feed(it, it.size) }
+        }
+        val batched = run(WakeWordGate.alwaysOpen()) { pipeline ->
+            clip.chunked(4).forEach { group ->
+                val block = ShortArray(group.sumOf { it.size })
+                var offset = 0
+                group.forEach { frame ->
+                    frame.copyInto(block, offset)
+                    offset += frame.size
+                }
+                pipeline.feed(block, block.size)
+            }
+        }
+
+        Log.i(TAG, "single=${single.scores.size} scores, batched=${batched.scores.size} scores")
+        assertEquals("batching changed how many frames got scored", single.scores.size, batched.scores.size)
+        for ((frame, score) in single.scores) {
+            assertEquals("frame $frame differs when fed in batches", score, batched.scores.getValue(frame), 0f)
+        }
+    }
+
+    /**
+     * The end-to-end question: does the phrase still fire the matcher, and does
+     * the gate change that answer? Both pipelines get identical audio.
+     */
+    @Test
+    fun spokenWakePhrase_stillFires() {
+        val samples = synthesizePhrase("Hey Gotcha")
+        Log.i(TAG, "phrase is ${samples.size} samples (${samples.size * 1000 / 16000} ms)")
+
+        // Lead-in and tail of near-silence: the gate needs somewhere to learn a
+        // floor and close, so this reproduces a real trigger from a quiet room.
+        val clip = framesOf(silence(90) + samples + silence(40))
+
+        val ungated = run(WakeWordGate.alwaysOpen()) { pipeline ->
+            clip.forEach { pipeline.feed(it, it.size) }
+        }
+        val gated = run(WakeWordGate()) { pipeline ->
+            clip.forEach { pipeline.feed(it, it.size) }
+        }
+
+        Log.i(
+            TAG,
+            "ungated: peak=${ungated.peak} detections=${ungated.detections} | " +
+                "gated: peak=${gated.peak} detections=${gated.detections} gatedOut=${gated.gatedFrames}"
+        )
+        Log.i(TAG, "matcher threshold at default sensitivity = ${WakeWordMatcher(WakeWordMatcher.DEFAULT_SENSITIVITY).threshold()}")
+
+        assertTrue(
+            "the pipeline never scored the phrase above 0.1 (peak=${ungated.peak}) — " +
+                "TTS may not be a usable positive on this device, so this test cannot " +
+                "tell us anything about the gate",
+            ungated.peak > 0.1f
+        )
+        assertEquals(
+            "the gate changed the peak score (ungated=${ungated.peak}, gated=${gated.peak})",
+            ungated.peak,
+            gated.peak,
+            0f
+        )
+        assertEquals(
+            "the gate changed whether the phrase fired",
+            ungated.detections,
+            gated.detections
+        )
+    }
+
+    private fun run(gate: WakeWordGate, body: (OnnxWakeWordPipeline) -> Unit): Recorder {
+        val env = OrtEnvironment.getEnvironment()
+        val recorder = Recorder()
+        val mel = loadSession(env, "melspectrogram.onnx")
+        val embedding = loadSession(env, "embedding_model.onnx")
+        val classifier = loadSession(env, WakeWordDetector.CLASSIFIER_MODEL)
+        try {
+            val pipeline = OnnxWakeWordPipeline(
+                env = env,
+                melSession = mel,
+                embeddingSession = embedding,
+                classifierSession = classifier,
+                matcher = WakeWordMatcher(WakeWordMatcher.DEFAULT_SENSITIVITY),
+                gate = gate,
+                probe = recorder
+            )
+            body(pipeline)
+        } finally {
+            classifier.close()
+            embedding.close()
+            mel.close()
+        }
+        return recorder
+    }
+
+    private fun loadSession(env: OrtEnvironment, name: String): OrtSession {
+        val bytes = context.assets
+            .open("${WakeWordDetector.MODEL_ASSET_DIR}/$name")
+            .use { it.readBytes() }
+        return OrtSession.SessionOptions().use { env.createSession(bytes, it) }
+    }
+
+    /** Renders [text] with the device TTS and returns it as 16 kHz mono PCM-16. */
+    private fun synthesizePhrase(text: String): ShortArray {
+        val ready = CountDownLatch(1)
+        var status = TextToSpeech.ERROR
+        lateinit var tts: TextToSpeech
+        tts = TextToSpeech(context) { code ->
+            status = code
+            ready.countDown()
+        }
+        assertTrue("TTS never initialised", ready.await(30, TimeUnit.SECONDS))
+        assertEquals("no TTS engine on this device", TextToSpeech.SUCCESS, status)
+
+        val out = File(context.cacheDir, "wake-probe.wav")
+        val done = CountDownLatch(1)
+        tts.setOnUtteranceProgressListener(object : android.speech.tts.UtteranceProgressListener() {
+            override fun onStart(utteranceId: String?) = Unit
+            override fun onDone(utteranceId: String?) = done.countDown()
+            @Deprecated("required override")
+            override fun onError(utteranceId: String?) = done.countDown()
+        })
+        tts.synthesizeToFile(text, null, out, "wake-probe")
+        assertTrue("TTS never produced a file", done.await(30, TimeUnit.SECONDS))
+        tts.shutdown()
+
+        return resampleTo16k(readWav(out))
+    }
+
+    /** Minimal PCM-16 WAV reader: walks the chunk list for `fmt ` and `data`. */
+    private fun readWav(file: File): Pair<Int, ShortArray> {
+        val bytes = file.readBytes()
+        val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
+        var offset = 12 // past "RIFF" <size> "WAVE"
+        var sampleRate = 0
+        var channels = 1
+        while (offset + 8 <= bytes.size) {
+            val id = String(bytes, offset, 4, Charsets.US_ASCII)
+            val size = buffer.getInt(offset + 4)
+            val body = offset + 8
+            when (id) {
+                "fmt " -> {
+                    channels = buffer.getShort(body + 2).toInt()
+                    sampleRate = buffer.getInt(body + 4)
+                }
+                "data" -> {
+                    val count = size / 2
+                    val all = ShortArray(count) { buffer.getShort(body + it * 2) }
+                    val mono = if (channels == 1) all else {
+                        ShortArray(count / channels) { all[it * channels] }
+                    }
+                    Log.i(TAG, "TTS wav: ${sampleRate}Hz, ${channels}ch, ${mono.size} samples")
+                    return sampleRate to mono
+                }
+            }
+            offset = body + size + (size % 2)
+        }
+        error("no data chunk in ${file.name}")
+    }
+
+    /** Linear resample. Good enough to ask "does this still fire"; not a codec. */
+    private fun resampleTo16k(input: Pair<Int, ShortArray>): ShortArray {
+        val (rate, samples) = input
+        if (rate == OnnxWakeWordPipeline.SAMPLE_RATE) return samples
+        val ratio = rate.toDouble() / OnnxWakeWordPipeline.SAMPLE_RATE
+        val out = ShortArray((samples.size / ratio).toInt())
+        for (i in out.indices) {
+            val at = i * ratio
+            val low = at.toInt()
+            val high = (low + 1).coerceAtMost(samples.lastIndex)
+            val frac = at - low
+            out[i] = (samples[low] * (1 - frac) + samples[high] * frac).toInt().toShort()
+        }
+        return out
+    }
+
+    private fun silence(frames: Int) =
+        ShortArray(frames * OnnxWakeWordPipeline.FRAME_SIZE) { (-6..6).random().toShort() }
+
+    private fun framesOf(samples: ShortArray): List<ShortArray> =
+        (0 until samples.size / OnnxWakeWordPipeline.FRAME_SIZE).map { index ->
+            samples.copyOfRange(
+                index * OnnxWakeWordPipeline.FRAME_SIZE,
+                (index + 1) * OnnxWakeWordPipeline.FRAME_SIZE
+            )
+        }
+
+    private fun syntheticClip(): List<ShortArray> = framesOf(
+        silence(60) + ShortArray(40 * OnnxWakeWordPipeline.FRAME_SIZE) { i ->
+            (kotlin.math.sin(2.0 * Math.PI * 300.0 * i / 16000.0) * 5000).toInt().toShort()
+        } + silence(60)
+    )
+
+    private operator fun ShortArray.plus(other: ShortArray): ShortArray {
+        val out = ShortArray(size + other.size)
+        copyInto(out)
+        other.copyInto(out, size)
+        return out
+    }
+
+    private class Recorder : OnnxWakeWordPipeline.PipelineProbe {
+        val scores = mutableMapOf<Int, Float>()
+        var gatedFrames = 0
+        var peak = 0f
+        var detections = 0
+        private var frames = -1
+
+        override fun onMelRows(rows: Int) {
+            frames++
+        }
+
+        override fun onGated() {
+            gatedFrames++
+        }
+
+        override fun onScore(score: Float) {
+            scores[frames] = score
+            if (score > peak) peak = score
+            if (score >= WakeWordMatcher(WakeWordMatcher.DEFAULT_SENSITIVITY).threshold()) detections++
+        }
+    }
+
+    private companion object {
+        const val TAG = "WakeWordDiag"
+    }
+}

--- a/app/src/androidTest/java/com/gotcha/service/WakeWordDetectionDiagnosticTest.kt
+++ b/app/src/androidTest/java/com/gotcha/service/WakeWordDetectionDiagnosticTest.kt
@@ -170,10 +170,15 @@ class WakeWordDetectionDiagnosticTest {
             override fun onError(utteranceId: String?) = done.countDown()
         })
         tts.synthesizeToFile(text, null, out, "wake-probe")
-        assertTrue("TTS never produced a file", done.await(30, TimeUnit.SECONDS))
-        tts.shutdown()
-
-        return resampleTo16k(readWav(out))
+        try {
+            assertTrue("TTS never produced a file", done.await(30, TimeUnit.SECONDS))
+            tts.shutdown()
+            return resampleTo16k(readWav(out))
+        } finally {
+            // A rendering of the wake phrase is not something to leave sitting
+            // in the app's cache after the test.
+            out.delete()
+        }
     }
 
     /** Minimal PCM-16 WAV reader: walks the chunk list for `fmt ` and `data`. */

--- a/app/src/androidTest/java/com/gotcha/service/WakeWordDetectorLifecycleTest.kt
+++ b/app/src/androidTest/java/com/gotcha/service/WakeWordDetectorLifecycleTest.kt
@@ -1,0 +1,136 @@
+package com.gotcha.service
+
+import android.Manifest
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.GrantPermissionRule
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Guards the pause/release split from issue #37.
+ *
+ * `AssistiveBallService` pauses the listener on every call transition *and*
+ * every TTS utterance, which before this split meant re-reading ~2.6 MB of
+ * model bytes and rebuilding three ORT sessions each time the app spoke a
+ * single sentence. The fix only holds if [WakeWordDetector.pause] genuinely
+ * keeps the sessions, so that is asserted directly rather than inferred from
+ * how long a resume takes.
+ */
+@RunWith(AndroidJUnit4::class)
+class WakeWordDetectorLifecycleTest {
+
+    @get:Rule
+    val micPermission: GrantPermissionRule = GrantPermissionRule.grant(Manifest.permission.RECORD_AUDIO)
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val error = AtomicReference<String?>(null)
+    private var started = CountDownLatch(1)
+    private var detector: WakeWordDetector? = null
+
+    @After
+    fun tearDown() {
+        detector?.release()
+        scope.cancel()
+    }
+
+    @Test
+    fun pauseKeepsTheModelsLoaded_releaseGivesThemBack() {
+        val detector = newDetector()
+
+        awaitStart(detector)
+        assertEquals("cold start should load the models once", 1, detector.sessionLoadCount)
+
+        // Three rounds of the churn a talkative session produces.
+        repeat(3) { round ->
+            detector.pause()
+            assertTrue("detector still running after pause in round $round", !detector.isRunning())
+            awaitStart(detector)
+            assertEquals(
+                "resume in round $round reloaded the models",
+                1,
+                detector.sessionLoadCount
+            )
+        }
+
+        // release() is the other half of the contract: it must actually let go,
+        // so switching the wake word off does not leave 2.6 MB of models resident.
+        detector.release()
+        awaitStart(detector)
+        assertEquals("release should force a fresh load", 2, detector.sessionLoadCount)
+        assertNull(error.get())
+    }
+
+    @Test
+    fun pauseReleasesTheMicrophone() {
+        val detector = newDetector()
+        awaitStart(detector)
+        detector.pause()
+
+        // The privacy guarantee in privacy-data-retention.md §10.3 is that the
+        // mic is handed back while the app's own TTS speaks — keeping the ONNX
+        // sessions must not have quietly weakened that. If pause() still held
+        // the recorder, this second AudioRecord could not start.
+        val probe = android.media.AudioRecord(
+            android.media.MediaRecorder.AudioSource.VOICE_RECOGNITION,
+            OnnxWakeWordPipeline.SAMPLE_RATE,
+            android.media.AudioFormat.CHANNEL_IN_MONO,
+            android.media.AudioFormat.ENCODING_PCM_16BIT,
+            OnnxWakeWordPipeline.FRAME_SIZE * 2 * 4
+        )
+        try {
+            assertEquals(
+                android.media.AudioRecord.STATE_INITIALIZED,
+                probe.state
+            )
+            probe.startRecording()
+            val buffer = ShortArray(OnnxWakeWordPipeline.FRAME_SIZE)
+            assertTrue("could not read audio after pause", probe.read(buffer, 0, buffer.size) > 0)
+        } finally {
+            try {
+                probe.stop()
+            } catch (_: IllegalStateException) {
+                // Never started.
+            }
+            probe.release()
+        }
+    }
+
+    private fun newDetector(): WakeWordDetector {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        return WakeWordDetector(
+            context = context,
+            scope = scope,
+            sensitivityProvider = { WakeWordMatcher.DEFAULT_SENSITIVITY },
+            onStarted = { started.countDown() },
+            onDetected = {},
+            onError = { message ->
+                error.set(message)
+                started.countDown()
+            }
+        ).also { detector = it }
+    }
+
+    private fun awaitStart(detector: WakeWordDetector) {
+        started = CountDownLatch(1)
+        assertTrue("start() reported a precondition failure", detector.start())
+        assertTrue(
+            "listener never started (error=${error.get()})",
+            started.await(10, TimeUnit.SECONDS)
+        )
+        assertNull("listener reported an error", error.get())
+    }
+}

--- a/app/src/androidTest/java/com/gotcha/service/WakeWordPipelineBenchmarkTest.kt
+++ b/app/src/androidTest/java/com/gotcha/service/WakeWordPipelineBenchmarkTest.kt
@@ -1,0 +1,210 @@
+package com.gotcha.service
+
+import ai.onnxruntime.OrtEnvironment
+import ai.onnxruntime.OrtSession
+import android.content.Context
+import android.util.Log
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.math.PI
+import kotlin.math.sin
+import kotlin.random.Random
+
+/**
+ * Measurement harness for issue #37 (wake-word battery drain). Not a pass/fail
+ * regression test — it exists to produce the two numbers the fix order depends
+ * on, and to keep them reproducible on a real device:
+ *
+ * 1. **The per-stage cost split.** The issue assumes the mel → embedding →
+ *    classify chain is dominated by the two large models. Whether the gate
+ *    (fix #1) or the ORT thread config (fix #2) is the bigger lever depends on
+ *    the actual ms-per-stage, so measure it rather than assume it.
+ * 2. **Mel rows emitted per 80 ms frame.** The whole pre-roll design rests on
+ *    "76 mel rows ≈ 10 frames ≈ 760 ms of audio", which was inferred from
+ *    upstream openWakeWord convention, not read out of the bundled graph.
+ *    [melRowsPerFrame_matchesTenMillisecondHop] pins it down.
+ *
+ * Run against the connected device (an emulator's timings are meaningless for
+ * a power question):
+ *
+ * ```
+ * ./gradlew :app:connectedDebugAndroidTest \
+ *     -Pandroid.testInstrumentationRunnerArguments.class=com.gotcha.service.WakeWordPipelineBenchmarkTest
+ * ```
+ *
+ * Then read the numbers out of logcat: `adb logcat -s WakeWordBench`.
+ */
+@RunWith(AndroidJUnit4::class)
+class WakeWordPipelineBenchmarkTest {
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    /**
+     * Times each stage under both the shipped default [OrtSession.SessionOptions]
+     * and the single-threaded/no-spin config proposed as fix #2, so the two are
+     * compared on the same device in the same run.
+     */
+    @Test
+    fun perStageCost_defaultVsTunedSessionOptions() {
+        val default = measure("default options") { OrtSession.SessionOptions() }
+        val tuned = measure("tuned options") { tunedOptions() }
+
+        Log.i(TAG, "=== summary (median ms per 80 ms frame) ===")
+        Log.i(TAG, "default: total=${default.medianTotalMs()} $default")
+        Log.i(TAG, "tuned:   total=${tuned.medianTotalMs()} $tuned")
+        Log.i(
+            TAG,
+            "duty cycle @12.5 fps — default=${dutyCycle(default)}%, tuned=${dutyCycle(tuned)}%"
+        )
+
+        // The harness is only useful if it actually exercised the full chain.
+        assertTrue("no classify samples recorded", default.classify.isNotEmpty())
+        assertTrue("no classify samples recorded", tuned.classify.isNotEmpty())
+    }
+
+    /**
+     * Confirms the mel front-end emits ~8 rows per 80 ms frame (a 10 ms hop),
+     * which is what makes a cold `melBuffer` need ~10 frames / 760 ms to refill
+     * the 76-row embedding window. If this ever changes, the pre-roll size in
+     * [OnnxWakeWordPipeline] has to change with it.
+     */
+    @Test
+    fun melRowsPerFrame_matchesTenMillisecondHop() {
+        val stats = measure("mel rows") { tunedOptions() }
+        val steady = stats.melRows.drop(WARMUP_FRAMES)
+        assertTrue("no mel runs recorded", steady.isNotEmpty())
+
+        val distinct = steady.distinct().sorted()
+        Log.i(TAG, "mel rows per frame (steady state): $distinct")
+        val rows = distinct.single()
+        val framesToFillEmbeddingWindow =
+            (OnnxWakeWordPipeline.MEL_EMBEDDING_WINDOW + rows - 1) / rows
+        Log.i(
+            TAG,
+            "$rows rows/frame → ${framesToFillEmbeddingWindow} frames " +
+                "(${framesToFillEmbeddingWindow * 80} ms) to refill a cold mel buffer"
+        )
+
+        // 1760-sample window, 400-sample analysis window, 160-sample (10 ms) hop.
+        assertEquals(8, rows)
+    }
+
+    private fun measure(label: String, options: () -> OrtSession.SessionOptions): Stats {
+        val env = OrtEnvironment.getEnvironment()
+        val stats = Stats()
+        val mel = loadSession(env, "melspectrogram.onnx", options())
+        val embedding = loadSession(env, "embedding_model.onnx", options())
+        val classifier = loadSession(env, WakeWordDetector.CLASSIFIER_MODEL, options())
+        try {
+            val pipeline = OnnxWakeWordPipeline(
+                env = env,
+                melSession = mel,
+                embeddingSession = embedding,
+                classifierSession = classifier,
+                matcher = WakeWordMatcher(WakeWordMatcher.DEFAULT_SENSITIVITY),
+                probe = stats
+            )
+            val frame = ShortArray(OnnxWakeWordPipeline.FRAME_SIZE)
+            repeat(WARMUP_FRAMES + MEASURED_FRAMES) { index ->
+                fillSpeechLike(frame, index)
+                pipeline.feed(frame, frame.size)
+                if (index == WARMUP_FRAMES - 1) stats.resetTimings()
+            }
+            Log.i(TAG, "$label → $stats")
+        } finally {
+            classifier.close()
+            embedding.close()
+            mel.close()
+        }
+        return stats
+    }
+
+    private fun loadSession(
+        env: OrtEnvironment,
+        name: String,
+        options: OrtSession.SessionOptions
+    ): OrtSession {
+        val bytes = context.assets
+            .open("${WakeWordDetector.MODEL_ASSET_DIR}/$name")
+            .use { it.readBytes() }
+        return options.use { env.createSession(bytes, it) }
+    }
+
+    private fun tunedOptions() = OrtSession.SessionOptions().apply {
+        setIntraOpNumThreads(1)
+        setInterOpNumThreads(1)
+        setExecutionMode(OrtSession.SessionOptions.ExecutionMode.SEQUENTIAL)
+        addConfigEntry("session.intra_op.allow_spinning", "0")
+        addConfigEntry("session.inter_op.allow_spinning", "0")
+    }
+
+    /**
+     * Band-limited noise at roughly speech level. Stage timings are shape-driven,
+     * not content-driven — every ONNX input here is a fixed size regardless of
+     * what the audio contains — so synthetic audio measures the same cost real
+     * speech would, without shipping a WAV fixture.
+     */
+    private fun fillSpeechLike(frame: ShortArray, frameIndex: Int) {
+        val random = Random(frameIndex)
+        var phase = frameIndex * frame.size.toDouble()
+        for (i in frame.indices) {
+            val tone = sin(2.0 * PI * 220.0 * phase / OnnxWakeWordPipeline.SAMPLE_RATE)
+            val noise = random.nextDouble(-0.3, 0.3)
+            frame[i] = ((tone * 0.4 + noise) * 8000).toInt().toShort()
+            phase += 1.0
+        }
+    }
+
+    private fun dutyCycle(stats: Stats): Int =
+        (stats.medianTotalMs() / 80.0 * 100).toInt()
+
+    private class Stats : OnnxWakeWordPipeline.PipelineProbe {
+        val mel = mutableListOf<Long>()
+        val embed = mutableListOf<Long>()
+        val classify = mutableListOf<Long>()
+        val melRows = mutableListOf<Int>()
+
+        override fun onStage(stage: OnnxWakeWordPipeline.PipelineProbe.Stage, nanos: Long) {
+            when (stage) {
+                OnnxWakeWordPipeline.PipelineProbe.Stage.MEL -> mel += nanos
+                OnnxWakeWordPipeline.PipelineProbe.Stage.EMBEDDING -> embed += nanos
+                OnnxWakeWordPipeline.PipelineProbe.Stage.CLASSIFY -> classify += nanos
+            }
+        }
+
+        override fun onMelRows(rows: Int) {
+            melRows += rows
+        }
+
+        /** Drops the warm-up samples; the first runs pay one-off lazy-init costs. */
+        fun resetTimings() {
+            mel.clear()
+            embed.clear()
+            classify.clear()
+        }
+
+        fun medianTotalMs(): Double = ms(mel, 50) + ms(embed, 50) + ms(classify, 50)
+
+        override fun toString(): String =
+            "mel p50=${ms(mel, 50)}ms p95=${ms(mel, 95)}ms, " +
+                "embed p50=${ms(embed, 50)}ms p95=${ms(embed, 95)}ms, " +
+                "classify p50=${ms(classify, 50)}ms p95=${ms(classify, 95)}ms"
+
+        private fun ms(samples: List<Long>, percentile: Int): Double {
+            if (samples.isEmpty()) return 0.0
+            val sorted = samples.sorted()
+            val index = (sorted.size * percentile / 100).coerceIn(0, sorted.lastIndex)
+            return Math.round(sorted[index] / 1_000.0) / 1_000.0
+        }
+    }
+
+    private companion object {
+        const val TAG = "WakeWordBench"
+        const val WARMUP_FRAMES = 30
+        const val MEASURED_FRAMES = 500
+    }
+}

--- a/app/src/main/java/com/gotcha/MainActivity.kt
+++ b/app/src/main/java/com/gotcha/MainActivity.kt
@@ -518,7 +518,16 @@ class MainActivity : ComponentActivity() {
 
     private fun persistAssistiveBall(enabled: Boolean) {
         val current = settingsRepository.load()
-        settingsRepository.save(current.copy(assistiveBallEnabled = enabled))
+        // The wake word runs inside the ball service, so switching the ball off
+        // must also switch the wake word off — otherwise the wake-word setting
+        // stays on and silently inert while the ball is off.
+        settingsRepository.save(
+            if (enabled) {
+                current.copy(assistiveBallEnabled = true)
+            } else {
+                current.copy(assistiveBallEnabled = false, wakeWordEnabled = false)
+            }
+        )
     }
 
     /** Any Samosa 401 (LLM or audio) clears the session and refreshes the

--- a/app/src/main/java/com/gotcha/MainActivity.kt
+++ b/app/src/main/java/com/gotcha/MainActivity.kt
@@ -75,6 +75,7 @@ import com.gotcha.ui.tour.TourNavigation
 import com.gotcha.ui.tour.TourOverlay
 import com.gotcha.ui.tour.TourPlace
 import com.gotcha.ui.tour.rememberTourHost
+import com.gotcha.util.GotchaLog
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -158,14 +159,13 @@ class MainActivity : ComponentActivity() {
     /** MediaProjection consent result — stores intent for screenshot capture. */
     private val mediaProjectionLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
-            android.util.Log.d(
-                "ScreenCapture",
+            GotchaLog.d("ScreenCapture") {
                 "mediaProjectionLauncher: resultCode=${result.resultCode}, data=${result.data != null}"
-            )
+            }
             if (result.resultCode == RESULT_OK && result.data != null) {
                 ScreenPerception.mediaProjectionResultData = result.data
                 Toast.makeText(this, "Screenshot permission granted.", Toast.LENGTH_SHORT).show()
-                android.util.Log.d("ScreenCapture", "mediaProjectionLauncher: consent stored successfully")
+                GotchaLog.d("ScreenCapture") { "mediaProjectionLauncher: consent stored successfully" }
             } else {
                 android.util.Log.w("ScreenCapture", "mediaProjectionLauncher: consent denied or data null")
             }

--- a/app/src/main/java/com/gotcha/MainActivity.kt
+++ b/app/src/main/java/com/gotcha/MainActivity.kt
@@ -172,19 +172,27 @@ class MainActivity : ComponentActivity() {
         }
 
     /**
-     * Health Connect uses its own permission contract rather than the standard
-     * runtime dialog, so it needs a launcher of its own.
+     * Health Connect uses its own permission screen rather than the standard
+     * runtime dialog. The intent is built by [requestHealthConnect], which picks
+     * the SDK's permission screen or a fallback that can actually be resolved
+     * on the device; the grant state is re-read from the provider when the user
+     * returns, because the fallback screens carry no useful result of their own.
      */
     private val healthConnectLauncher = registerForActivityResult(
-        androidx.health.connect.client.PermissionController.createRequestPermissionResultContract()
-    ) { granted ->
-        com.gotcha.tools.HealthPermissionState.set(granted.isNotEmpty())
-        val message = if (granted.isEmpty()) {
-            "No health permissions granted."
-        } else {
-            "Health Connect: ${granted.size} permission(s) granted."
+        ActivityResultContracts.StartActivityForResult()
+    ) {
+        lifecycleScope.launch {
+            val granted = com.gotcha.tools.HealthPermissionState.refresh(this@MainActivity)
+            Toast.makeText(
+                this@MainActivity,
+                if (granted) {
+                    "Health Connect: permissions granted."
+                } else {
+                    "No health permissions granted."
+                },
+                Toast.LENGTH_SHORT
+            ).show()
         }
-        Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
     }
 
     /**
@@ -391,30 +399,23 @@ class MainActivity : ComponentActivity() {
     }
 
     /**
-     * Opens Health Connect's permission screen, or steers to the Play listing when
-     * no provider is installed (Android 13 and below ship it as a separate app).
+     * Opens Health Connect's permission screen, or the nearest thing that can
+     * actually be resolved on this device. Never crashes: the intent is chosen
+     * by [com.gotcha.tools.healthConnectPermissionIntent], which only returns
+     * something with a resolver, and the launch itself goes through the
+     * activity-result launcher.
      */
     private fun requestHealthConnect() {
-        val status = androidx.health.connect.client.HealthConnectClient.getSdkStatus(this)
-        if (status == androidx.health.connect.client.HealthConnectClient.SDK_AVAILABLE) {
-            healthConnectLauncher.launch(com.gotcha.tools.HealthTool.PERMISSIONS)
-            return
+        if (androidx.health.connect.client.HealthConnectClient.getSdkStatus(this) !=
+            androidx.health.connect.client.HealthConnectClient.SDK_AVAILABLE
+        ) {
+            Toast.makeText(
+                this,
+                "Health Connect is not available — install or update it from the Play Store.",
+                Toast.LENGTH_LONG
+            ).show()
         }
-        Toast.makeText(
-            this,
-            "Health Connect is not available — install or update it from the Play Store.",
-            Toast.LENGTH_LONG
-        ).show()
-        runCatching {
-            startActivity(
-                Intent(
-                    Intent.ACTION_VIEW,
-                    android.net.Uri.parse(
-                        "market://details?id=com.google.android.apps.healthdata"
-                    )
-                )
-            )
-        }
+        com.gotcha.tools.healthConnectPermissionIntent(this)?.let { healthConnectLauncher.launch(it) }
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/app/src/main/java/com/gotcha/agent/AgentEngine.kt
+++ b/app/src/main/java/com/gotcha/agent/AgentEngine.kt
@@ -1,7 +1,6 @@
 package com.gotcha.agent
 
 import android.content.Context
-import android.util.Log
 import com.gotcha.agent.skills.SkillPromptBuilder
 import com.gotcha.agent.skills.SkillRegistry
 import com.gotcha.connectors.ConnectorRegistry
@@ -25,6 +24,7 @@ import com.gotcha.tools.SubAgentSession
 import com.gotcha.tools.ToolExecutor
 import com.gotcha.tools.ToolRegistry
 import com.gotcha.tools.ToolResult
+import com.gotcha.util.GotchaLog
 import com.gotcha.util.HumanReadableError
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
@@ -219,7 +219,7 @@ class AgentEngine(
     fun setupWorkingDir(create: Boolean = true) {
         val dir = resolveWorkingDir(create)
         FileResolver.WORKING_DIR_BASE = dir.absolutePath
-        Log.d(TAG, "setupWorkingDir: ${dir.absolutePath}")
+        GotchaLog.d(TAG) { "setupWorkingDir: ${dir.absolutePath}" }
     }
 
     /** LLM-generated short title, once available; set once per session. */
@@ -833,7 +833,7 @@ class AgentEngine(
         }
         val label = parts[0]
         val pkg = parts[1]
-        Log.d(TAG, "handleUninstallConfirm: label=$label pkg=$pkg")
+        GotchaLog.d(TAG) { "handleUninstallConfirm: label=$label pkg=$pkg" }
         val description = "Request to uninstall \"$label\". After you approve, a system dialog will " +
             "open — you must tap \"OK\" in that dialog to complete the removal. This action is irreversible."
         val approved = events.awaitConfirmation(listOf("uninstall_app"), description)
@@ -1355,10 +1355,7 @@ class AgentEngine(
      * can "see" the screen alongside structured element data.
      */
     internal suspend fun injectReadScreenObservation() {
-        android.util.Log.d(
-            "ScreenCapture",
-            "read_screen auto-injection: calling captureCompressedScreenshot()"
-        )
+        GotchaLog.d("ScreenCapture") { "read_screen auto-injection: calling captureCompressedScreenshot()" }
         val uiTree = ScreenPerception.buildUiHierarchyText()
         val screenshot = try {
             events.onScreenCaptureChrome(true)
@@ -1367,10 +1364,7 @@ class AgentEngine(
         } finally {
             events.onScreenCaptureChrome(false)
         }
-        android.util.Log.d(
-            "ScreenCapture",
-            "read_screen auto-injection: screenshot=${screenshot != null}"
-        )
+        GotchaLog.d("ScreenCapture") { "read_screen auto-injection: screenshot=${screenshot != null}" }
         // The accessibility text read happened regardless of screenshot success —
         // signal the host so it can flash the "screen was read" feedback.
         events.onScreenReadDone()
@@ -1379,10 +1373,9 @@ class AgentEngine(
             val visionMsg = visionUserMessage(observationText, screenshot.base64, "jpeg")
             history.add(visionMsg)
             events.onUi(MessageKind.ASSISTANT, "[Screenshot captured for visual context]")
-            android.util.Log.d(
-                "ScreenCapture",
+            GotchaLog.d("ScreenCapture") {
                 "read_screen auto-injection: vision message added, base64 length=${screenshot.base64.length}"
-            )
+            }
         } else {
             android.util.Log.e(
                 "ScreenCapture",

--- a/app/src/main/java/com/gotcha/agent/skills/SkillRegistry.kt
+++ b/app/src/main/java/com/gotcha/agent/skills/SkillRegistry.kt
@@ -3,6 +3,7 @@ package com.gotcha.agent.skills
 import android.content.Context
 import android.util.Log
 import androidx.annotation.VisibleForTesting
+import com.gotcha.util.GotchaLog
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.decodeFromString
@@ -90,7 +91,7 @@ object SkillRegistry {
                     val text = assetManager.open(fullPath).bufferedReader().use { it.readText() }
                     val skill = json.decodeFromString<Skill>(text)
                     bundledSkills.add(skill)
-                    Log.d(TAG, "Loaded bundled skill: ${skill.id}")
+                    GotchaLog.d(TAG) { "Loaded bundled skill: ${skill.id}" }
                 } catch (e: Exception) {
                     Log.e(TAG, "Error parsing $fullPath", e)
                 }

--- a/app/src/main/java/com/gotcha/audio/AudioApi.kt
+++ b/app/src/main/java/com/gotcha/audio/AudioApi.kt
@@ -1,6 +1,8 @@
 package com.gotcha.audio
 
 import android.util.Log
+import com.gotcha.BuildConfig
+import com.gotcha.util.GotchaLog
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -40,7 +42,13 @@ class AudioApi(
 
     init {
         val logging = HttpLoggingInterceptor().apply {
-            level = HttpLoggingInterceptor.Level.BASIC
+            // The request URL (the configured provider endpoint) is not user
+            // content we should ship to release logcat; keep tracing debug-only.
+            level = if (BuildConfig.DEBUG) {
+                HttpLoggingInterceptor.Level.BASIC
+            } else {
+                HttpLoggingInterceptor.Level.NONE
+            }
             redactHeader("Authorization")
         }
         client = OkHttpClient.Builder()
@@ -67,7 +75,7 @@ class AudioApi(
     fun listAudioModels(): List<AudioModel> {
         return try {
             val url = "${baseUrl.trimEnd('/')}/models"
-            try { Log.d("AudioApi", "Fetching models from: $url") } catch (_: Throwable) {}
+            try { GotchaLog.d("AudioApi") { "Fetching models from: $url" } } catch (_: Throwable) {}
             val request = Request.Builder().url(url).get().build()
             client.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) {
@@ -75,7 +83,9 @@ class AudioApi(
                     return@use emptyList()
                 }
                 val body = response.body?.string() ?: return@use emptyList()
-                try { Log.d("AudioApi", "Models response (first 200 chars): ${body.take(200)}") } catch (_: Throwable) {
+                try {
+                    GotchaLog.d("AudioApi") { "Models response (first 200 chars): ${body.take(200)}" }
+                } catch (_: Throwable) {
                 }
                 val jsonObj = jsonParser.parseToJsonElement(body).jsonObject
                 val dataArr = jsonObj["data"]?.jsonArray ?: return@use emptyList()

--- a/app/src/main/java/com/gotcha/audio/SttEngine.kt
+++ b/app/src/main/java/com/gotcha/audio/SttEngine.kt
@@ -15,6 +15,7 @@ import android.speech.RecognizerIntent
 import android.speech.SpeechRecognizer
 import android.util.Log
 import com.gotcha.i18n.Language
+import com.gotcha.util.GotchaLog
 import com.gotcha.util.HumanReadableError
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
@@ -296,15 +297,15 @@ class SttEngine(
             recognizer = newRec
             newRec.setRecognitionListener(object : RecognitionListener {
                 override fun onReadyForSpeech(params: Bundle?) {
-                    Log.d(TAG, "onReadyForSpeech")
+                    GotchaLog.d(TAG) { "onReadyForSpeech" }
                 }
-                override fun onBeginningOfSpeech() { Log.d(TAG, "onBeginningOfSpeech") }
+                override fun onBeginningOfSpeech() { GotchaLog.d(TAG) { "onBeginningOfSpeech" } }
                 override fun onRmsChanged(rmsdB: Float) {}
                 override fun onBufferReceived(buffer: ByteArray?) {}
-                override fun onEndOfSpeech() { Log.d(TAG, "onEndOfSpeech") }
+                override fun onEndOfSpeech() { GotchaLog.d(TAG) { "onEndOfSpeech" } }
                 override fun onError(error: Int) {
                     val humanMsg = HumanReadableError.fromSpeechRecognizerCode(error)
-                    Log.d(TAG, "onError: $error ($humanMsg)")
+                    GotchaLog.d(TAG) { "onError: $error ($humanMsg)" }
                     if (error == SpeechRecognizer.ERROR_CLIENT ||
                         error == SpeechRecognizer.ERROR_RECOGNIZER_BUSY ||
                         error == SpeechRecognizer.ERROR_SERVER
@@ -322,7 +323,7 @@ class SttEngine(
                     }
                 }
                 override fun onResults(results: Bundle?) {
-                    Log.d(TAG, "onResults")
+                    GotchaLog.d(TAG) { "onResults" }
                     val matches = results?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)
                     val text = matches?.firstOrNull() ?: ""
                     if (text.isNotBlank()) {
@@ -338,17 +339,17 @@ class SttEngine(
                     }
                 }
                 override fun onPartialResults(partialResults: Bundle?) {
-                    Log.d(TAG, "onPartialResults")
+                    GotchaLog.d(TAG) { "onPartialResults" }
                     val matches = partialResults?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)
                     val text = matches?.firstOrNull() ?: ""
                     if (text.isNotBlank()) {
                         currentPartialResult = text
                     }
                 }
-                override fun onEvent(eventType: Int, params: Bundle?) { Log.d(TAG, "onEvent: $eventType") }
+                override fun onEvent(eventType: Int, params: Bundle?) { GotchaLog.d(TAG) { "onEvent: $eventType" } }
 
                 override fun onSegmentResults(segmentResults: Bundle) {
-                    Log.d(TAG, "onSegmentResults")
+                    GotchaLog.d(TAG) { "onSegmentResults" }
                     val matches = segmentResults.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)
                     val text = matches?.firstOrNull() ?: ""
                     if (text.isNotBlank()) {
@@ -359,7 +360,7 @@ class SttEngine(
                 }
 
                 override fun onEndOfSegmentedSession() {
-                    Log.d(TAG, "onEndOfSegmentedSession")
+                    GotchaLog.d(TAG) { "onEndOfSegmentedSession" }
                     if (isContinuousListening) {
                         mainHandler.post { startContinuousListeningCycle() }
                     } else {

--- a/app/src/main/java/com/gotcha/auth/SamosaAuthApi.kt
+++ b/app/src/main/java/com/gotcha/auth/SamosaAuthApi.kt
@@ -77,7 +77,12 @@ interface SamosaAuthApi {
                 encodeDefaults = false
             }
             val logging = HttpLoggingInterceptor().apply {
-                level = HttpLoggingInterceptor.Level.BASIC
+                // The request URL is the configured endpoint — not for release logcat.
+                level = if (BuildConfig.DEBUG) {
+                    HttpLoggingInterceptor.Level.BASIC
+                } else {
+                    HttpLoggingInterceptor.Level.NONE
+                }
                 redactHeader("Authorization")
             }
             val client = OkHttpClient.Builder()

--- a/app/src/main/java/com/gotcha/auth/SamosaAuthManager.kt
+++ b/app/src/main/java/com/gotcha/auth/SamosaAuthManager.kt
@@ -11,6 +11,7 @@ import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import com.gotcha.BuildConfig
 import com.gotcha.data.SettingsRepository
+import com.gotcha.util.GotchaLog
 import kotlinx.coroutines.CancellationException
 import retrofit2.HttpException
 import java.io.IOException
@@ -49,10 +50,10 @@ class SamosaAuthManager(
         val idToken = try {
             requestGoogleIdToken(activityContext)
         } catch (e: GetCredentialCancellationException) {
-            Log.d(TAG, "Sign-in cancelled by user", e)
+            GotchaLog.d(TAG, e) { "Sign-in cancelled by user" }
             return SamosaSignInResult.Cancelled
         } catch (e: NoCredentialException) {
-            Log.d(TAG, "No Google credential available", e)
+            GotchaLog.d(TAG, e) { "No Google credential available" }
             return SamosaSignInResult.Error(
                 "No Google account available. Add a Google account to this device and try again."
             )
@@ -95,7 +96,7 @@ class SamosaAuthManager(
     } catch (e: HttpException) {
         SamosaSignInResult.Error(mapRegisterError(e.code()))
     } catch (e: IOException) {
-        Log.d(TAG, "Network error during register", e)
+        GotchaLog.d(TAG, e) { "Network error during register" }
         SamosaSignInResult.Error("Network error. Check your connection and try again.")
     }
 
@@ -115,7 +116,7 @@ class SamosaAuthManager(
         val token = settingsRepository.load().samosaSessionToken
         if (token.isNotBlank()) {
             runCatching { api.logout("Bearer $token") }
-                .onFailure { Log.d(TAG, "Server logout failed (ignored): ${it.message}") }
+                .onFailure { GotchaLog.d(TAG) { "Server logout failed (ignored): ${it.message}" } }
         }
         settingsRepository.clearSamosaSession()
         runCatching {
@@ -143,7 +144,7 @@ class SamosaAuthManager(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            Log.d(TAG, "Could not fetch credit balance (ignored)", e)
+            GotchaLog.d(TAG, e) { "Could not fetch credit balance (ignored)" }
             null
         }
     }

--- a/app/src/main/java/com/gotcha/data/SettingsRepository.kt
+++ b/app/src/main/java/com/gotcha/data/SettingsRepository.kt
@@ -93,7 +93,7 @@ data class Settings(
      * build that drops a skin degrades to the default instead of throwing on a
      * value it no longer knows.
      */
-    val skinId: String = "deepspace",
+    val skinId: String = "vellum",
     val disabledSkills: Set<String> = emptySet(),
     /**
      * Ids of connectors the user switched off. Credentials survive (re-enabling
@@ -282,13 +282,16 @@ data class Settings(
  * whole reason this exists. It runs once: [SettingsRepository] writes the
  * result, and every later load reads that instead.
  *
+ * A legacy light/dark choice keeps the matching Deep Space skin; an install
+ * that never chose a theme lands on the Vellum default.
+ *
  * @param legacyThemeMode the old `theme_mode` value, or null if never set.
  */
 internal fun migrateSkinId(legacyThemeMode: String?): String =
-    if (legacyThemeMode == LEGACY_THEME_MODE_LIGHT) {
-        SKIN_DEEP_SPACE_LIGHT
-    } else {
-        SKIN_DEEP_SPACE_DARK
+    when (legacyThemeMode) {
+        LEGACY_THEME_MODE_LIGHT -> SKIN_DEEP_SPACE_LIGHT
+        LEGACY_THEME_MODE_DARK -> SKIN_DEEP_SPACE_DARK
+        else -> SKIN_VELLUM
     }
 
 /** The preference file [SettingsRepository] encrypts into. */
@@ -314,7 +317,9 @@ fun settingsChangeNotifier(context: Context): SharedPreferences =
 
 internal const val SKIN_DEEP_SPACE_DARK = "deepspace"
 internal const val SKIN_DEEP_SPACE_LIGHT = "deepspace_light"
+internal const val SKIN_VELLUM = "vellum"
 private const val LEGACY_THEME_MODE_LIGHT = "LIGHT"
+private const val LEGACY_THEME_MODE_DARK = "DARK"
 
 interface SettingsStore {
     fun load(): Settings

--- a/app/src/main/java/com/gotcha/data/SettingsRepository.kt
+++ b/app/src/main/java/com/gotcha/data/SettingsRepository.kt
@@ -5,6 +5,32 @@ import android.content.SharedPreferences
 import com.gotcha.BuildConfig
 import com.gotcha.audio.AudioProvider
 
+/**
+ * When the wake-word listener is allowed to run, relative to the screen state.
+ *
+ * The listener's idle cost (issue #37, `docs/benchmark/wake-word-idle.md`) is
+ * dominated by holding the microphone — the `AudioIn` wake lock, not the
+ * inference. These modes trade how much of the day that happens for where the
+ * user is most likely to want a hands-free trigger.
+ */
+enum class WakeWordListeningMode {
+    /** Listen regardless of screen state — the original always-on behaviour. */
+    ALWAYS,
+
+    /** Listen only while the screen is on, so the mic LED is off when it is not. */
+    SCREEN_ON,
+
+    /** Listen only while the screen is off, for hands-free use away from the app. */
+    SCREEN_OFF;
+
+    /** Whether the listener should run given the current screen interactivity. */
+    fun allows(screenInteractive: Boolean): Boolean = when (this) {
+        ALWAYS -> true
+        SCREEN_ON -> screenInteractive
+        SCREEN_OFF -> !screenInteractive
+    }
+}
+
 data class Settings(
     // Which LLM backend is active. Defaults to the Samosa AI flow.
     val provider: LlmProvider = LlmProvider.SAMOSA_AI,
@@ -54,6 +80,7 @@ data class Settings(
     val assistiveBallEnabled: Boolean = false,
     val wakeWordEnabled: Boolean = false,
     val wakeWordSensitivity: Float = 0.75f,
+    val wakeWordListeningMode: WakeWordListeningMode = WakeWordListeningMode.ALWAYS,
     /** Server-driven notifications from `<SAMOSA_API_URL>/v1/gotcha/notifications`. */
     val serverMessagesEnabled: Boolean = true,
     /** Epoch millis of the last successful server-messages fetch. 0 = never. */
@@ -356,6 +383,9 @@ class SettingsRepository(context: Context) : SettingsStore {
         assistiveBallEnabled = prefs.getBoolean(KEY_ASSISTIVE_BALL, false),
         wakeWordEnabled = prefs.getBoolean(KEY_WAKE_WORD_ENABLED, false),
         wakeWordSensitivity = prefs.getFloat(KEY_WAKE_WORD_SENSITIVITY, 0.75f),
+        wakeWordListeningMode = runCatching {
+            WakeWordListeningMode.valueOf(string(KEY_WAKE_WORD_LISTENING_MODE, "ALWAYS"))
+        }.getOrDefault(WakeWordListeningMode.ALWAYS),
         serverMessagesEnabled = prefs.getBoolean(KEY_SERVER_MESSAGES_ENABLED, true),
         serverMessagesLastFetchedAt = prefs.getLong(KEY_SERVER_MESSAGES_LAST_FETCHED, 0L),
         serverMessagesEtag = string(KEY_SERVER_MESSAGES_ETAG),
@@ -417,6 +447,7 @@ class SettingsRepository(context: Context) : SettingsStore {
             .putBoolean(KEY_ASSISTIVE_BALL, settings.assistiveBallEnabled)
             .putBoolean(KEY_WAKE_WORD_ENABLED, settings.wakeWordEnabled)
             .putFloat(KEY_WAKE_WORD_SENSITIVITY, settings.wakeWordSensitivity)
+            .putString(KEY_WAKE_WORD_LISTENING_MODE, settings.wakeWordListeningMode.name)
             .putBoolean(KEY_SERVER_MESSAGES_ENABLED, settings.serverMessagesEnabled)
             .putLong(KEY_SERVER_MESSAGES_LAST_FETCHED, settings.serverMessagesLastFetchedAt)
             .putString(KEY_SERVER_MESSAGES_ETAG, settings.serverMessagesEtag)
@@ -523,6 +554,7 @@ class SettingsRepository(context: Context) : SettingsStore {
         const val KEY_ASSISTIVE_BALL = "assistive_ball_enabled"
         const val KEY_WAKE_WORD_ENABLED = "wake_word_enabled"
         const val KEY_WAKE_WORD_SENSITIVITY = "wake_word_sensitivity"
+        const val KEY_WAKE_WORD_LISTENING_MODE = "wake_word_listening_mode"
         const val KEY_SERVER_MESSAGES_ENABLED = "server_messages_enabled"
         const val KEY_SERVER_MESSAGES_LAST_FETCHED = "server_messages_last_fetched"
         const val KEY_SERVER_MESSAGES_ETAG = "server_messages_etag"

--- a/app/src/main/java/com/gotcha/data/SettingsRepository.kt
+++ b/app/src/main/java/com/gotcha/data/SettingsRepository.kt
@@ -92,6 +92,9 @@ data class Settings(
      * Which skin is painted. Stored as the id string rather than an enum so a
      * build that drops a skin degrades to the default instead of throwing on a
      * value it no longer knows.
+     *
+     * Keep this default in sync with [com.gotcha.ui.theme.Skins.DEFAULT_ID] — a
+     * fresh install that never runs the migration reads it straight from here.
      */
     val skinId: String = "vellum",
     val disabledSkills: Set<String> = emptySet(),
@@ -282,15 +285,18 @@ data class Settings(
  * whole reason this exists. It runs once: [SettingsRepository] writes the
  * result, and every later load reads that instead.
  *
- * A legacy light/dark choice keeps the matching Deep Space skin; an install
- * that never chose a theme lands on the Vellum default.
+ * A legacy light/dark choice keeps the matching Deep Space skin. SYSTEM was the
+ * stored default, so it was the theme the app actually showed for most installs
+ * — it stays on Deep Space Dark rather than silently flipping those users from
+ * dark to light. Only an install that never wrote the field (a fresh install,
+ * where the new skin system replaced `theme_mode` entirely) lands on Vellum.
  *
  * @param legacyThemeMode the old `theme_mode` value, or null if never set.
  */
 internal fun migrateSkinId(legacyThemeMode: String?): String =
     when (legacyThemeMode) {
         LEGACY_THEME_MODE_LIGHT -> SKIN_DEEP_SPACE_LIGHT
-        LEGACY_THEME_MODE_DARK -> SKIN_DEEP_SPACE_DARK
+        LEGACY_THEME_MODE_DARK, LEGACY_THEME_MODE_SYSTEM -> SKIN_DEEP_SPACE_DARK
         else -> SKIN_VELLUM
     }
 
@@ -320,6 +326,7 @@ internal const val SKIN_DEEP_SPACE_LIGHT = "deepspace_light"
 internal const val SKIN_VELLUM = "vellum"
 private const val LEGACY_THEME_MODE_LIGHT = "LIGHT"
 private const val LEGACY_THEME_MODE_DARK = "DARK"
+private const val LEGACY_THEME_MODE_SYSTEM = "SYSTEM"
 
 interface SettingsStore {
     fun load(): Settings

--- a/app/src/main/java/com/gotcha/llm/LLMClient.kt
+++ b/app/src/main/java/com/gotcha/llm/LLMClient.kt
@@ -1,6 +1,7 @@
 package com.gotcha.llm
 
 import android.content.Context
+import com.gotcha.BuildConfig
 import com.gotcha.audio.AudioModel
 import com.gotcha.audio.ModelCategory
 import com.gotcha.i18n.Language
@@ -38,7 +39,12 @@ class LLMClient(
 
     init {
         val logging = HttpLoggingInterceptor().apply {
-            level = HttpLoggingInterceptor.Level.BODY
+            // BODY tracing writes full prompts/replies to logcat — never in release.
+            level = if (BuildConfig.DEBUG) {
+                HttpLoggingInterceptor.Level.BODY
+            } else {
+                HttpLoggingInterceptor.Level.NONE
+            }
             redactHeader("Authorization")
         }
 

--- a/app/src/main/java/com/gotcha/notifications/NotificationApi.kt
+++ b/app/src/main/java/com/gotcha/notifications/NotificationApi.kt
@@ -39,7 +39,12 @@ open class NotificationApi(
 
     init {
         val logging = HttpLoggingInterceptor().apply {
-            level = HttpLoggingInterceptor.Level.BASIC
+            // The request URL is the configured endpoint — not for release logcat.
+            level = if (BuildConfig.DEBUG) {
+                HttpLoggingInterceptor.Level.BASIC
+            } else {
+                HttpLoggingInterceptor.Level.NONE
+            }
         }
         client = OkHttpClient.Builder()
             .connectTimeout(timeoutSeconds, TimeUnit.SECONDS)

--- a/app/src/main/java/com/gotcha/service/AssistiveBallService.kt
+++ b/app/src/main/java/com/gotcha/service/AssistiveBallService.kt
@@ -5,18 +5,23 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.Service
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.content.SharedPreferences
 import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.IBinder
+import android.os.PowerManager
+import androidx.core.content.ContextCompat
 import com.gotcha.MainActivity
 import com.gotcha.audio.AudioProvider
 import com.gotcha.audio.SttEngine
 import com.gotcha.audio.TtsEngine
 import com.gotcha.data.ChatHistoryRepository
 import com.gotcha.data.SettingsRepository
+import com.gotcha.data.WakeWordListeningMode
 import com.gotcha.data.settingsChangeNotifier
 import com.gotcha.i18n.Language
 import com.gotcha.ui.AssistiveBallOverlay
@@ -83,16 +88,39 @@ class AssistiveBallService : Service() {
             return@OnSharedPreferenceChangeListener
         }
         // The key arrives encrypted; compare the value read back instead (see
-        // settingsChangeNotifier's note). Restarting with a new threshold only
-        // makes sense while idle — the state collector stops the detector
-        // whenever a call becomes active anyway.
-        if (s.wakeWordSensitivity != appliedWakeWordSensitivity &&
-            callController.state.value == CallState.IDLE
-        ) {
+        // settingsChangeNotifier's note). Restarting with a new threshold or a
+        // new listening mode only makes sense while idle — the state collector
+        // stops the detector whenever a call becomes active anyway.
+        val settingsChanged = s.wakeWordSensitivity != appliedWakeWordSensitivity ||
+            s.wakeWordListeningMode != appliedWakeWordMode
+        if (settingsChanged && callController.state.value == CallState.IDLE) {
             maybeStartWakeWord()
         }
     }
     private var appliedWakeWordSensitivity: Float? = null
+    private var appliedWakeWordMode: WakeWordListeningMode? = null
+
+    /**
+     * Re-evaluates the listener when the screen toggles, so the SCREEN_ON /
+     * SCREEN_OFF listening modes track the display instead of waiting for a
+     * settings edit or a call transition to re-arm.
+     *
+     * Guarded like the call-state and TTS collectors: a screen toggle must
+     * never re-arm the listener while a call is active or the app is speaking
+     * — those pauses are deliberate, and an unconditional re-arm here would
+     * grab the microphone out from under the call's STT or from the app's own
+     * voice.
+     */
+    private val screenStateReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            when (intent.action) {
+                Intent.ACTION_SCREEN_ON, Intent.ACTION_SCREEN_OFF ->
+                    if (callController.state.value == CallState.IDLE && !ttsEngine.isSpeaking.value) {
+                        maybeStartWakeWord()
+                    }
+            }
+        }
+    }
     private lateinit var screenCompanionController: ScreenCompanionController
     private lateinit var screenCompanionPanel: com.gotcha.ui.ScreenCompanionPanelOverlay
     private lateinit var screenLensController: ScreenLensController
@@ -159,6 +187,7 @@ class AssistiveBallService : Service() {
 
         settingsPrefs = settingsChangeNotifier(applicationContext)
         settingsPrefs.registerOnSharedPreferenceChangeListener(wakeWordSettingsWatcher)
+        registerScreenStateReceiver()
 
         // Floating call buttons (shown during a call, hidden otherwise)
         chatWindow = CallChatWindow(this).apply {
@@ -909,7 +938,9 @@ class AssistiveBallService : Service() {
 
     private fun maybeStartWakeWord() {
         val settings = settingsRepository.load()
-        if (settings.wakeWordEnabled && settings.assistiveBallEnabled && hasMicPermission()) {
+        if (settings.wakeWordEnabled && settings.assistiveBallEnabled && hasMicPermission() &&
+            settings.wakeWordListeningMode.allows(isScreenInteractive())
+        ) {
             // A running detector skips its own start() (see WakeWordDetector),
             // so a live sensitivity change would otherwise never reach the
             // matcher. Stop first to force a rebuild whenever the threshold
@@ -920,11 +951,36 @@ class AssistiveBallService : Service() {
                 wakeWordDetector.pause()
             }
             appliedWakeWordSensitivity = settings.wakeWordSensitivity
+            appliedWakeWordMode = settings.wakeWordListeningMode
             wakeWordDetector.start()
         } else {
-            // Switched off, or no mic grant: give the models back.
+            // Switched off, no mic grant, or the listening mode does not allow
+            // the current screen state: give the models back.
             wakeWordDetector.release()
         }
+    }
+
+    /** Whether the display is on and usable. Defaults to true when unknown. */
+    private fun isScreenInteractive(): Boolean {
+        val powerManager = getSystemService(PowerManager::class.java) ?: return true
+        return powerManager.isInteractive
+    }
+
+    /**
+     * Screen on/off re-arm for the SCREEN_ON / SCREEN_OFF listening modes.
+     * Registered once in [onCreate] and unregistered alongside the settings
+     * watcher in [stopBall] and [onDestroy].
+     */
+    private fun registerScreenStateReceiver() {
+        ContextCompat.registerReceiver(
+            this,
+            screenStateReceiver,
+            IntentFilter().apply {
+                addAction(Intent.ACTION_SCREEN_ON)
+                addAction(Intent.ACTION_SCREEN_OFF)
+            },
+            ContextCompat.RECEIVER_NOT_EXPORTED
+        )
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -952,6 +1008,7 @@ class AssistiveBallService : Service() {
         if (::settingsPrefs.isInitialized) {
             settingsPrefs.unregisterOnSharedPreferenceChangeListener(wakeWordSettingsWatcher)
         }
+        runCatching { unregisterReceiver(screenStateReceiver) }
         callController.endCall()
         chatWindow.hide()
         screenCompanionPanel.dismiss()
@@ -1035,10 +1092,13 @@ class AssistiveBallService : Service() {
         if (::settingsPrefs.isInitialized) {
             settingsPrefs.unregisterOnSharedPreferenceChangeListener(wakeWordSettingsWatcher)
         }
+        runCatching { unregisterReceiver(screenStateReceiver) }
         callController.endCall()
         chatWindow.hide()
         screenCompanionPanel.dismiss()
-        settingsRepository.save(settingsRepository.load().copy(assistiveBallEnabled = false))
+        settingsRepository.save(
+            settingsRepository.load().copy(assistiveBallEnabled = false, wakeWordEnabled = false)
+        )
         _isRunning.value = false
         overlay.dismiss()
         stopForeground(STOP_FOREGROUND_REMOVE)

--- a/app/src/main/java/com/gotcha/service/AssistiveBallService.kt
+++ b/app/src/main/java/com/gotcha/service/AssistiveBallService.kt
@@ -79,7 +79,7 @@ class AssistiveBallService : Service() {
     private val wakeWordSettingsWatcher = SharedPreferences.OnSharedPreferenceChangeListener { _, _ ->
         val s = settingsRepository.load()
         if (!s.wakeWordEnabled || !s.assistiveBallEnabled) {
-            wakeWordDetector.stop()
+            wakeWordDetector.release()
             return@OnSharedPreferenceChangeListener
         }
         // The key arrives encrypted; compare the value read back instead (see
@@ -227,7 +227,9 @@ class AssistiveBallService : Service() {
             callController.state.collect { state ->
                 val active = state != CallState.IDLE && state != CallState.ENDING
                 if (active) {
-                    wakeWordDetector.stop()
+                    // Pause, not release: a call ends and we re-arm within
+                    // seconds, so keep the models loaded across it.
+                    wakeWordDetector.pause()
                 } else if (state == CallState.IDLE) {
                     maybeStartWakeWord()
                 }
@@ -247,10 +249,14 @@ class AssistiveBallService : Service() {
         // post-detection isSpeaking guard in onWakeWordDetected is a second
         // line of defence against self-triggering, but stopping the listener
         // here closes the race at the source — see privacy-data-retention.md §10.3.
+        // pause() still hands the microphone back in full; it keeps only the
+        // loaded ONNX models, which hold no audio. The privacy guarantee is
+        // unchanged — what goes away is reloading 2.6 MB of models every time
+        // the app speaks a sentence.
         scope.launch {
             ttsEngine.isSpeaking.collect { speaking ->
                 if (speaking) {
-                    wakeWordDetector.stop()
+                    wakeWordDetector.pause()
                 } else if (callController.state.value == CallState.IDLE) {
                     maybeStartWakeWord()
                 }
@@ -864,7 +870,7 @@ class AssistiveBallService : Service() {
         ) == android.content.pm.PackageManager.PERMISSION_GRANTED
 
     private fun onWakeWordDetected() {
-        wakeWordDetector.stop()
+        wakeWordDetector.pause()
         if (ttsEngine.isSpeaking.value) {
             // The app was reading something aloud (e.g. a screen read-aloud that
             // happened to contain "gotcha") — never start a call from our own
@@ -894,12 +900,13 @@ class AssistiveBallService : Service() {
             if (appliedWakeWordSensitivity != settings.wakeWordSensitivity &&
                 wakeWordDetector.isRunning()
             ) {
-                wakeWordDetector.stop()
+                wakeWordDetector.pause()
             }
             appliedWakeWordSensitivity = settings.wakeWordSensitivity
             wakeWordDetector.start()
         } else {
-            wakeWordDetector.stop()
+            // Switched off, or no mic grant: give the models back.
+            wakeWordDetector.release()
         }
     }
 
@@ -924,7 +931,7 @@ class AssistiveBallService : Service() {
     override fun onDestroy() {
         if (instance === this) instance = null
         _isRunning.value = false
-        wakeWordDetector.stop()
+        wakeWordDetector.release()
         if (::settingsPrefs.isInitialized) {
             settingsPrefs.unregisterOnSharedPreferenceChangeListener(wakeWordSettingsWatcher)
         }
@@ -1007,7 +1014,7 @@ class AssistiveBallService : Service() {
     // ---- Lifecycle helpers ----
 
     private fun stopBall() {
-        wakeWordDetector.stop()
+        wakeWordDetector.release()
         if (::settingsPrefs.isInitialized) {
             settingsPrefs.unregisterOnSharedPreferenceChangeListener(wakeWordSettingsWatcher)
         }

--- a/app/src/main/java/com/gotcha/service/AssistiveBallService.kt
+++ b/app/src/main/java/com/gotcha/service/AssistiveBallService.kt
@@ -874,8 +874,13 @@ class AssistiveBallService : Service() {
         if (ttsEngine.isSpeaking.value) {
             // The app was reading something aloud (e.g. a screen read-aloud that
             // happened to contain "gotcha") — never start a call from our own
-            // voice. Resume listening instead.
-            maybeStartWakeWord()
+            // voice.
+            //
+            // Deliberately does not re-arm here. Doing so put the listener back
+            // on the mic *while the app was still talking*, so the rest of the
+            // utterance could trigger this path again and again. The isSpeaking
+            // collector re-arms as soon as the app goes quiet, which is the
+            // moment listening should resume.
             return
         }
         val s = settingsRepository.load()

--- a/app/src/main/java/com/gotcha/service/AssistiveBallService.kt
+++ b/app/src/main/java/com/gotcha/service/AssistiveBallService.kt
@@ -26,6 +26,7 @@ import com.gotcha.data.settingsChangeNotifier
 import com.gotcha.i18n.Language
 import com.gotcha.ui.AssistiveBallOverlay
 import com.gotcha.ui.CallChatWindow
+import com.gotcha.util.GotchaLog
 import com.gotcha.util.HumanReadableError
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -460,22 +461,21 @@ class AssistiveBallService : Service() {
 
     /** Read the clipboard (via a focus-stealing activity) and offer a smart action. */
     private fun handleClipboardRead() {
-        android.util.Log.d("AssistiveBallService", "onReadClipboardRequest called")
+        GotchaLog.d("AssistiveBallService") { "onReadClipboardRequest called" }
         overlay.readClipboardWithFocus { clip ->
-            android.util.Log.d(
-                "AssistiveBallService",
+            GotchaLog.d("AssistiveBallService") {
                 "readClipboardWithFocus: null=${clip == null}, count=${clip?.itemCount ?: 0}"
-            )
+            }
             com.gotcha.service.GotchaAccessibilityService.lastClipboardData = clip
             val clipText = clip?.getItemAt(0)?.text?.toString()
-            android.util.Log.d("AssistiveBallService", "clip length=${clipText?.length ?: 0}")
+            GotchaLog.d("AssistiveBallService") { "clip length=${clipText?.length ?: 0}" }
             if (clipText.isNullOrBlank()) {
-                android.util.Log.d("AssistiveBallService", "clipText is null or blank, not setting smart action")
+                GotchaLog.d("AssistiveBallService") { "clipText is null or blank, not setting smart action" }
                 return@readClipboardWithFocus
             }
             val url = SmartActionDetector.extractUrl(clipText)
             if (url != null) {
-                android.util.Log.d("AssistiveBallService", "Setting smart action: Summarize link ($url)")
+                GotchaLog.d("AssistiveBallService") { "Setting smart action: Summarize link ($url)" }
                 val fetch = SmartActionDetector.fetchAction(url)
                 overlay.setSmartActionAvailable(fetch.label, fetch.prompt)
                 return@readClipboardWithFocus

--- a/app/src/main/java/com/gotcha/service/AssistiveBallService.kt
+++ b/app/src/main/java/com/gotcha/service/AssistiveBallService.kt
@@ -887,7 +887,19 @@ class AssistiveBallService : Service() {
         // The call hides the ball almost immediately, so the visual ack has to
         // be kicked off before it starts — see AssistiveBallOverlay.playWakeAnimation.
         overlay.playWakeAnimation()
-        callController.startWakeWordCall()
+        if (!callController.startWakeWordCall()) {
+            // The call was refused before it began — no provider configured, no
+            // API key, the mic grant gone. startCall() reports that through
+            // onError() and leaves the state machine in IDLE, so the collector
+            // that normally re-arms the listener never fires: a StateFlow that
+            // does not change does not emit.
+            //
+            // Without this the wake word is dead until the ball is restarted,
+            // and the failure looks permanent to the user — they fix the thing
+            // the error told them to fix, say "Hey Gotcha" again, and nothing
+            // happens. Re-arm here so the next attempt reaches the new config.
+            maybeStartWakeWord()
+        }
     }
 
     private fun maybeStartWakeWord() {

--- a/app/src/main/java/com/gotcha/service/GotchaAccessibilityService.kt
+++ b/app/src/main/java/com/gotcha/service/GotchaAccessibilityService.kt
@@ -10,6 +10,7 @@ import android.view.Display
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
 import androidx.annotation.RequiresApi
+import com.gotcha.util.GotchaLog
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume
 
@@ -57,10 +58,7 @@ class GotchaAccessibilityService : AccessibilityService() {
                 val desc = source.contentDescription?.toString() ?: ""
                 val viewId = source.viewIdResourceName ?: ""
                 if (isCopyString(text) || isCopyString(desc) || viewId.lowercase().contains("copy")) {
-                    android.util.Log.d(
-                        "GotchaAccessibilityService",
-                        "Copy click detected: id=$viewId"
-                    )
+                    GotchaLog.d("GotchaAccessibilityService") { "Copy click detected: id=$viewId" }
                     triggerClipboardBroadcast()
                 }
                 source.recycle()
@@ -69,7 +67,7 @@ class GotchaAccessibilityService : AccessibilityService() {
             for (t in eventTexts) {
                 val textStr = t?.toString() ?: ""
                 if (isCopyString(textStr)) {
-                    android.util.Log.d("GotchaAccessibilityService", "Copy event text detected")
+                    GotchaLog.d("GotchaAccessibilityService") { "Copy event text detected" }
                     triggerClipboardBroadcast()
                     break
                 }
@@ -79,10 +77,7 @@ class GotchaAccessibilityService : AccessibilityService() {
             for (t in eventTexts) {
                 val textStr = t?.toString() ?: ""
                 if (isClipboardToast(textStr)) {
-                    android.util.Log.d(
-                        "GotchaAccessibilityService",
-                        "Clipboard toast detected"
-                    )
+                    GotchaLog.d("GotchaAccessibilityService") { "Clipboard toast detected" }
                     triggerClipboardBroadcast()
                     break
                 }
@@ -123,10 +118,7 @@ class GotchaAccessibilityService : AccessibilityService() {
                 setPackage(packageName)
             }
             sendBroadcast(intent)
-            android.util.Log.d(
-                "GotchaAccessibilityService",
-                "Sent CLIPBOARD_CHANGED broadcast"
-            )
+            GotchaLog.d("GotchaAccessibilityService") { "Sent CLIPBOARD_CHANGED broadcast" }
         } catch (e: Exception) {
             android.util.Log.e(
                 "GotchaAccessibilityService",
@@ -658,9 +650,6 @@ class GotchaAccessibilityService : AccessibilityService() {
 
     /** Register a clipboard listener to cache clipboard content. */
     internal fun initClipboardListener() {
-        android.util.Log.d(
-            "GotchaAccessibilityService",
-            "initClipboardListener: using event-based detection"
-        )
+        GotchaLog.d("GotchaAccessibilityService") { "initClipboardListener: using event-based detection" }
     }
 }

--- a/app/src/main/java/com/gotcha/service/MediaProjectionService.kt
+++ b/app/src/main/java/com/gotcha/service/MediaProjectionService.kt
@@ -21,6 +21,7 @@ import android.os.IBinder
 import android.util.DisplayMetrics
 import android.util.Log
 import android.view.WindowManager
+import com.gotcha.util.GotchaLog
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.util.concurrent.CountDownLatch
@@ -68,7 +69,7 @@ class MediaProjectionService : Service() {
             resultIntent: Intent,
             timeoutMs: Long = 5000
         ): ByteArray? = synchronized(captureLock) {
-            Log.d("ScreenCapture", "MediaProjectionService.capture() called")
+            GotchaLog.d("ScreenCapture") { "MediaProjectionService.capture() called" }
             resultData = resultIntent
             resultReady = CountDownLatch(1)
             resultFilePath = null
@@ -76,14 +77,16 @@ class MediaProjectionService : Service() {
             val serviceIntent = Intent(context, MediaProjectionService::class.java)
             try {
                 context.startForegroundService(serviceIntent)
-                Log.d("ScreenCapture", "MediaProjectionService started")
+                GotchaLog.d("ScreenCapture") { "MediaProjectionService started" }
             } catch (e: Exception) {
                 Log.e("ScreenCapture", "Failed to start MediaProjectionService: ${e.message}")
                 return null
             }
 
             val completed = resultReady.await(timeoutMs, TimeUnit.MILLISECONDS)
-            Log.d("ScreenCapture", "MediaProjectionService latch completed=$completed, resultFilePath=$resultFilePath")
+            GotchaLog.d("ScreenCapture") {
+                "MediaProjectionService latch completed=$completed, resultFilePath=$resultFilePath"
+            }
 
             val path = resultFilePath ?: return null
             val file = File(path)
@@ -93,7 +96,7 @@ class MediaProjectionService : Service() {
             }
             val bytes = file.readBytes()
             file.delete()
-            Log.d("ScreenCapture", "MediaProjectionService returning ${bytes.size} bytes")
+            GotchaLog.d("ScreenCapture") { "MediaProjectionService returning ${bytes.size} bytes" }
             return bytes
         }
     }
@@ -112,7 +115,7 @@ class MediaProjectionService : Service() {
     /** API 34 requires a registered callback before createVirtualDisplay(). */
     private val projectionCallback = object : MediaProjection.Callback() {
         override fun onStop() {
-            Log.d("ScreenCapture", "MediaProjection.onStop()")
+            GotchaLog.d("ScreenCapture") { "MediaProjection.onStop()" }
             finish(null)
         }
     }
@@ -134,7 +137,7 @@ class MediaProjectionService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         val data = resultData
         val handler = captureHandler
-        Log.d("ScreenCapture", "MediaProjectionService.onStartCommand: data=${data != null}")
+        GotchaLog.d("ScreenCapture") { "MediaProjectionService.onStartCommand: data=${data != null}" }
         if (data == null || handler == null) {
             finish(null)
             return START_NOT_STICKY
@@ -157,7 +160,7 @@ class MediaProjectionService : Service() {
      * asynchronously on [captureHandler] via the ImageReader listener.
      */
     private fun startCapture(data: Intent) {
-        Log.d("ScreenCapture", "startCapture: starting")
+        GotchaLog.d("ScreenCapture") { "startCapture: starting" }
         val mpManager = getSystemService(Context.MEDIA_PROJECTION_SERVICE) as MediaProjectionManager
         // A spent or stale token throws here rather than returning null on API 34+.
         val mp = try {
@@ -182,7 +185,7 @@ class MediaProjectionService : Service() {
         val screenWidth = metrics.widthPixels
         val screenHeight = metrics.heightPixels
         val screenDpi = metrics.densityDpi
-        Log.d("ScreenCapture", "startCapture: screen ${screenWidth}x$screenHeight dpi=$screenDpi")
+        GotchaLog.d("ScreenCapture") { "startCapture: screen ${screenWidth}x$screenHeight dpi=$screenDpi" }
 
         val reader = ImageReader.newInstance(screenWidth, screenHeight, PixelFormat.RGBA_8888, 2)
         imageReader = reader
@@ -210,7 +213,7 @@ class MediaProjectionService : Service() {
             reader.surface,
             null, null
         )
-        Log.d("ScreenCapture", "startCapture: virtualDisplay=${virtualDisplay != null}")
+        GotchaLog.d("ScreenCapture") { "startCapture: virtualDisplay=${virtualDisplay != null}" }
 
         // Never leave the caller (and the service) hanging if no frame is produced.
         captureHandler?.postDelayed({
@@ -233,7 +236,7 @@ class MediaProjectionService : Service() {
         bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream)
         bitmap.recycle()
         val pngBytes = stream.toByteArray()
-        Log.d("ScreenCapture", "onFrame: PNG compressed ${pngBytes.size} bytes")
+        GotchaLog.d("ScreenCapture") { "onFrame: PNG compressed ${pngBytes.size} bytes" }
         if (pngBytes.isEmpty()) {
             Log.e("ScreenCapture", "onFrame: PNG compression produced 0 bytes")
             finish(null)
@@ -241,7 +244,7 @@ class MediaProjectionService : Service() {
         }
         val outPath = File(cacheDir, RESULT_FILE).absolutePath
         File(outPath).writeBytes(pngBytes)
-        Log.d("ScreenCapture", "onFrame: saved to $outPath")
+        GotchaLog.d("ScreenCapture") { "onFrame: saved to $outPath" }
         finish(outPath)
     }
 
@@ -270,7 +273,9 @@ class MediaProjectionService : Service() {
         }
         val bmp = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
         bmp.copyPixelsFromBuffer(java.nio.ByteBuffer.wrap(packedBytes))
-        Log.d("ScreenCapture", "toBitmap: ${bmp.width}x${bmp.height} (stride=$rowStride, pxStride=$pixelStride)")
+        GotchaLog.d("ScreenCapture") {
+            "toBitmap: ${bmp.width}x${bmp.height} (stride=$rowStride, pxStride=$pixelStride)"
+        }
         bmp
     } catch (t: Throwable) {
         Log.e("ScreenCapture", "toBitmap failed: ${t.message}", t)

--- a/app/src/main/java/com/gotcha/service/OnnxWakeWordPipeline.kt
+++ b/app/src/main/java/com/gotcha/service/OnnxWakeWordPipeline.kt
@@ -50,6 +50,9 @@ import java.nio.FloatBuffer
  * and the classifier input. The mel rows and embeddings are recycled through
  * [melRowPool] and [featurePool] as they fall out of their bounded buffers.
  *
+ * [WakeWordGate] holds the same line: its noise floor is a sorted percentile,
+ * but over reused scratch and refreshed on a schedule rather than per frame.
+ *
  * What still allocates per frame: the `OnnxTensor` wrappers and whatever ORT
  * hands back from `run()`. Both are ORT's to own. This is not "zero
  * allocation" — keep the claim honest, a profiler is the arbiter.
@@ -251,7 +254,9 @@ internal class OnnxWakeWordPipeline(
         if (!timed(PipelineProbe.Stage.MEL) { computeMel() }) return false
 
         if (!open) {
-            if (gatedFrames < CLASSIFIER_FRAMES) gatedFrames++
+            // Capped at what a replay can actually use; anything older has
+            // already fallen out of the classifier's window.
+            if (gatedFrames < CLASSIFIER_FRAMES - 1) gatedFrames++
             probe?.onGated()
             return false
         }

--- a/app/src/main/java/com/gotcha/service/OnnxWakeWordPipeline.kt
+++ b/app/src/main/java/com/gotcha/service/OnnxWakeWordPipeline.kt
@@ -41,12 +41,18 @@ import java.nio.FloatBuffer
  * longer than ~1.3 s. `WakeWordGate`'s hangover is what keeps gaps that short
  * from re-arming at all.
  *
- * The hot path avoids per-frame GC pressure: the raw PCM ring buffer, the
- * combined feed buffer, the frame buffer, and the mel window are all
- * pre-allocated once and reused. The per-row mel arrays, `toList()` snapshots,
- * and ONNX tensor inputs are still allocated each frame (~37.5/s), which is
- * acceptable — keep this from drifting into the comment-free "zero allocation"
- * territory that a profiler would disprove.
+ * ## Allocation
+ *
+ * The hot path is close to allocation-free, which matters on a path that runs
+ * for as long as the phone is on. Pre-allocated and reused: the raw PCM ring,
+ * the combined feed buffer, the frame buffer, the mel window, the embedding
+ * input (`[1][76][32][1]` — this one was 2432 one-element arrays per frame),
+ * and the classifier input. The mel rows and embeddings are recycled through
+ * [melRowPool] and [featurePool] as they fall out of their bounded buffers.
+ *
+ * What still allocates per frame: the `OnnxTensor` wrappers and whatever ORT
+ * hands back from `run()`. Both are ORT's to own. This is not "zero
+ * allocation" — keep the claim honest, a profiler is the arbiter.
  */
 @Suppress("UNCHECKED_CAST")
 internal class OnnxWakeWordPipeline(
@@ -104,6 +110,32 @@ internal class OnnxWakeWordPipeline(
     private val featureBuffer = ArrayDeque<FloatArray>()
 
     /**
+     * Mel rows that fell out of [melBuffer], kept for reuse. The buffer is
+     * bounded, so in the steady state every row appended can take the storage
+     * of one that was just evicted and the hot path stops allocating.
+     */
+    private val melRowPool = ArrayDeque<FloatArray>()
+
+    /** The same idea as [melRowPool], for the 96-dim embeddings. */
+    private val featurePool = ArrayDeque<FloatArray>()
+
+    /**
+     * Reused embedding input, `[1][76][32][1]`. Allocating this per frame meant
+     * 2432 one-element FloatArrays every 80 ms — by a wide margin the largest
+     * source of garbage on a path that runs forever. Every element is written
+     * before the tensor is built, and the tensor is closed before the next fill.
+     */
+    private val embeddingInput =
+        Array(1) { Array(MEL_EMBEDDING_WINDOW) { Array(MEL_BINS) { FloatArray(1) } } }
+
+    /**
+     * Reused classifier input, `[1][16][96]`. The rows are references into
+     * [featureBuffer], replaced wholesale each call, so the placeholder they
+     * start out pointing at is never read.
+     */
+    private val classifierInput = Array(1) { Array(CLASSIFIER_FRAMES) { EMPTY_FEATURE } }
+
+    /**
      * Rows appended to [melBuffer] by each of the last [CLASSIFIER_FRAMES]
      * frames. Re-arming after the gate closes has to rebuild the embeddings for
      * a run of earlier frames, and that means knowing where each of those
@@ -152,6 +184,8 @@ internal class OnnxWakeWordPipeline(
         gatedFrames = 0
         melBuffer.clear()
         featureBuffer.clear()
+        melRowPool.clear()
+        featurePool.clear()
         matcher.reset()
         gate.reset()
         prefillFeatures()
@@ -258,9 +292,11 @@ internal class OnnxWakeWordPipeline(
         if (rows.isEmpty()) return false
         probe?.onMelRows(rows.size)
         for (row in rows) {
-            melBuffer.addLast(FloatArray(MEL_BINS) { row[it] / 10f + 2f })
+            val stored = melRowPool.removeLastOrNull() ?: FloatArray(MEL_BINS)
+            for (bin in 0 until MEL_BINS) stored[bin] = row[bin] / 10f + 2f
+            melBuffer.addLast(stored)
         }
-        while (melBuffer.size > MEL_BUFFER_MAX) melBuffer.removeFirst()
+        while (melBuffer.size > MEL_BUFFER_MAX) melRowPool.addLast(melBuffer.removeFirst())
         recordRowCount(rows.size)
         return true
     }
@@ -290,28 +326,35 @@ internal class OnnxWakeWordPipeline(
         val end = melBuffer.size - rowsBack
         val base = end - MEL_EMBEDDING_WINDOW
         if (base < 0) return false
-        val x = Array(1) { Array(MEL_EMBEDDING_WINDOW) { Array(MEL_BINS) { FloatArray(1) } } }
+        val x = embeddingInput
         for (k in 0 until MEL_EMBEDDING_WINDOW) {
             val row = melBuffer[base + k]
-            for (w in 0 until MEL_BINS) x[0][k][w][0] = row[w]
+            val slot = x[0][k]
+            for (w in 0 until MEL_BINS) slot[w][0] = row[w]
         }
 
         val tensor = OnnxTensor.createTensor(env, x)
         val embedding = try {
             embeddingSession.run(mapOf(embeddingSession.inputNames.first() to tensor)).use { result ->
-                (result.get(0).value as Array<Array<Array<FloatArray>>>)[0][0][0].copyOf()
+                val out = (result.get(0).value as Array<Array<Array<FloatArray>>>)[0][0][0]
+                // Recycled rather than copyOf()'d. Safe because classify()
+                // refills every slot of classifierInput before it reads them,
+                // so no evicted row is ever read after being handed back.
+                val stored = featurePool.removeLastOrNull() ?: FloatArray(FEATURE_DIM)
+                out.copyInto(stored)
+                stored
             }
         } finally {
             tensor.close()
         }
         featureBuffer.addLast(embedding)
-        while (featureBuffer.size > FEATURE_BUFFER_MAX) featureBuffer.removeFirst()
+        while (featureBuffer.size > FEATURE_BUFFER_MAX) featurePool.addLast(featureBuffer.removeFirst())
         return true
     }
 
     private fun classify(): Float? {
         if (featureBuffer.size < CLASSIFIER_FRAMES) return null
-        val x = Array(1) { Array(CLASSIFIER_FRAMES) { FloatArray(FEATURE_DIM) } }
+        val x = classifierInput
         val base = featureBuffer.size - CLASSIFIER_FRAMES
         for (k in 0 until CLASSIFIER_FRAMES) x[0][k] = featureBuffer[base + k]
 
@@ -374,5 +417,8 @@ internal class OnnxWakeWordPipeline(
          */
         private const val MEL_BUFFER_MAX = 240
         private const val FEATURE_BUFFER_MAX = 32
+
+        /** Placeholder for [classifierInput]'s rows; overwritten before every read. */
+        private val EMPTY_FEATURE = FloatArray(FEATURE_DIM)
     }
 }

--- a/app/src/main/java/com/gotcha/service/OnnxWakeWordPipeline.kt
+++ b/app/src/main/java/com/gotcha/service/OnnxWakeWordPipeline.kt
@@ -35,8 +35,23 @@ internal class OnnxWakeWordPipeline(
     private val melSession: OrtSession,
     private val embeddingSession: OrtSession,
     private val classifierSession: OrtSession,
-    private val matcher: WakeWordMatcher
+    private val matcher: WakeWordMatcher,
+    private val probe: PipelineProbe? = null
 ) {
+    /**
+     * Optional measurement hook. Off (null) in production; the instrumented
+     * benchmark passes one in to get the per-stage cost split that decides how
+     * much of the wake-word CPU budget each ONNX model actually owns.
+     */
+    internal interface PipelineProbe {
+        fun onStage(stage: Stage, nanos: Long) {}
+
+        /** Number of mel rows one `melspectrogram.onnx` run emitted. */
+        fun onMelRows(rows: Int) {}
+
+        enum class Stage { MEL, EMBEDDING, CLASSIFY }
+    }
+
     /** Ring buffer of the most recent raw PCM samples. Size caps at [MEL_WINDOW]. */
     private val rawSamples = ShortArray(MEL_WINDOW)
     private var rawStart = 0
@@ -136,9 +151,9 @@ internal class OnnxWakeWordPipeline(
             if (rawCount < MEL_WINDOW) rawCount++
         }
 
-        if (!computeMel()) return false
-        if (!computeEmbedding()) return false
-        val score = classify() ?: return false
+        if (!timed(PipelineProbe.Stage.MEL) { computeMel() }) return false
+        if (!timed(PipelineProbe.Stage.EMBEDDING) { computeEmbedding() }) return false
+        val score = timed(PipelineProbe.Stage.CLASSIFY) { classify() } ?: return false
 
         scoredFrames++
         if (scoredFrames <= WARMUP_FRAMES) return false
@@ -174,6 +189,7 @@ internal class OnnxWakeWordPipeline(
             tensor.close()
         }
         if (rows.isEmpty()) return false
+        probe?.onMelRows(rows.size)
         for (row in rows) {
             melBuffer.addLast(FloatArray(MEL_BINS) { row[it] / 10f + 2f })
         }
@@ -218,6 +234,17 @@ internal class OnnxWakeWordPipeline(
             }
         } finally {
             tensor.close()
+        }
+    }
+
+    /** Times [body] only when a [probe] is attached, so production stays free of the clock reads. */
+    private inline fun <T> timed(stage: PipelineProbe.Stage, body: () -> T): T {
+        val active = probe ?: return body()
+        val startedAt = System.nanoTime()
+        try {
+            return body()
+        } finally {
+            active.onStage(stage, System.nanoTime() - startedAt)
         }
     }
 

--- a/app/src/main/java/com/gotcha/service/OnnxWakeWordPipeline.kt
+++ b/app/src/main/java/com/gotcha/service/OnnxWakeWordPipeline.kt
@@ -81,6 +81,14 @@ internal class OnnxWakeWordPipeline(
         /** The classifier's output for a frame that made it past the gate. */
         fun onScore(score: Float) {}
 
+        /**
+         * Summary statistics of one stage's output. Used to bisect where a
+         * detection failure lives — if the mel values match a working run but
+         * the embeddings do not, the audio is fine and the model is not, and
+         * vice versa. Statistics only: these could not reconstruct speech.
+         */
+        fun onStageStats(stage: Stage, min: Float, mean: Float, max: Float) {}
+
         enum class Stage { MEL, EMBEDDING, CLASSIFY }
     }
 
@@ -291,6 +299,24 @@ internal class OnnxWakeWordPipeline(
         }
         if (rows.isEmpty()) return false
         probe?.onMelRows(rows.size)
+        probe?.let { active ->
+            var min = Float.MAX_VALUE
+            var max = -Float.MAX_VALUE
+            var sum = 0.0
+            for (row in rows) {
+                for (value in row) {
+                    if (value < min) min = value
+                    if (value > max) max = value
+                    sum += value
+                }
+            }
+            active.onStageStats(
+                PipelineProbe.Stage.MEL,
+                min,
+                (sum / (rows.size * MEL_BINS)).toFloat(),
+                max
+            )
+        }
         for (row in rows) {
             val stored = melRowPool.removeLastOrNull() ?: FloatArray(MEL_BINS)
             for (bin in 0 until MEL_BINS) stored[bin] = row[bin] / 10f + 2f
@@ -346,6 +372,22 @@ internal class OnnxWakeWordPipeline(
             }
         } finally {
             tensor.close()
+        }
+        probe?.let { active ->
+            var min = Float.MAX_VALUE
+            var max = -Float.MAX_VALUE
+            var sum = 0.0
+            for (value in embedding) {
+                if (value < min) min = value
+                if (value > max) max = value
+                sum += value
+            }
+            active.onStageStats(
+                PipelineProbe.Stage.EMBEDDING,
+                min,
+                (sum / embedding.size).toFloat(),
+                max
+            )
         }
         featureBuffer.addLast(embedding)
         while (featureBuffer.size > FEATURE_BUFFER_MAX) featurePool.addLast(featureBuffer.removeFirst())

--- a/app/src/main/java/com/gotcha/service/OnnxWakeWordPipeline.kt
+++ b/app/src/main/java/com/gotcha/service/OnnxWakeWordPipeline.kt
@@ -22,6 +22,25 @@ import java.nio.FloatBuffer
  * The first [WARMUP_FRAMES] scored frames are ignored so the feature buffers
  * fill up before anything can be detected.
  *
+ * ## Energy gating (issue #37)
+ *
+ * Steps 1 and 2 above are ~8% of a frame's cost; step 3 is the rest. So the
+ * mel front-end runs on every frame and [WakeWordGate] decides whether to pay
+ * for the embedding backbone. When the room is quiet the pipeline is doing
+ * mel + an RMS, and nothing else.
+ *
+ * Re-arming is **exact**, not approximate. Because `melBuffer` kept filling
+ * while the gate was shut, [replayGatedEmbeddings] can rebuild the skipped
+ * embeddings from the real audio that produced them, so the classifier sees
+ * bit-for-bit the window an ungated run would have handed it. That is what
+ * `OnnxWakeWordPipelineGateTest` asserts, and it is why gating cannot cost a
+ * detection — including when the gate closes mid-phrase.
+ *
+ * The one thing gating trades away is CPU in a *choppy* room: each re-arm
+ * replays up to 15 embeddings, which only pays for itself if the quiet gap was
+ * longer than ~1.3 s. `WakeWordGate`'s hangover is what keeps gaps that short
+ * from re-arming at all.
+ *
  * The hot path avoids per-frame GC pressure: the raw PCM ring buffer, the
  * combined feed buffer, the frame buffer, and the mel window are all
  * pre-allocated once and reused. The per-row mel arrays, `toList()` snapshots,
@@ -36,6 +55,7 @@ internal class OnnxWakeWordPipeline(
     private val embeddingSession: OrtSession,
     private val classifierSession: OrtSession,
     private val matcher: WakeWordMatcher,
+    private val gate: WakeWordGate = WakeWordGate(),
     private val probe: PipelineProbe? = null
 ) {
     /**
@@ -49,6 +69,12 @@ internal class OnnxWakeWordPipeline(
         /** Number of mel rows one `melspectrogram.onnx` run emitted. */
         fun onMelRows(rows: Int) {}
 
+        /** A frame whose embedding stage was skipped by [WakeWordGate]. */
+        fun onGated() {}
+
+        /** The classifier's output for a frame that made it past the gate. */
+        fun onScore(score: Float) {}
+
         enum class Stage { MEL, EMBEDDING, CLASSIFY }
     }
 
@@ -59,11 +85,13 @@ internal class OnnxWakeWordPipeline(
 
     /**
      * Scratch buffer that holds the current feed's samples plus whatever was
-     * carried over from the previous feed. Bounded by
-     * [MEL_WINDOW] + [FRAME_SIZE], which is the worst case when [feed] is
-     * called with a full [FRAME_SIZE] shortly after a remainder was kept.
+     * carried over from the previous feed. [feed] takes whatever the caller's
+     * `AudioRecord.read` returned — several frames at a time, since the reads
+     * were batched to cut wakeups — so this grows to fit the largest feed seen
+     * and is then reused. The carried-over remainder is always shorter than
+     * [FRAME_SIZE].
      */
-    private val combined = ShortArray(MEL_WINDOW + FRAME_SIZE)
+    private var combined = ShortArray(MEL_WINDOW + FRAME_SIZE)
     private var combinedLength = 0
 
     /** Reused destination for each extracted 80 ms frame. */
@@ -74,6 +102,20 @@ internal class OnnxWakeWordPipeline(
 
     private val melBuffer = ArrayDeque<FloatArray>()
     private val featureBuffer = ArrayDeque<FloatArray>()
+
+    /**
+     * Rows appended to [melBuffer] by each of the last [CLASSIFIER_FRAMES]
+     * frames. Re-arming after the gate closes has to rebuild the embeddings for
+     * a run of earlier frames, and that means knowing where each of those
+     * frames ended in [melBuffer]. Measured to be a flat 8 rows per frame, but
+     * recording it beats hardcoding a number the bundled graph could change.
+     */
+    private val rowCounts = IntArray(CLASSIFIER_FRAMES)
+    private var rowCountHead = 0
+    private var rowCountFilled = 0
+
+    /** Consecutive frames whose embedding was skipped because the gate was shut. */
+    private var gatedFrames = 0
 
     private var remainder = ShortArray(0)
     private var scoredFrames = 0
@@ -105,9 +147,13 @@ internal class OnnxWakeWordPipeline(
         combinedLength = 0
         remainder = ShortArray(0)
         scoredFrames = 0
+        rowCountHead = 0
+        rowCountFilled = 0
+        gatedFrames = 0
         melBuffer.clear()
         featureBuffer.clear()
         matcher.reset()
+        gate.reset()
         prefillFeatures()
     }
 
@@ -116,6 +162,8 @@ internal class OnnxWakeWordPipeline(
         var detected = false
 
         // Concatenate remainder + new samples into the reusable combined buffer.
+        val needed = remainder.size + count
+        if (combined.size < needed) combined = ShortArray(needed)
         combinedLength = 0
         if (remainder.isNotEmpty()) {
             System.arraycopy(remainder, 0, combined, 0, remainder.size)
@@ -151,9 +199,28 @@ internal class OnnxWakeWordPipeline(
             if (rawCount < MEL_WINDOW) rawCount++
         }
 
+        val open = gate.onFrame(frame, FRAME_SIZE)
+
+        // The mel front-end runs unconditionally even while the gate is shut.
+        // It is ~8% of the chain's cost, and keeping it warm is what makes
+        // re-arming exact: every mel row the embedding stage skipped is still
+        // in melBuffer, so the classifier window can be rebuilt from real audio
+        // instead of from whatever silence-shaped stand-in was available.
         if (!timed(PipelineProbe.Stage.MEL) { computeMel() }) return false
+
+        if (!open) {
+            if (gatedFrames < CLASSIFIER_FRAMES) gatedFrames++
+            probe?.onGated()
+            return false
+        }
+        if (gatedFrames > 0) {
+            replayGatedEmbeddings(gatedFrames)
+            gatedFrames = 0
+        }
+
         if (!timed(PipelineProbe.Stage.EMBEDDING) { computeEmbedding() }) return false
         val score = timed(PipelineProbe.Stage.CLASSIFY) { classify() } ?: return false
+        probe?.onScore(score)
 
         scoredFrames++
         if (scoredFrames <= WARMUP_FRAMES) return false
@@ -194,16 +261,38 @@ internal class OnnxWakeWordPipeline(
             melBuffer.addLast(FloatArray(MEL_BINS) { row[it] / 10f + 2f })
         }
         while (melBuffer.size > MEL_BUFFER_MAX) melBuffer.removeFirst()
+        recordRowCount(rows.size)
         return true
     }
 
-    private fun computeEmbedding(): Boolean {
-        if (melBuffer.size < MEL_EMBEDDING_WINDOW) return false
-        val mels = melBuffer.toList()
+    /**
+     * Rebuilds the embeddings for the [missedFrames] frames the gate skipped,
+     * oldest first, so the classifier sees the same 16-embedding window it
+     * would have seen had the gate never closed.
+     *
+     * Only the last [CLASSIFIER_FRAMES] − 1 matter: anything older has already
+     * fallen out of the classifier's window, and the entries still sitting in
+     * [featureBuffer] from before the gate closed are exactly the ones an
+     * ungated run would have there.
+     */
+    private fun replayGatedEmbeddings(missedFrames: Int) {
+        val replay = minOf(missedFrames, CLASSIFIER_FRAMES - 1, rowCountFilled - 1)
+        for (framesBack in replay downTo 1) {
+            timed(PipelineProbe.Stage.EMBEDDING) { computeEmbedding(rowsInLast(framesBack)) }
+        }
+    }
+
+    /**
+     * Runs the embedding model over the 76 mel rows ending [rowsBack] rows
+     * before the end of [melBuffer]. [rowsBack] of 0 is the current frame.
+     */
+    private fun computeEmbedding(rowsBack: Int = 0): Boolean {
+        val end = melBuffer.size - rowsBack
+        val base = end - MEL_EMBEDDING_WINDOW
+        if (base < 0) return false
         val x = Array(1) { Array(MEL_EMBEDDING_WINDOW) { Array(MEL_BINS) { FloatArray(1) } } }
-        val base = mels.size - MEL_EMBEDDING_WINDOW
         for (k in 0 until MEL_EMBEDDING_WINDOW) {
-            val row = mels[base + k]
+            val row = melBuffer[base + k]
             for (w in 0 until MEL_BINS) x[0][k][w][0] = row[w]
         }
 
@@ -222,10 +311,9 @@ internal class OnnxWakeWordPipeline(
 
     private fun classify(): Float? {
         if (featureBuffer.size < CLASSIFIER_FRAMES) return null
-        val features = featureBuffer.toList()
         val x = Array(1) { Array(CLASSIFIER_FRAMES) { FloatArray(FEATURE_DIM) } }
-        val base = features.size - CLASSIFIER_FRAMES
-        for (k in 0 until CLASSIFIER_FRAMES) x[0][k] = features[base + k]
+        val base = featureBuffer.size - CLASSIFIER_FRAMES
+        for (k in 0 until CLASSIFIER_FRAMES) x[0][k] = featureBuffer[base + k]
 
         val tensor = OnnxTensor.createTensor(env, x)
         return try {
@@ -235,6 +323,21 @@ internal class OnnxWakeWordPipeline(
         } finally {
             tensor.close()
         }
+    }
+
+    private fun recordRowCount(rows: Int) {
+        rowCounts[rowCountHead] = rows
+        rowCountHead = (rowCountHead + 1) % CLASSIFIER_FRAMES
+        if (rowCountFilled < CLASSIFIER_FRAMES) rowCountFilled++
+    }
+
+    /** Rows appended by the most recent [frames] frames, current frame included. */
+    private fun rowsInLast(frames: Int): Int {
+        var total = 0
+        for (k in 1..frames) {
+            total += rowCounts[(rowCountHead - k + CLASSIFIER_FRAMES) % CLASSIFIER_FRAMES]
+        }
+        return total
     }
 
     /** Times [body] only when a [probe] is attached, so production stays free of the clock reads. */
@@ -261,7 +364,15 @@ internal class OnnxWakeWordPipeline(
         const val FEATURE_DIM = 96
         const val CLASSIFIER_FRAMES = 16
         private const val WARMUP_FRAMES = 5
-        private const val MEL_BUFFER_MAX = 120
+
+        /**
+         * Mel rows kept around. Re-arming after the gate closes has to rebuild
+         * the embeddings for up to [CLASSIFIER_FRAMES] − 1 earlier frames, and
+         * the oldest of those still needs a full [MEL_EMBEDDING_WINDOW] of rows
+         * behind it: 76 + 15 × 8 = 196 at the measured 8 rows per frame. 240
+         * leaves headroom without mattering (240 × 32 floats ≈ 30 KB).
+         */
+        private const val MEL_BUFFER_MAX = 240
         private const val FEATURE_BUFFER_MAX = 32
     }
 }

--- a/app/src/main/java/com/gotcha/service/ScreenLensController.kt
+++ b/app/src/main/java/com/gotcha/service/ScreenLensController.kt
@@ -43,7 +43,7 @@ class ScreenLensController(
     private fun currentColors(): OverlaySkin = overlaySkin(
         appContext,
         runCatching { com.gotcha.data.SettingsRepository(appContext).load().skinId }
-            .getOrDefault(Skins.DEFAULT_ID)
+            .getOrDefault(Skins.OVERLAY_FALLBACK_ID)
     )
 
     private val windowManager = appContext.getSystemService(Context.WINDOW_SERVICE) as WindowManager

--- a/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
+++ b/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
@@ -79,7 +79,21 @@ class WakeWordDetector(
         val embedding: OrtSession,
         val classifier: OrtSession
     ) {
+        private val closed = AtomicBoolean(false)
+
+        /**
+         * Idempotent. The reference count should make a second close
+         * unreachable — but ORT throws on one, and an ownership mistake here
+         * should not be the thing that takes down a user's assistant. In debug
+         * builds it complains loudly so the mistake still gets found.
+         */
         fun close() {
+            if (!closed.compareAndSet(false, true)) {
+                if (BuildConfig.DEBUG) {
+                    Log.w(TAG, "Sessions closed twice", Throwable("second close from"))
+                }
+                return
+            }
             mel.close()
             embedding.close()
             classifier.close()
@@ -188,13 +202,37 @@ class WakeWordDetector(
     @SuppressLint("MissingPermission")
     private suspend fun initializeAndListen(generation: Int) {
         val env = OrtEnvironment.getEnvironment()
-        var loadedSessions: Sessions? = null
+        /** Sessions this run holds a use-claim on; released in the finally. */
+        var claimed: Sessions? = null
         var createdRecorder: AudioRecord? = null
         try {
-            // Reuse the sessions from a previous run when this is a resume
-            // after pause(); only a cold start pays the ~2.6 MB model load.
-            val cached = synchronized(stateLock) { sessions }
-            val active = cached ?: loadSessions(env).also { loadedSessions = it }
+            // Claim cached sessions under the very lock that reads them. Reading
+            // first and claiming later leaves a window where sessionUsers is 0,
+            // and a release() landing in that window frees the models this run
+            // is about to adopt — which is exactly how it went wrong.
+            synchronized(stateLock) {
+                if (!running.get() || generation != this.generation) return
+                sessions?.let {
+                    claimed = it
+                    sessionUsers++
+                }
+            }
+            if (claimed == null) {
+                // Cold start. The load is slow, so it happens off the lock; the
+                // result is unpublished until the block below, so nothing else
+                // can see it and no claim is needed yet.
+                val loaded = loadSessions(env)
+                synchronized(stateLock) {
+                    if (!running.get() || generation != this.generation) {
+                        loaded.close()
+                        return
+                    }
+                    sessions = loaded
+                    claimed = loaded
+                    sessionUsers++
+                }
+            }
+            val active = claimed ?: return
             // Bytes, not samples: 16-bit mono. A minimum-size buffer forces a
             // wakeup every 80 ms and leaves no room to absorb the burst of work
             // that re-arming the gate can cost, so ask for ~1.3 s instead. The
@@ -217,34 +255,29 @@ class WakeWordDetector(
 
             synchronized(stateLock) {
                 if (!running.get() || generation != this.generation) {
-                    // Stopped while loading. Only discard sessions this run
-                    // created — a cached set belongs to whoever comes next.
-                    loadedSessions?.close()
+                    // Stopped while starting up. The claim is dropped by the
+                    // finally below, which closes the models if a release()
+                    // was waiting on this run to let go of them.
                     createdRecorder.release()
                     return
                 }
-                sessions = active
                 recorder = createdRecorder
-                // Claim the models for as long as this loop runs, so a
-                // concurrent release() defers closing them rather than pulling
-                // them out from under an in-flight inference.
-                sessionUsers++
             }
             scope.launch(Dispatchers.Main) { onStarted() }
-            try {
-                listen(
-                    generation = generation,
-                    env = env,
-                    localRecorder = createdRecorder,
-                    localSessions = active
-                )
-            } finally {
-                releaseSessionUse()
-            }
+            listen(
+                generation = generation,
+                env = env,
+                localRecorder = createdRecorder,
+                localSessions = active
+            )
         } catch (e: Exception) {
-            loadedSessions?.close()
+            // Deliberately does not close the sessions: once published they are
+            // owned by the reference count, and closing them here raced with a
+            // concurrent run that had legitimately adopted them.
             createdRecorder?.release()
             fail(startupError(e), e, generation)
+        } finally {
+            if (claimed != null) releaseSessionUse()
         }
     }
 

--- a/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
+++ b/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
@@ -9,6 +9,7 @@ import android.content.pm.PackageManager
 import android.media.AudioFormat
 import android.media.AudioRecord
 import android.media.MediaRecorder
+import android.os.Process
 import android.util.Log
 import androidx.core.content.ContextCompat
 import kotlinx.coroutines.CoroutineScope
@@ -285,6 +286,12 @@ class WakeWordDetector(
             classifierSession = localSessions.classifier,
             matcher = matcher
         )
+        // An audio capture loop should be scheduled like one. At the default
+        // priority of a Dispatchers.IO thread this loop competes with ordinary
+        // background work, and a preempted read is a dropped frame. Restored
+        // afterwards because the thread goes back to the shared IO pool.
+        val callerPriority = Process.getThreadPriority(Process.myTid())
+        Process.setThreadPriority(Process.THREAD_PRIORITY_AUDIO)
         try {
             localRecorder.startRecording()
             while (running.get()) {
@@ -318,6 +325,8 @@ class WakeWordDetector(
             }
         } catch (e: Exception) {
             if (running.get()) fail("Wake word listening stopped unexpectedly.", e, generation)
+        } finally {
+            Process.setThreadPriority(callerPriority)
         }
     }
 

--- a/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
+++ b/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
@@ -117,11 +117,15 @@ class WakeWordDetector(
             createdMel = loadSession(env, "$modelAssetDir/melspectrogram.onnx")
             createdEmbedding = loadSession(env, "$modelAssetDir/embedding_model.onnx")
             createdClassifier = loadSession(env, "$modelAssetDir/$classifierModel")
+            // Bytes, not samples: 16-bit mono. A minimum-size buffer forces a
+            // wakeup every 80 ms and leaves no room to absorb the burst of work
+            // that re-arming the gate can cost, so ask for ~1.3 s instead. The
+            // memory is irrelevant (~40 KB); the wakeup rate is not.
             val bufferSize = AudioRecord.getMinBufferSize(
                 OnnxWakeWordPipeline.SAMPLE_RATE,
                 AudioFormat.CHANNEL_IN_MONO,
                 AudioFormat.ENCODING_PCM_16BIT
-            ).coerceAtLeast(OnnxWakeWordPipeline.FRAME_SIZE * 2)
+            ).coerceAtLeast(OnnxWakeWordPipeline.FRAME_SIZE * 2 * BUFFER_FRAMES)
             createdRecorder = AudioRecord(
                 MediaRecorder.AudioSource.VOICE_RECOGNITION,
                 OnnxWakeWordPipeline.SAMPLE_RATE,
@@ -173,7 +177,10 @@ class WakeWordDetector(
         localEmbedding: OrtSession,
         localClassifier: OrtSession
     ) {
-        val frame = ShortArray(OnnxWakeWordPipeline.FRAME_SIZE)
+        // Read several 80 ms frames per wakeup rather than one. The pipeline
+        // splits whatever it is handed back into frames, so this changes only
+        // how often the CPU is woken: 3.1 times a second instead of 12.5.
+        val block = ShortArray(OnnxWakeWordPipeline.FRAME_SIZE * READ_FRAMES)
         val pipeline = OnnxWakeWordPipeline(
             env = env,
             melSession = localMel,
@@ -184,19 +191,25 @@ class WakeWordDetector(
         try {
             localRecorder.startRecording()
             while (running.get()) {
-                val count = localRecorder.read(frame, 0, frame.size)
+                val count = localRecorder.read(block, 0, block.size)
                 if (count < 0) {
                     if (running.get()) throw IOException("AudioRecord read failed: $count")
                     return
                 }
-                if (count == 0) continue
+                // A blocking read should never come back empty, but returning
+                // to the top on 0 would spin the loop at full tilt if one ever
+                // did. Wait out a frame instead.
+                if (count == 0) {
+                    Thread.sleep(FRAME_DURATION_MS)
+                    continue
+                }
 
                 var detected = false
                 synchronized(stateLock) {
                     if (!running.get() || recorder !== localRecorder || generation != this.generation) {
                         return
                     }
-                    if (pipeline.feed(frame, count)) {
+                    if (pipeline.feed(block, count)) {
                         detected = true
                         running.set(false)
                     }
@@ -238,5 +251,17 @@ class WakeWordDetector(
         const val MODEL_ASSET_DIR = "openwakeword"
         const val CLASSIFIER_MODEL = "hey_gotcha.onnx"
         private const val TAG = "WakeWordDetector"
+
+        /**
+         * 80 ms frames drained per `AudioRecord.read`. Four cuts the wakeup
+         * rate by 4× and costs up to 320 ms of extra trigger latency, on top of
+         * the matcher's existing 160 ms patience.
+         */
+        private const val READ_FRAMES = 4
+
+        /** ~1.3 s of audio: enough headroom that a slow frame cannot overrun the buffer. */
+        private const val BUFFER_FRAMES = 16
+
+        private const val FRAME_DURATION_MS = 80L
     }
 }

--- a/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
+++ b/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
@@ -164,9 +164,41 @@ class WakeWordDetector(
         }
     }
 
+    /**
+     * Loads one model with a thread configuration suited to a 12.5 Hz duty
+     * cycle (issue #37). ONNX Runtime's defaults are tuned for throughput on a
+     * busy server, and both of them are wrong here:
+     *
+     * - The intra-op thread count defaults to the core count, so three sessions
+     *   spin up three pools and each 80 ms tick wakes several cores for a few
+     *   milliseconds of work that fits comfortably on one.
+     * - The pools busy-spin waiting for the next `run()`. At this duty cycle
+     *   that is mostly burning CPU doing nothing, and it stops the SoC dropping
+     *   to a low-power state between frames.
+     *
+     * Measured wall time barely moves (4.14 ms → 4.41 ms per frame at the
+     * median), while p95 on the embedding stage improves a lot (11.35 ms →
+     * 4.21 ms). That is expected — wall time is not core time, and this trades
+     * a little median latency for far less total core time and no spinning.
+     * The battery half of the claim needs batterystats, not the benchmark.
+     *
+     * Deliberately not set: `setOptimizationLevel(ORT_ENABLE_ALL)`, which is
+     * already the default and would be a no-op. XNNPACK remains an untested
+     * lever — contrary to a common claim it is *not* the default CPU EP in the
+     * Android AAR (the shipped 1.26.0 exposes `addXnnpack` as explicit opt-in
+     * and defaults to MLAS), so it is worth trying, but as its own measured
+     * experiment.
+     */
     private fun loadSession(env: OrtEnvironment, assetPath: String): OrtSession {
         val bytes = appContext.assets.open(assetPath).use { it.readBytes() }
-        return env.createSession(bytes)
+        return OrtSession.SessionOptions().use { options ->
+            options.setIntraOpNumThreads(1)
+            options.setInterOpNumThreads(1)
+            options.setExecutionMode(OrtSession.SessionOptions.ExecutionMode.SEQUENTIAL)
+            options.addConfigEntry("session.intra_op.allow_spinning", "0")
+            options.addConfigEntry("session.inter_op.allow_spinning", "0")
+            env.createSession(bytes, options)
+        }
     }
 
     private fun listen(

--- a/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
+++ b/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
@@ -12,6 +12,7 @@ import android.media.MediaRecorder
 import android.os.Process
 import android.util.Log
 import androidx.core.content.ContextCompat
+import com.gotcha.BuildConfig
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -87,6 +88,7 @@ class WakeWordDetector(
             matcher = WakeWordMatcher(sensitivityProvider().coerceIn(0f, 1f))
             running.set(true)
             val startGeneration = generation
+            if (BuildConfig.DEBUG) Log.d(TAG, "start(): generation=$startGeneration")
             job = scope.launch(Dispatchers.IO) { initializeAndListen(startGeneration) }
         }
         return true
@@ -122,6 +124,9 @@ class WakeWordDetector(
     }
 
     private fun teardown(closeSessions: Boolean) {
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, if (closeSessions) "release()" else "pause()", Throwable("called from"))
+        }
         val oldRecorder: AudioRecord?
         val oldSessions: Sessions?
         val oldJob: Job?
@@ -279,13 +284,37 @@ class WakeWordDetector(
         // splits whatever it is handed back into frames, so this changes only
         // how often the CPU is woken: 3.1 times a second instead of 12.5.
         val block = ShortArray(OnnxWakeWordPipeline.FRAME_SIZE * READ_FRAMES)
+        // Debug builds get a running account of what the listener is hearing.
+        // "The wake word stopped working" is otherwise unfalsifiable from the
+        // outside: a listener that holds the mic and scores nothing looks
+        // exactly like one that is reading silence.
+        val telemetry = if (BuildConfig.DEBUG) ListenTelemetry() else null
         val pipeline = OnnxWakeWordPipeline(
             env = env,
             melSession = localSessions.mel,
             embeddingSession = localSessions.embedding,
             classifierSession = localSessions.classifier,
-            matcher = matcher
+            matcher = matcher,
+            probe = telemetry
         )
+        telemetry?.let {
+            // The listener can be running, holding the mic and reading
+            // plausible levels while still being fed the wrong thing — a
+            // different physical mic, or a stream mangled by voice-comm
+            // processing left behind by a call. Record what we actually got.
+            val audio = appContext.getSystemService(android.content.Context.AUDIO_SERVICE)
+                as android.media.AudioManager
+            Log.d(
+                TAG,
+                "listening: threshold=${matcher.threshold()} readFrames=$READ_FRAMES " +
+                    "rate=${localRecorder.sampleRate} ch=${localRecorder.channelCount} " +
+                    "session=${localRecorder.audioSessionId} " +
+                    "route=${describeRoute(localRecorder)} " +
+                    "audioMode=${audio.mode} " +
+                    "micMute=${audio.isMicrophoneMute} " +
+                    "bufFrames=${localRecorder.bufferSizeInFrames}"
+            )
+        }
         // An audio capture loop should be scheduled like one. At the default
         // priority of a Dispatchers.IO thread this loop competes with ordinary
         // background work, and a preempted read is a dropped frame. Restored
@@ -308,6 +337,8 @@ class WakeWordDetector(
                     continue
                 }
 
+                telemetry?.onRead(WakeWordGate.rmsDb(block, count))
+
                 var detected = false
                 synchronized(stateLock) {
                     if (!running.get() || recorder !== localRecorder || generation != this.generation) {
@@ -327,6 +358,100 @@ class WakeWordDetector(
             if (running.get()) fail("Wake word listening stopped unexpectedly.", e, generation)
         } finally {
             Process.setThreadPriority(callerPriority)
+        }
+    }
+
+    private fun describeRoute(recorder: AudioRecord): String {
+        val device = recorder.routedDevice ?: return "none"
+        val effects = buildList {
+            if (android.media.audiofx.AcousticEchoCanceler.isAvailable()) add("aec-avail")
+            if (android.media.audiofx.NoiseSuppressor.isAvailable()) add("ns-avail")
+            if (android.media.audiofx.AutomaticGainControl.isAvailable()) add("agc-avail")
+        }
+        return "type=${device.type} product=${device.productName} address=${device.address} " +
+            "effects=${effects.joinToString("|")}"
+    }
+
+    /**
+     * Debug-only running summary of what the listener hears. Reports levels and
+     * scores, never audio — nothing here could reconstruct what was said.
+     */
+    private class ListenTelemetry : OnnxWakeWordPipeline.PipelineProbe {
+        private var reads = 0
+        private var frames = 0
+        private var gated = 0
+        private var scored = 0
+        private var peakScore = 0f
+        private var peakRms = -200f
+        private var quietestRms = 200f
+        private var melMin = Float.MAX_VALUE
+        private var melMax = -Float.MAX_VALUE
+        private var melMean = 0f
+        private var embMin = Float.MAX_VALUE
+        private var embMax = -Float.MAX_VALUE
+        private var embMean = 0f
+
+        override fun onStageStats(
+            stage: OnnxWakeWordPipeline.PipelineProbe.Stage,
+            min: Float,
+            mean: Float,
+            max: Float
+        ) {
+            when (stage) {
+                OnnxWakeWordPipeline.PipelineProbe.Stage.MEL -> {
+                    if (min < melMin) melMin = min
+                    if (max > melMax) melMax = max
+                    melMean = mean
+                }
+                OnnxWakeWordPipeline.PipelineProbe.Stage.EMBEDDING -> {
+                    if (min < embMin) embMin = min
+                    if (max > embMax) embMax = max
+                    embMean = mean
+                }
+                else -> Unit
+            }
+        }
+
+        fun onRead(rmsDb: Float) {
+            reads++
+            if (rmsDb > peakRms) peakRms = rmsDb
+            if (rmsDb < quietestRms) quietestRms = rmsDb
+            if (reads % REPORT_EVERY_READS != 0) return
+            Log.d(
+                TAG,
+                "heard: rms ${"%.1f".format(quietestRms)}..${"%.1f".format(peakRms)} dBFS, " +
+                    "frames=$frames scored=$scored gated=$gated peakScore=${"%.3f".format(peakScore)} " +
+                    "mel[${"%.2f".format(melMin)}..${"%.2f".format(melMax)} avg ${"%.2f".format(melMean)}] " +
+                    "emb[${"%.2f".format(embMin)}..${"%.2f".format(embMax)} avg ${"%.2f".format(embMean)}]"
+            )
+            melMin = Float.MAX_VALUE
+            melMax = -Float.MAX_VALUE
+            embMin = Float.MAX_VALUE
+            embMax = -Float.MAX_VALUE
+            peakRms = -200f
+            quietestRms = 200f
+            peakScore = 0f
+            frames = 0
+            scored = 0
+            gated = 0
+        }
+
+        override fun onMelRows(rows: Int) {
+            frames++
+        }
+
+        override fun onGated() {
+            gated++
+        }
+
+        override fun onScore(score: Float) {
+            scored++
+            if (score > peakScore) peakScore = score
+        }
+
+        private companion object {
+            /** ~3 s at 4 frames per read. */
+            const val REPORT_EVERY_READS = 10
         }
     }
 

--- a/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
+++ b/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
@@ -156,7 +156,12 @@ class WakeWordDetector(
     }
 
     private fun teardown(closeSessions: Boolean) {
-        GotchaLog.d(TAG, Throwable("called from")) { if (closeSessions) "release()" else "pause()" }
+        // The Throwable snapshots the call stack for debug diagnostics; constructing
+        // it unconditionally would do that work on every pause()/release() in
+        // release builds too, so keep it behind the debug guard.
+        if (BuildConfig.DEBUG) {
+            GotchaLog.d(TAG, Throwable("called from")) { if (closeSessions) "release()" else "pause()" }
+        }
         val oldRecorder: AudioRecord?
         var oldSessions: Sessions? = null
         val oldJob: Job?

--- a/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
+++ b/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
@@ -54,6 +54,23 @@ class WakeWordDetector(
      * [release] closes them — see [pause] for why.
      */
     private var sessions: Sessions? = null
+
+    /**
+     * How many listen loops are currently running inference against [sessions].
+     * Normally 0 or 1; briefly 2 when a stale loop has not yet noticed it was
+     * superseded. Guarded by [stateLock].
+     *
+     * This exists so the inference itself does not have to hold [stateLock].
+     * A `run()` on the embedding model, plus the burst a gate re-arm can
+     * trigger, is tens of milliseconds — long enough that holding the lock
+     * across it would stall any main-thread `pause()`/`release()` behind it.
+     * Instead the lock is held only for the state checks, and the models are
+     * kept alive by whoever is using them.
+     */
+    private var sessionUsers = 0
+
+    /** Sessions a [release] wanted to close while a listen loop still held them. */
+    private var pendingClose: Sessions? = null
     private var matcher = WakeWordMatcher(WakeWordMatcher.DEFAULT_SENSITIVITY)
     private var generation = 0
 
@@ -128,7 +145,7 @@ class WakeWordDetector(
             Log.d(TAG, if (closeSessions) "release()" else "pause()", Throwable("called from"))
         }
         val oldRecorder: AudioRecord?
-        val oldSessions: Sessions?
+        var oldSessions: Sessions? = null
         val oldJob: Job?
         synchronized(stateLock) {
             running.set(false)
@@ -136,10 +153,23 @@ class WakeWordDetector(
             matcher.reset()
             oldRecorder = recorder
             oldJob = job
-            oldSessions = if (closeSessions) sessions else null
             recorder = null
             job = null
-            if (closeSessions) sessions = null
+            if (closeSessions) {
+                val doomed = sessions
+                sessions = null
+                if (doomed != null) {
+                    if (sessionUsers > 0) {
+                        // A listen loop is mid-inference against these. Closing
+                        // them here would free models out from under a running
+                        // OrtSession.run() — hand the close to whoever finishes
+                        // last instead.
+                        pendingClose = doomed
+                    } else {
+                        oldSessions = doomed
+                    }
+                }
+            }
         }
         oldRecorder?.let {
             try {
@@ -195,14 +225,22 @@ class WakeWordDetector(
                 }
                 sessions = active
                 recorder = createdRecorder
+                // Claim the models for as long as this loop runs, so a
+                // concurrent release() defers closing them rather than pulling
+                // them out from under an in-flight inference.
+                sessionUsers++
             }
             scope.launch(Dispatchers.Main) { onStarted() }
-            listen(
-                generation = generation,
-                env = env,
-                localRecorder = createdRecorder,
-                localSessions = active
-            )
+            try {
+                listen(
+                    generation = generation,
+                    env = env,
+                    localRecorder = createdRecorder,
+                    localSessions = active
+                )
+            } finally {
+                releaseSessionUse()
+            }
         } catch (e: Exception) {
             loadedSessions?.close()
             createdRecorder?.release()
@@ -219,6 +257,19 @@ class WakeWordDetector(
     @Volatile
     internal var sessionLoadCount = 0
         private set
+
+    /**
+     * Drops this loop's claim on the models, closing them if a [release]
+     * asked for that while the loop was still running.
+     */
+    private fun releaseSessionUse() {
+        val toClose: Sessions?
+        synchronized(stateLock) {
+            sessionUsers--
+            toClose = if (sessionUsers == 0) pendingClose.also { pendingClose = null } else null
+        }
+        toClose?.close()
+    }
 
     /** Loads all three models, closing any that succeeded if a later one fails. */
     private fun loadSessions(env: OrtEnvironment): Sessions {
@@ -346,20 +397,29 @@ class WakeWordDetector(
                     telemetry.onRead(WakeWordGate.rmsDb(block, count))
                 }
 
-                var detected = false
-                synchronized(stateLock) {
-                    if (!running.get() || recorder !== localRecorder || generation != this.generation) {
-                        return
-                    }
-                    if (pipeline.feed(block, count)) {
-                        detected = true
+                // The state check is under the lock; the inference is not. A
+                // batch of four frames, plus the replay a gate re-arm can
+                // trigger, is tens of milliseconds of ONNX — long enough that
+                // running it under the lock would stall a main-thread pause()
+                // or release() behind it. The models cannot be closed while
+                // this loop runs (see sessionUsers), so dropping the lock here
+                // is safe.
+                if (isStale(localRecorder, generation)) return
+                if (!pipeline.feed(block, count)) continue
+
+                // Re-check before acting: the listener may have been paused
+                // while that batch was being processed, in which case this
+                // detection belongs to a listener that no longer exists.
+                val fire = synchronized(stateLock) {
+                    if (isStaleLocked(localRecorder, generation)) {
+                        false
+                    } else {
                         running.set(false)
+                        true
                     }
                 }
-                if (detected) {
-                    scope.launch(Dispatchers.Main) { onDetected() }
-                    return
-                }
+                if (fire) scope.launch(Dispatchers.Main) { onDetected() }
+                return
             }
         } catch (e: Exception) {
             if (running.get()) fail("Wake word listening stopped unexpectedly.", e, generation)
@@ -467,6 +527,13 @@ class WakeWordDetector(
             const val REPORT_EVERY_READS = 10
         }
     }
+
+    private fun isStale(localRecorder: AudioRecord, generation: Int): Boolean =
+        synchronized(stateLock) { isStaleLocked(localRecorder, generation) }
+
+    /** Caller must hold [stateLock]. */
+    private fun isStaleLocked(localRecorder: AudioRecord, generation: Int): Boolean =
+        !running.get() || recorder !== localRecorder || generation != this.generation
 
     private fun fail(message: String, cause: Exception? = null, generation: Int) {
         synchronized(stateLock) {

--- a/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
+++ b/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
@@ -13,6 +13,7 @@ import android.os.Process
 import android.util.Log
 import androidx.core.content.ContextCompat
 import com.gotcha.BuildConfig
+import com.gotcha.util.GotchaLog
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -119,7 +120,7 @@ class WakeWordDetector(
             matcher = WakeWordMatcher(sensitivityProvider().coerceIn(0f, 1f))
             running.set(true)
             val startGeneration = generation
-            if (BuildConfig.DEBUG) Log.d(TAG, "start(): generation=$startGeneration")
+            GotchaLog.d(TAG) { "start(): generation=$startGeneration" }
             job = scope.launch(Dispatchers.IO) { initializeAndListen(startGeneration) }
         }
         return true
@@ -155,9 +156,7 @@ class WakeWordDetector(
     }
 
     private fun teardown(closeSessions: Boolean) {
-        if (BuildConfig.DEBUG) {
-            Log.d(TAG, if (closeSessions) "release()" else "pause()", Throwable("called from"))
-        }
+        GotchaLog.d(TAG, Throwable("called from")) { if (closeSessions) "release()" else "pause()" }
         val oldRecorder: AudioRecord?
         var oldSessions: Sessions? = null
         val oldJob: Job?
@@ -388,8 +387,7 @@ class WakeWordDetector(
             // processing left behind by a call. Record what we actually got.
             val audio = appContext.getSystemService(android.content.Context.AUDIO_SERVICE)
                 as android.media.AudioManager
-            Log.d(
-                TAG,
+            GotchaLog.d(TAG) {
                 "listening: threshold=${matcher.threshold()} readFrames=$READ_FRAMES " +
                     "rate=${localRecorder.sampleRate} ch=${localRecorder.channelCount} " +
                     "session=${localRecorder.audioSessionId} " +
@@ -397,7 +395,7 @@ class WakeWordDetector(
                     "audioMode=${audio.mode} " +
                     "micMute=${audio.isMicrophoneMute} " +
                     "bufFrames=${localRecorder.bufferSizeInFrames}"
-            )
+            }
         }
         // An audio capture loop should be scheduled like one. At the default
         // priority of a Dispatchers.IO thread this loop competes with ordinary
@@ -520,13 +518,12 @@ class WakeWordDetector(
             // Locale.ROOT, not the default: on a decimal-comma device these
             // become "-70,5" and stop being greppable, which is the whole point
             // of the line.
-            Log.d(
-                TAG,
+            GotchaLog.d(TAG) {
                 "heard: rms ${fmt(quietestRms, 1)}..${fmt(peakRms, 1)} dBFS, " +
                     "frames=$frames scored=$scored gated=$gated peakScore=${fmt(peakScore, 3)} " +
                     "mel[${fmt(melMin, 2)}..${fmt(melMax, 2)} avg ${fmt(melMean, 2)}] " +
                     "emb[${fmt(embMin, 2)}..${fmt(embMax, 2)} avg ${fmt(embMean, 2)}]"
-            )
+            }
             melMin = Float.MAX_VALUE
             melMax = -Float.MAX_VALUE
             embMin = Float.MAX_VALUE

--- a/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
+++ b/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
@@ -337,7 +337,14 @@ class WakeWordDetector(
                     continue
                 }
 
-                telemetry?.onRead(WakeWordGate.rmsDb(block, count))
+                // Spelled out rather than `telemetry?.onRead(rmsDb(...))`. Both
+                // skip the RMS scan in release — a safe call does not evaluate
+                // its arguments when the receiver is null — but that is a
+                // subtlety one refactor away from being lost, and this is a
+                // per-frame path in an always-on listener.
+                if (telemetry != null) {
+                    telemetry.onRead(WakeWordGate.rmsDb(block, count))
+                }
 
                 var detected = false
                 synchronized(stateLock) {

--- a/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
+++ b/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
@@ -202,7 +202,7 @@ class WakeWordDetector(
     @SuppressLint("MissingPermission")
     private suspend fun initializeAndListen(generation: Int) {
         val env = OrtEnvironment.getEnvironment()
-        /** Sessions this run holds a use-claim on; released in the finally. */
+        // Sessions this run holds a use-claim on; released in the finally.
         var claimed: Sessions? = null
         var createdRecorder: AudioRecord? = null
         try {

--- a/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
+++ b/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
@@ -25,6 +25,11 @@ import java.util.concurrent.atomic.AtomicBoolean
  * The three ONNX models are read from assets and loaded on an IO coroutine —
  * model load takes tens of milliseconds, so doing it on the service's main
  * thread would show up as a ball-service freeze right after start.
+ *
+ * There are two ways to stop it, and the difference is the point:
+ * [pause] gives up the microphone but keeps the loaded models, for the
+ * constant interruptions of ordinary use; [release] gives up everything, for
+ * when the feature is switched off or the service is going away.
  */
 class WakeWordDetector(
     context: Context,
@@ -41,11 +46,26 @@ class WakeWordDetector(
     private val running = AtomicBoolean(false)
     private var job: Job? = null
     private var recorder: AudioRecord? = null
-    private var melSession: OrtSession? = null
-    private var embeddingSession: OrtSession? = null
-    private var classifierSession: OrtSession? = null
+
+    /**
+     * The three ORT sessions, cached across [pause]/[start] cycles. Only
+     * [release] closes them — see [pause] for why.
+     */
+    private var sessions: Sessions? = null
     private var matcher = WakeWordMatcher(WakeWordMatcher.DEFAULT_SENSITIVITY)
     private var generation = 0
+
+    private class Sessions(
+        val mel: OrtSession,
+        val embedding: OrtSession,
+        val classifier: OrtSession
+    ) {
+        fun close() {
+            mel.close()
+            embedding.close()
+            classifier.close()
+        }
+    }
 
     @Volatile
     var lastError: String? = null
@@ -71,26 +91,49 @@ class WakeWordDetector(
         return true
     }
 
-    fun stop() {
+    /**
+     * Stops listening and **fully releases the microphone**, but keeps the ONNX
+     * sessions loaded for the next [start].
+     *
+     * This is the right call for every transient interruption — a call starting
+     * or ending, the app's own TTS speaking. Those happen constantly: the
+     * service pauses the listener on every single TTS utterance, and before
+     * this split that meant re-reading ~2.6 MB of model bytes out of assets and
+     * rebuilding three ORT sessions each time the app said one sentence.
+     *
+     * The mic is still released here, not merely stopped. That matters beyond
+     * battery: pausing while TTS speaks is a privacy guarantee, not an
+     * optimisation (privacy-data-retention.md §10.3), and "we kept the mic open
+     * but promise we ignored it" is not the same guarantee. Keeping sessions is
+     * safe because a loaded model holds no audio.
+     */
+    fun pause() {
+        teardown(closeSessions = false)
+    }
+
+    /**
+     * Stops listening and frees everything, sessions included. For when the
+     * wake word is switched off or the service is going away — not for the
+     * pause/resume churn of ordinary use.
+     */
+    fun release() {
+        teardown(closeSessions = true)
+    }
+
+    private fun teardown(closeSessions: Boolean) {
         val oldRecorder: AudioRecord?
-        val oldMel: OrtSession?
-        val oldEmbedding: OrtSession?
-        val oldClassifier: OrtSession?
+        val oldSessions: Sessions?
         val oldJob: Job?
         synchronized(stateLock) {
             running.set(false)
             generation++
             matcher.reset()
             oldRecorder = recorder
-            oldMel = melSession
-            oldEmbedding = embeddingSession
-            oldClassifier = classifierSession
             oldJob = job
+            oldSessions = if (closeSessions) sessions else null
             recorder = null
-            melSession = null
-            embeddingSession = null
-            classifierSession = null
             job = null
+            if (closeSessions) sessions = null
         }
         oldRecorder?.let {
             try {
@@ -100,7 +143,7 @@ class WakeWordDetector(
             }
             it.release()
         }
-        closeSessions(oldMel, oldEmbedding, oldClassifier)
+        oldSessions?.close()
         oldJob?.cancel()
     }
 
@@ -109,14 +152,13 @@ class WakeWordDetector(
     @SuppressLint("MissingPermission")
     private suspend fun initializeAndListen(generation: Int) {
         val env = OrtEnvironment.getEnvironment()
-        var createdMel: OrtSession? = null
-        var createdEmbedding: OrtSession? = null
-        var createdClassifier: OrtSession? = null
+        var loadedSessions: Sessions? = null
         var createdRecorder: AudioRecord? = null
         try {
-            createdMel = loadSession(env, "$modelAssetDir/melspectrogram.onnx")
-            createdEmbedding = loadSession(env, "$modelAssetDir/embedding_model.onnx")
-            createdClassifier = loadSession(env, "$modelAssetDir/$classifierModel")
+            // Reuse the sessions from a previous run when this is a resume
+            // after pause(); only a cold start pays the ~2.6 MB model load.
+            val cached = synchronized(stateLock) { sessions }
+            val active = cached ?: loadSessions(env).also { loadedSessions = it }
             // Bytes, not samples: 16-bit mono. A minimum-size buffer forces a
             // wakeup every 80 ms and leaves no room to absorb the burst of work
             // that re-arming the gate can cost, so ask for ~1.3 s instead. The
@@ -139,13 +181,13 @@ class WakeWordDetector(
 
             synchronized(stateLock) {
                 if (!running.get() || generation != this.generation) {
-                    closeSessions(createdMel, createdEmbedding, createdClassifier)
+                    // Stopped while loading. Only discard sessions this run
+                    // created — a cached set belongs to whoever comes next.
+                    loadedSessions?.close()
                     createdRecorder.release()
                     return
                 }
-                melSession = createdMel
-                embeddingSession = createdEmbedding
-                classifierSession = createdClassifier
+                sessions = active
                 recorder = createdRecorder
             }
             scope.launch(Dispatchers.Main) { onStarted() }
@@ -153,14 +195,39 @@ class WakeWordDetector(
                 generation = generation,
                 env = env,
                 localRecorder = createdRecorder,
-                localMel = createdMel,
-                localEmbedding = createdEmbedding,
-                localClassifier = createdClassifier
+                localSessions = active
             )
         } catch (e: Exception) {
-            closeSessions(createdMel, createdEmbedding, createdClassifier)
+            loadedSessions?.close()
             createdRecorder?.release()
             fail(startupError(e), e, generation)
+        }
+    }
+
+    /**
+     * How many times all three models have been read out of assets and turned
+     * into ORT sessions. The whole point of [pause] is that this does not climb
+     * with ordinary use, and a count is the only way to assert that from a test
+     * — the alternative is timing a resume, which is inherently flaky.
+     */
+    @Volatile
+    internal var sessionLoadCount = 0
+        private set
+
+    /** Loads all three models, closing any that succeeded if a later one fails. */
+    private fun loadSessions(env: OrtEnvironment): Sessions {
+        var mel: OrtSession? = null
+        var embedding: OrtSession? = null
+        try {
+            mel = loadSession(env, "$modelAssetDir/melspectrogram.onnx")
+            embedding = loadSession(env, "$modelAssetDir/embedding_model.onnx")
+            val loaded = Sessions(mel, embedding, loadSession(env, "$modelAssetDir/$classifierModel"))
+            sessionLoadCount++
+            return loaded
+        } catch (e: Exception) {
+            mel?.close()
+            embedding?.close()
+            throw e
         }
     }
 
@@ -205,9 +272,7 @@ class WakeWordDetector(
         generation: Int,
         env: OrtEnvironment,
         localRecorder: AudioRecord,
-        localMel: OrtSession,
-        localEmbedding: OrtSession,
-        localClassifier: OrtSession
+        localSessions: Sessions
     ) {
         // Read several 80 ms frames per wakeup rather than one. The pipeline
         // splits whatever it is handed back into frames, so this changes only
@@ -215,9 +280,9 @@ class WakeWordDetector(
         val block = ShortArray(OnnxWakeWordPipeline.FRAME_SIZE * READ_FRAMES)
         val pipeline = OnnxWakeWordPipeline(
             env = env,
-            melSession = localMel,
-            embeddingSession = localEmbedding,
-            classifierSession = localClassifier,
+            melSession = localSessions.mel,
+            embeddingSession = localSessions.embedding,
+            classifierSession = localSessions.classifier,
             matcher = matcher
         )
         try {
@@ -262,7 +327,9 @@ class WakeWordDetector(
         }
         lastError = message
         if (cause != null) Log.w(TAG, message, cause)
-        stop()
+        // Full release, not pause: a failure here can mean a session that never
+        // loaded or one that broke mid-run, so nothing cached is worth keeping.
+        release()
         scope.launch(Dispatchers.Main) { onError(message) }
     }
 
@@ -270,12 +337,6 @@ class WakeWordDetector(
         is SecurityException -> "Microphone permission is not available."
         is IOException -> "The bundled wake-word model could not be loaded."
         else -> "Wake word could not start."
-    }
-
-    private fun closeSessions(mel: OrtSession?, embedding: OrtSession?, classifier: OrtSession?) {
-        mel?.close()
-        embedding?.close()
-        classifier?.close()
     }
 
     companion object {

--- a/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
+++ b/app/src/main/java/com/gotcha/service/WakeWordDetector.kt
@@ -424,12 +424,15 @@ class WakeWordDetector(
             if (rmsDb > peakRms) peakRms = rmsDb
             if (rmsDb < quietestRms) quietestRms = rmsDb
             if (reads % REPORT_EVERY_READS != 0) return
+            // Locale.ROOT, not the default: on a decimal-comma device these
+            // become "-70,5" and stop being greppable, which is the whole point
+            // of the line.
             Log.d(
                 TAG,
-                "heard: rms ${"%.1f".format(quietestRms)}..${"%.1f".format(peakRms)} dBFS, " +
-                    "frames=$frames scored=$scored gated=$gated peakScore=${"%.3f".format(peakScore)} " +
-                    "mel[${"%.2f".format(melMin)}..${"%.2f".format(melMax)} avg ${"%.2f".format(melMean)}] " +
-                    "emb[${"%.2f".format(embMin)}..${"%.2f".format(embMax)} avg ${"%.2f".format(embMean)}]"
+                "heard: rms ${fmt(quietestRms, 1)}..${fmt(peakRms, 1)} dBFS, " +
+                    "frames=$frames scored=$scored gated=$gated peakScore=${fmt(peakScore, 3)} " +
+                    "mel[${fmt(melMin, 2)}..${fmt(melMax, 2)} avg ${fmt(melMean, 2)}] " +
+                    "emb[${fmt(embMin, 2)}..${fmt(embMax, 2)} avg ${fmt(embMean, 2)}]"
             )
             melMin = Float.MAX_VALUE
             melMax = -Float.MAX_VALUE
@@ -455,6 +458,9 @@ class WakeWordDetector(
             scored++
             if (score > peakScore) peakScore = score
         }
+
+        private fun fmt(value: Float, decimals: Int): String =
+            String.format(java.util.Locale.ROOT, "%.${decimals}f", value)
 
         private companion object {
             /** ~3 s at 4 frames per read. */

--- a/app/src/main/java/com/gotcha/service/WakeWordGate.kt
+++ b/app/src/main/java/com/gotcha/service/WakeWordGate.kt
@@ -1,0 +1,149 @@
+package com.gotcha.service
+
+import kotlin.math.log10
+import kotlin.math.sqrt
+
+/**
+ * Cheap energy gate in front of the wake-word embedding stage (issue #37).
+ *
+ * The listener runs 12.5 frames a second forever, and a measured ~85% of each
+ * frame's cost is the embedding backbone. Almost every real-world frame is
+ * silence, so the fix is to only pay for that backbone when there is something
+ * to hear. This class answers exactly one question per 80 ms frame — "is there
+ * energy above the room's noise floor?" — for a few microseconds of RMS.
+ *
+ * It deliberately does **not** reuse [com.gotcha.audio.SilenceDetector]:
+ *
+ * - That is a conversational state machine (accept-streak, "user stopped
+ *   talking", "user never spoke") built for the STT turn. Its `Decision` values
+ *   have no meaning per frame.
+ * - Its `rmsDb` clamps its return at −50 dBFS, so a gate built on it has no
+ *   resolution below −50 and cannot be tuned for a quiet room. [rmsDb] here is
+ *   unclamped.
+ *
+ * Behaviour:
+ *
+ * - The noise floor is a low percentile over the last [FLOOR_WINDOW] frames, so
+ *   a loud room raises the bar instead of holding the gate permanently open.
+ *   Unlike `SilenceDetector` the floor keeps updating while the gate is open:
+ *   re-arming is exact (see [OnnxWakeWordPipeline]), so a gate that closes
+ *   mid-phrase costs a little CPU but never costs a detection, and that makes
+ *   "never let the floor go stale" the safer trade.
+ * - A **single** frame above the threshold opens the gate — no accept-streak.
+ *   A spurious open costs milliseconds; a missed onset costs a detection.
+ * - Once open it stays open for [hangoverFrames] after energy drops. This is
+ *   what keeps an intermittently noisy room from flapping the gate: each
+ *   re-arm replays the classifier window, and that replay only pays for itself
+ *   if the quiet gap was longer than ~1.3 s.
+ * - It starts open and stays open until the floor window is primed, so the
+ *   first seconds after start can never be gated against an unlearned floor.
+ */
+internal class WakeWordGate(
+    private val marginDb: Float = SPEECH_MARGIN_DB,
+    private val minThresholdDb: Float = MIN_THRESHOLD_DB,
+    private val hangoverFrames: Int = HANGOVER_FRAMES,
+    private val alwaysOpen: Boolean = false
+) {
+    private val recentRms = FloatArray(FLOOR_WINDOW)
+    private var recentCount = 0
+    private var recentStart = 0
+    private var framesSinceEnergy = 0
+
+    /** The level a frame must exceed to open the gate, in dBFS. */
+    val thresholdDb: Float
+        get() = maxOf(minThresholdDb, noiseFloorEstimate + marginDb)
+
+    /** True while the floor window is still filling; the gate is forced open. */
+    val priming: Boolean
+        get() = recentCount < FLOOR_WINDOW
+
+    /** Returns true when [frame] should be run through the embedding stage. */
+    fun onFrame(frame: ShortArray, count: Int): Boolean = onLevel(rmsDb(frame, count))
+
+    /** [onFrame] split out from the PCM, so tests can drive levels directly. */
+    fun onLevel(frameRmsDb: Float): Boolean {
+        if (alwaysOpen) return true
+        val open = priming || frameRmsDb > thresholdDb
+
+        recentRms[recentStart] = frameRmsDb
+        recentStart = (recentStart + 1) % FLOOR_WINDOW
+        if (recentCount < FLOOR_WINDOW) recentCount++
+
+        if (open) {
+            framesSinceEnergy = 0
+            return true
+        }
+        // Saturate rather than overflow: this counter runs for as long as the
+        // room is quiet, which on a 24/7 listener is a very long time.
+        if (framesSinceEnergy <= hangoverFrames) framesSinceEnergy++
+        return framesSinceEnergy <= hangoverFrames
+    }
+
+    fun reset() {
+        recentCount = 0
+        recentStart = 0
+        framesSinceEnergy = 0
+    }
+
+    private val noiseFloorEstimate: Float
+        get() {
+            if (recentCount < FLOOR_WINDOW) return INITIAL_NOISE_FLOOR_DB
+            val sorted = recentRms.copyOf(FLOOR_WINDOW).apply { sort() }
+            val index = (sorted.size * FLOOR_QUANTILE).toInt().coerceIn(0, sorted.lastIndex)
+            return sorted[index]
+        }
+
+    companion object {
+        /**
+         * A gate that never closes — i.e. the pre-#37 behaviour, where every
+         * frame paid for the embedding backbone. The parity tests run one
+         * pipeline behind this and one behind a real gate, and require the two
+         * to produce identical classifier scores.
+         */
+        fun alwaysOpen(): WakeWordGate = WakeWordGate(alwaysOpen = true)
+
+        /** How far above the noise floor a frame has to be to count as sound. */
+        private const val SPEECH_MARGIN_DB = 6f
+
+        /**
+         * Absolute lower bound on the threshold. Well below
+         * `SilenceDetector.ABSOLUTE_FLOOR_DB` (−50) on purpose: a quiet bedroom
+         * at night sits below −50 dBFS, and a gate that cannot be set quieter
+         * than the room never closes.
+         */
+        private const val MIN_THRESHOLD_DB = -60f
+
+        private const val INITIAL_NOISE_FLOOR_DB = -70f
+
+        /**
+         * ~3 s. Long enough that a pause inside a sentence does not re-arm the
+         * pipeline, which matters because each re-arm costs a replay of the
+         * 16-frame classifier window.
+         */
+        private const val HANGOVER_FRAMES = 38
+
+        /** ~4 s of frames. Long enough that continuous speech cannot lift the floor to its own level. */
+        private const val FLOOR_WINDOW = 50
+
+        private const val FLOOR_QUANTILE = 0.2f
+
+        /** Level reported for digital silence, where the log is undefined. */
+        const val SILENT_DB = -120f
+
+        /**
+         * RMS of [count] 16-bit PCM samples in dBFS. Unlike
+         * `SilenceDetector.rmsDb` this is **not** clamped at −50 dBFS.
+         */
+        fun rmsDb(samples: ShortArray, count: Int): Float {
+            if (count <= 0) return SILENT_DB
+            var sum = 0L
+            for (i in 0 until count) {
+                val sample = samples[i].toInt()
+                sum += sample.toLong() * sample
+            }
+            val rms = sqrt(sum.toDouble() / count)
+            if (rms <= 0.0) return SILENT_DB
+            return maxOf(20.0 * log10(rms / 32768.0), SILENT_DB.toDouble()).toFloat()
+        }
+    }
+}

--- a/app/src/main/java/com/gotcha/service/WakeWordGate.kt
+++ b/app/src/main/java/com/gotcha/service/WakeWordGate.kt
@@ -45,13 +45,26 @@ internal class WakeWordGate(
     private val alwaysOpen: Boolean = false
 ) {
     private val recentRms = FloatArray(FLOOR_WINDOW)
+
+    /** Reused scratch for the percentile sort, so the floor costs no allocation. */
+    private val floorScratch = FloatArray(FLOOR_WINDOW)
     private var recentCount = 0
     private var recentStart = 0
     private var framesSinceEnergy = 0
+    private var framesSinceFloorRefresh = 0
 
-    /** The level a frame must exceed to open the gate, in dBFS. */
-    val thresholdDb: Float
-        get() = maxOf(minThresholdDb, noiseFloorEstimate + marginDb)
+    /**
+     * The level a frame must exceed to open the gate, in dBFS.
+     *
+     * Cached rather than recomputed per frame. The floor is a percentile over
+     * four seconds of history — it moves slowly by construction, so refreshing
+     * it every [FLOOR_REFRESH_FRAMES] tracks it just as well while keeping the
+     * sort off a path that runs 12.5 times a second for as long as the phone is
+     * on. Recomputing it per frame made the gate the only remaining per-frame
+     * allocation in the listener.
+     */
+    var thresholdDb: Float = maxOf(minThresholdDb, INITIAL_NOISE_FLOOR_DB + marginDb)
+        private set
 
     /** True while the floor window is still filling; the gate is forced open. */
     val priming: Boolean
@@ -67,7 +80,17 @@ internal class WakeWordGate(
 
         recentRms[recentStart] = frameRmsDb
         recentStart = (recentStart + 1) % FLOOR_WINDOW
-        if (recentCount < FLOOR_WINDOW) recentCount++
+        val wasPriming = recentCount < FLOOR_WINDOW
+        if (wasPriming) recentCount++
+
+        // Refresh on the frame that completes priming — the first real floor is
+        // worth having immediately — and periodically after that.
+        framesSinceFloorRefresh++
+        if ((wasPriming && recentCount == FLOOR_WINDOW) ||
+            framesSinceFloorRefresh >= FLOOR_REFRESH_FRAMES
+        ) {
+            refreshThreshold()
+        }
 
         if (open) {
             framesSinceEnergy = 0
@@ -83,15 +106,24 @@ internal class WakeWordGate(
         recentCount = 0
         recentStart = 0
         framesSinceEnergy = 0
+        framesSinceFloorRefresh = 0
+        recentRms.fill(0f)
+        thresholdDb = maxOf(minThresholdDb, INITIAL_NOISE_FLOOR_DB + marginDb)
     }
 
-    private val noiseFloorEstimate: Float
-        get() {
-            if (recentCount < FLOOR_WINDOW) return INITIAL_NOISE_FLOOR_DB
-            val sorted = recentRms.copyOf(FLOOR_WINDOW).apply { sort() }
-            val index = (sorted.size * FLOOR_QUANTILE).toInt().coerceIn(0, sorted.lastIndex)
-            return sorted[index]
-        }
+    private fun refreshThreshold() {
+        framesSinceFloorRefresh = 0
+        thresholdDb = maxOf(minThresholdDb, noiseFloorEstimate() + marginDb)
+    }
+
+    private fun noiseFloorEstimate(): Float {
+        if (recentCount < FLOOR_WINDOW) return INITIAL_NOISE_FLOOR_DB
+        recentRms.copyInto(floorScratch)
+        floorScratch.sort()
+        val index = (floorScratch.size * FLOOR_QUANTILE).toInt()
+            .coerceIn(0, floorScratch.lastIndex)
+        return floorScratch[index]
+    }
 
     companion object {
         /**
@@ -126,6 +158,9 @@ internal class WakeWordGate(
         private const val FLOOR_WINDOW = 50
 
         private const val FLOOR_QUANTILE = 0.2f
+
+        /** ~1 s. The floor spans 4 s of history, so this loses nothing. */
+        private const val FLOOR_REFRESH_FRAMES = 12
 
         /** Level reported for digital silence, where the log is undefined. */
         const val SILENT_DB = -120f

--- a/app/src/main/java/com/gotcha/tools/AppsTool.kt
+++ b/app/src/main/java/com/gotcha/tools/AppsTool.kt
@@ -10,6 +10,7 @@ import android.net.ConnectivityManager
 import android.net.Uri
 import android.os.Process
 import android.util.Log
+import com.gotcha.util.GotchaLog
 
 class AppsTool(private val context: Context) {
 
@@ -126,7 +127,7 @@ class AppsTool(private val context: Context) {
      * the app is gone via list_installed_apps after tapping OK.
      */
     fun doUninstall(packageName: String): ToolResult {
-        Log.d(TAG, "doUninstall: $packageName")
+        GotchaLog.d(TAG) { "doUninstall: $packageName" }
         return try {
             val pm = context.packageManager
             val installed = try {
@@ -150,7 +151,7 @@ class AppsTool(private val context: Context) {
                 .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             context.startActivity(intent)
 
-            Log.d(TAG, "doUninstall: dialog opened for $label")
+            GotchaLog.d(TAG) { "doUninstall: dialog opened for $label" }
             ToolResult.ok(
                 "System dialog opened to uninstall $label. After you tap OK in the dialog, ask the assistant to verify the app is gone."
             )

--- a/app/src/main/java/com/gotcha/tools/HealthTool.kt
+++ b/app/src/main/java/com/gotcha/tools/HealthTool.kt
@@ -1,7 +1,10 @@
 package com.gotcha.tools
 
 import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import androidx.health.connect.client.HealthConnectClient
+import androidx.health.connect.client.PermissionController
 import androidx.health.connect.client.aggregate.AggregateMetric
 import androidx.health.connect.client.aggregate.AggregationResult
 import androidx.health.connect.client.permission.HealthPermission
@@ -90,6 +93,14 @@ class HealthTool(private val context: Context) {
         )
 
         val RECORD_TYPE_NAMES: List<String> = RECORD_TYPES.keys.toList()
+
+        /** Android 14+ platform action for Health Connect's per-app permission manager. */
+        const val ACTION_MANAGE_HEALTH_PERMISSIONS =
+            "android.health.connect.action.MANAGE_HEALTH_PERMISSIONS"
+
+        internal const val PLAY_LISTING_URI = "market://details?id=com.google.android.apps.healthdata"
+        internal const val CONTROLLER_PACKAGE = "com.google.android.healthconnect.controller"
+        internal const val LEGACY_PROVIDER_PACKAGE = "com.google.android.apps.healthdata"
     }
 
     private fun clientOrNull(): HealthConnectClient? =
@@ -242,3 +253,54 @@ class HealthTool(private val context: Context) {
         else -> record.javaClass.simpleName
     }
 }
+
+/**
+ * The Health Connect permission intent to fire, or the best fallback that can
+ * actually be resolved on this device. Never null when the Play Store is
+ * reachable and never throws.
+ *
+ * On API 34+ the SDK's `PermissionController` contract builds its intent from
+ * `ActivityResultContracts.RequestMultiplePermissions`, which stock Android
+ * routes to the Health Connect screen but some OEM builds do not resolve at
+ * all — firing it blind throws `ActivityNotFoundException` (the crash this
+ * guards against). Each candidate is therefore only used when it has a
+ * resolver, and the chain degrades to the Health Connect app itself rather
+ * than a crash. Shared by the Settings permission row and the agent path.
+ */
+fun healthConnectPermissionIntent(context: Context): Intent? {
+    if (HealthConnectClient.getSdkStatus(context) != HealthConnectClient.SDK_AVAILABLE) {
+        // No provider (or one that is out of date): steer to the Play listing
+        // instead of crash-launching a screen nothing can handle.
+        return Intent(Intent.ACTION_VIEW, Uri.parse(HealthTool.PLAY_LISTING_URI))
+    }
+    val pm = context.packageManager
+    // Preferred: the SDK's permission-request screen (parses the granted set on
+    // the way back). Only used when something actually resolves it.
+    runCatching {
+        PermissionController.createRequestPermissionResultContract()
+            .createIntent(context, HealthTool.PERMISSIONS)
+    }.getOrNull()?.let { intent ->
+        if (intent.resolveActivity(pm) != null) return intent
+    }
+    // Fallback: the Health Connect home screen. This is the reliable opener on
+    // OEM builds whose per-app permission page refuses to show (launches and
+    // immediately finishes) for an app with no grants yet — the home always
+    // opens, and the user reaches App permissions from there.
+    Intent(HealthConnectClient.ACTION_HEALTH_CONNECT_SETTINGS)
+        .takeIf { it.resolveActivity(pm) != null }
+        ?.let { return it }
+    // Fallback: Health Connect's per-app permission manager (Android 14+), for
+    // devices where it does show the target app directly.
+    healthConnectManagePermissionsIntent(context)
+        .takeIf { it.resolveActivity(pm) != null }
+        ?.let { return it }
+    // Last resort: open the Health Connect app so the user can grant from there.
+    pm.getLaunchIntentForPackage(HealthTool.CONTROLLER_PACKAGE)?.let { return it }
+    pm.getLaunchIntentForPackage(HealthTool.LEGACY_PROVIDER_PACKAGE)?.let { return it }
+    return null
+}
+
+/** The per-app Health Connect permission manager intent (Android 14+ platform action). */
+internal fun healthConnectManagePermissionsIntent(context: Context): Intent =
+    Intent(HealthTool.ACTION_MANAGE_HEALTH_PERMISSIONS)
+        .putExtra(Intent.EXTRA_PACKAGE_NAME, context.packageName)

--- a/app/src/main/java/com/gotcha/tools/MediaCaptureTool.kt
+++ b/app/src/main/java/com/gotcha/tools/MediaCaptureTool.kt
@@ -11,6 +11,7 @@ import androidx.camera.core.ImageCapture
 import androidx.camera.core.ImageCaptureException
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.core.content.ContextCompat
+import com.gotcha.util.GotchaLog
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
@@ -44,7 +45,7 @@ class MediaCaptureTool(private val context: Context) {
     private var lastSavedDurationSeconds: Long = 0L
 
     suspend fun takePhoto(camera: String?): ToolResult {
-        Log.d(TAG, "takePhoto: camera=$camera")
+        GotchaLog.d(TAG) { "takePhoto: camera=$camera" }
         if (ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA)
             != PackageManager.PERMISSION_GRANTED
         ) {
@@ -76,20 +77,20 @@ class MediaCaptureTool(private val context: Context) {
             val outputOptions = ImageCapture.OutputFileOptions.Builder(file).build()
 
             val result = withContext(Dispatchers.Main) {
-                Log.d(TAG, "takePhoto: on main thread, acquiring provider…")
+                GotchaLog.d(TAG) { "takePhoto: on main thread, acquiring provider…" }
                 val cameraProvider = ProcessCameraProvider.getInstance(context).get(5, TimeUnit.SECONDS)
-                Log.d(TAG, "takePhoto: provider acquired, binding…")
+                GotchaLog.d(TAG) { "takePhoto: provider acquired, binding…" }
                 cameraProvider.unbindAll()
                 cameraProvider.bindToLifecycle(lifecycleOwner, cameraSelector, imageCapture)
 
                 val res = suspendCancellableCoroutine<ToolResult> { cont ->
-                    Log.d(TAG, "takePhoto: calling takePicture…")
+                    GotchaLog.d(TAG) { "takePhoto: calling takePicture…" }
                     imageCapture.takePicture(
                         outputOptions,
                         ContextCompat.getMainExecutor(context),
                         object : ImageCapture.OnImageSavedCallback {
                             override fun onImageSaved(output: ImageCapture.OutputFileResults) {
-                                Log.d(TAG, "takePhoto: image saved to ${file.absolutePath}")
+                                GotchaLog.d(TAG) { "takePhoto: image saved to ${file.absolutePath}" }
                                 com.gotcha.data.GotchaStorage.publishToGallery(context, file)
                                 cont.resume(ToolResult.ok("Photo saved to ${file.absolutePath}."))
                             }

--- a/app/src/main/java/com/gotcha/tools/ScreenPerception.kt
+++ b/app/src/main/java/com/gotcha/tools/ScreenPerception.kt
@@ -11,6 +11,7 @@ import android.util.Log
 import android.view.accessibility.AccessibilityNodeInfo
 import com.gotcha.service.GotchaAccessibilityService
 import com.gotcha.service.MediaProjectionService
+import com.gotcha.util.GotchaLog
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -82,13 +83,13 @@ object ScreenPerception {
         saveDir: File? = null
     ): CompressedScreenshot? {
         return try {
-            Log.d("ScreenCapture", "compressScreenshot: starting capture...")
+            GotchaLog.d("ScreenCapture") { "compressScreenshot: starting capture..." }
             val bytes = captureRawBytes()
             if (bytes == null) {
                 Log.e("ScreenCapture", "compressScreenshot: captureRawBytes returned null — all paths failed")
                 return null
             }
-            Log.d("ScreenCapture", "compressScreenshot: got ${bytes.size} raw bytes")
+            GotchaLog.d("ScreenCapture") { "compressScreenshot: got ${bytes.size} raw bytes" }
             val originalSize = bytes.size.toLong()
             val options = BitmapFactory.Options().apply {
                 inMutable = true
@@ -102,7 +103,7 @@ object ScreenPerception {
                 )
                 return null
             }
-            Log.d("ScreenCapture", "compressScreenshot: decoded bitmap ${bitmap.width}x${bitmap.height}")
+            GotchaLog.d("ScreenCapture") { "compressScreenshot: decoded bitmap ${bitmap.width}x${bitmap.height}" }
             val annotated = if (drawGrid) {
                 val elements = lastElementsCache ?: emptyList()
                 if (elements.isNotEmpty()) {
@@ -337,12 +338,12 @@ object ScreenPerception {
     private suspend fun captureRawBytes(): ByteArray? {
         // Path 1: AccessibilityService.takeScreenshot() — API 30+, no special perms.
         val service = GotchaAccessibilityService.instance
-        Log.d("ScreenCapture", "Path1: service=${service != null}")
+        GotchaLog.d("ScreenCapture") { "Path1: service=${service != null}" }
         if (service != null) {
             for (attempt in 1..2) {
-                Log.d("ScreenCapture", "Path1: takeScreenshotBitmap attempt $attempt")
+                GotchaLog.d("ScreenCapture") { "Path1: takeScreenshotBitmap attempt $attempt" }
                 val bitmap = service.takeScreenshotBitmap()
-                Log.d("ScreenCapture", "Path1: takeScreenshotBitmap returned ${bitmap != null}")
+                GotchaLog.d("ScreenCapture") { "Path1: takeScreenshotBitmap returned ${bitmap != null}" }
                 if (bitmap != null) {
                     val bytes = withContext(Dispatchers.Default) {
                         val stream = ByteArrayOutputStream()
@@ -350,7 +351,7 @@ object ScreenPerception {
                         bitmap.recycle()
                         stream.toByteArray()
                     }
-                    Log.d("ScreenCapture", "Path1: compressed to ${bytes.size} bytes")
+                    GotchaLog.d("ScreenCapture") { "Path1: compressed to ${bytes.size} bytes" }
                     if (bytes.isNotEmpty()) return bytes
                 }
                 if (attempt < 2) delay(1100)
@@ -364,26 +365,29 @@ object ScreenPerception {
         // consent instead of silently retrying with a dead token, and a concurrent
         // capture cannot claim the same single-use token.
         val projectionData = if (ctx != null) consumeMediaProjectionResultData() else null
-        Log.d(
-            "ScreenCapture",
+        GotchaLog.d("ScreenCapture") {
             "Path2: projectionData=${projectionData != null}, ctx=${ctx != null}, appContext=${appContext != null}"
-        )
+        }
         if (projectionData != null && ctx != null) {
-            Log.d("ScreenCapture", "Path2: calling MediaProjectionService.capture()")
+            GotchaLog.d("ScreenCapture") { "Path2: calling MediaProjectionService.capture()" }
             val bytes = withContext(Dispatchers.IO) {
                 MediaProjectionService.capture(ctx, projectionData)
             }
-            Log.d("ScreenCapture", "Path2: MediaProjectionService.capture returned ${bytes?.size ?: "null"} bytes")
+            GotchaLog.d("ScreenCapture") {
+                "Path2: MediaProjectionService.capture returned ${bytes?.size ?: "null"} bytes"
+            }
             if (bytes != null && bytes.isNotEmpty()) return bytes
         }
         // Path 3: screencap via shell (works on rooted devices / emulators).
-        Log.d("ScreenCapture", "Path3: trying screencap -p")
+        GotchaLog.d("ScreenCapture") { "Path3: trying screencap -p" }
         return try {
             withContext(Dispatchers.IO) {
                 val process = Runtime.getRuntime().exec("screencap -p")
                 val bytes = process.inputStream.use { it.readBytes() }
                 process.waitFor()
-                Log.d("ScreenCapture", "Path3: screencap returned ${bytes.size} bytes, exit=${process.exitValue()}")
+                GotchaLog.d("ScreenCapture") {
+                    "Path3: screencap returned ${bytes.size} bytes, exit=${process.exitValue()}"
+                }
                 if (bytes.isEmpty()) null else bytes
             }
         } catch (e: Exception) {

--- a/app/src/main/java/com/gotcha/tools/SubAgentSession.kt
+++ b/app/src/main/java/com/gotcha/tools/SubAgentSession.kt
@@ -10,6 +10,7 @@ import com.gotcha.data.Settings
 import com.gotcha.llm.ChatMessage
 import com.gotcha.llm.LLMClient
 import com.gotcha.llm.withValidToolCallArguments
+import com.gotcha.util.GotchaLog
 import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -41,7 +42,7 @@ class SubAgentSession(
 
     suspend fun run(): SubAgentOutput {
         val model = settings.subAgentModel.ifBlank { settings.model }
-        Log.d(TAG, "Starting sub-agent with model=$model: $description")
+        GotchaLog.d(TAG) { "Starting sub-agent with model=$model: $description" }
 
         val subLlm = LLMClient(
             apiKey = settings.effectiveApiKey,
@@ -58,7 +59,7 @@ class SubAgentSession(
         val subAgentTools = ToolRegistry.toolsForSubAgent(hiddenTools)
 
         for (round in 0 until maxRounds) {
-            Log.d(TAG, "Sub-agent round ${round + 1}/$maxRounds")
+            GotchaLog.d(TAG) { "Sub-agent round ${round + 1}/$maxRounds" }
 
             val messages = buildList {
                 addAll(history)
@@ -94,7 +95,7 @@ class SubAgentSession(
             if (toolCalls.isEmpty()) {
                 history.add(message)
                 val text = message.textContent.ifEmpty { "(no output)" }
-                Log.d(TAG, "Sub-agent finished (text response): ${text.take(100)}")
+                GotchaLog.d(TAG) { "Sub-agent finished (text response): ${text.take(100)}" }
                 return SubAgentOutput(text, collectedSteps.toList())
             }
 
@@ -109,7 +110,7 @@ class SubAgentSession(
                 } catch (e: Exception) {
                     "(failed to parse ask_final_answer: ${e.message})"
                 }
-                Log.d(TAG, "Sub-agent finished (ask_final_answer)")
+                GotchaLog.d(TAG) { "Sub-agent finished (ask_final_answer)" }
                 return SubAgentOutput(answer, collectedSteps.toList())
             }
 

--- a/app/src/main/java/com/gotcha/tools/ToolExecutor.kt
+++ b/app/src/main/java/com/gotcha/tools/ToolExecutor.kt
@@ -1,9 +1,9 @@
 package com.gotcha.tools
 
 import android.content.Context
-import android.util.Log
 import com.gotcha.agent.skills.SkillRegistry
 import com.gotcha.connectors.ConnectorCatalog
+import com.gotcha.util.GotchaLog
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -120,10 +120,9 @@ class ToolExecutor(
         }
         // Do not log result.message — tool payloads can contain sensitive user data
         // (SMS bodies, clipboard text, file contents, location, etc.).
-        Log.d(
-            TAG,
+        GotchaLog.d(TAG) {
             "execute: $name -> success=${result.success}, msgLen=${result.message.length}, perm=${result.needsPermission}"
-        )
+        }
         actionLog.record(name, args.redactedForAudit(), result)
         return result
     }
@@ -153,7 +152,7 @@ class ToolExecutor(
      * Bypasses the destructive-action confirmation flow.
      */
     suspend fun executeUninstall(packageName: String): ToolResult {
-        Log.d(TAG, "executeUninstall: $packageName")
+        GotchaLog.d(TAG) { "executeUninstall: $packageName" }
         val result = withContext(Dispatchers.IO) { appsTool.doUninstall(packageName) }
         actionLog.record("uninstall_app", packageName, result)
         return result
@@ -423,7 +422,7 @@ class ToolExecutor(
                 val secs = args.requireInt("duration_seconds")?.coerceIn(1, 86400)
                     ?: return missing("duration_seconds")
                 for (remaining in secs downTo 1) {
-                    Log.d(TAG, "sleep: ${remaining}s remaining")
+                    GotchaLog.d(TAG) { "sleep: ${remaining}s remaining" }
                     delay(1000L)
                 }
                 ToolResult.ok("Slept for $secs seconds.")

--- a/app/src/main/java/com/gotcha/ui/AiConfigScreen.kt
+++ b/app/src/main/java/com/gotcha/ui/AiConfigScreen.kt
@@ -147,6 +147,18 @@ fun AiConfigScreen(
     }
 
     SettingsScaffold(title = SettingsPage.AI_CONFIG.title, onBack = onBack, overlay = overlay) {
+        // ---- Provider / model guidance ----
+        Text(
+            "Recommended setup:\n" +
+                "• Use the SAMOSA AI provider for the best LLM performance — it " +
+                "includes a built-in TTS that handles mixed-language text.\n" +
+                "• For high-quality single-language speech (e.g. English primarily), " +
+                "SAMOSA AI's TTS is the recommendation.\n" +
+                "• SAMOSA AI's STT is the recommended speech-to-text engine.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
         // ---- LLM provider selector ----
         ExposedDropdownMenuBox(
             expanded = providerExpanded,

--- a/app/src/main/java/com/gotcha/ui/AiConfigScreen.kt
+++ b/app/src/main/java/com/gotcha/ui/AiConfigScreen.kt
@@ -150,11 +150,10 @@ fun AiConfigScreen(
         // ---- Provider / model guidance ----
         Text(
             "Recommended setup:\n" +
-                "• Use the SAMOSA AI provider for the best LLM performance — it " +
-                "includes a built-in TTS that handles mixed-language text.\n" +
-                "• For high-quality single-language speech (e.g. English primarily), " +
-                "SAMOSA AI's TTS is the recommendation.\n" +
-                "• SAMOSA AI's STT is the recommended speech-to-text engine.",
+                "• Use the SAMOSA AI provider for the best LLM performance.\n" +
+                "• For speech, pick SAMOSA AI's TTS and STT on the Speech screen — " +
+                "its TTS handles mixed-language text, and its STT is the recommended " +
+                "transcription engine.",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )

--- a/app/src/main/java/com/gotcha/ui/AssistiveBallOverlay.kt
+++ b/app/src/main/java/com/gotcha/ui/AssistiveBallOverlay.kt
@@ -188,7 +188,7 @@ class AssistiveBallOverlay(context: Context) {
     }
 
     private fun currentSkinId(): String =
-        runCatching { settingsRepository.load().skinId }.getOrDefault(Skins.DEFAULT_ID)
+        runCatching { settingsRepository.load().skinId }.getOrDefault(Skins.OVERLAY_FALLBACK_ID)
 
     /** The active skin, translated for View code. */
     private fun palette(): OverlaySkin = overlaySkin(appContext, currentSkinId())

--- a/app/src/main/java/com/gotcha/ui/AssistiveBallScreen.kt
+++ b/app/src/main/java/com/gotcha/ui/AssistiveBallScreen.kt
@@ -10,21 +10,29 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.gotcha.data.Settings
+import com.gotcha.data.WakeWordListeningMode
 import android.provider.Settings as AndroidSettings
 
 /**
@@ -48,8 +56,22 @@ fun AssistiveBallScreen(
 ) {
     val overlay = rememberSettingsOverlayState()
     val initial = remember { load() }
+    val ballEnabled = enabled
     var wakeWordEnabled by remember { mutableStateOf(initial.wakeWordEnabled) }
     var wakeWordSensitivity by remember { mutableStateOf(initial.wakeWordSensitivity) }
+    var wakeWordListeningMode by remember { mutableStateOf(initial.wakeWordListeningMode) }
+
+    // The wake word runs inside the ball service, so it cannot be on while the
+    // ball is off. When the ball is switched off here (or this screen is opened
+    // with the ball already off and a leftover ON), reset the wake word to off
+    // in both the local state and the saved setting — not merely disable the
+    // toggle, which would leave it visually on but inert.
+    LaunchedEffect(ballEnabled) {
+        if (!ballEnabled && wakeWordEnabled) {
+            wakeWordEnabled = false
+            onSave { settings -> settings.copy(wakeWordEnabled = false) }
+        }
+    }
 
     SettingsScaffold(title = SettingsPage.ASSISTIVE_BALL.title, onBack = onBack, overlay = overlay) {
         SettingsToggleRow(
@@ -74,6 +96,11 @@ fun AssistiveBallScreen(
         SettingsToggleRow(
             label = "Wake word: Hey Gotcha",
             checked = wakeWordEnabled,
+            // The listener runs inside the Assistive Ball service, so the wake
+            // word cannot be turned on while the ball is off. Turning the ball
+            // off also switches the wake word off (see LaunchedEffect above),
+            // so this toggle is simply locked to the ball state.
+            enabled = ballEnabled,
             onCheckedChange = {
                 wakeWordEnabled = it
                 onSave { settings -> settings.copy(wakeWordEnabled = it) }
@@ -85,6 +112,14 @@ fun AssistiveBallScreen(
                 "Turn on Hey Gotcha wake word"
             }
         )
+        if (!ballEnabled) {
+            Text(
+                "The wake word requires the Assistive Ball to be on — turn on " +
+                    "\"Show Assistive Ball\" to use it.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
         Text(
             "Says \"Hey Gotcha\" — the bundled OpenWakeWord model runs on-device while " +
                 "the assistive ball is on and no call is active. Keep microphone " +
@@ -93,6 +128,35 @@ fun AssistiveBallScreen(
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
         if (wakeWordEnabled) {
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                "When to listen",
+                style = MaterialTheme.typography.bodyMedium
+            )
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .selectableGroup()
+                    .testTag("settings_wake_word_mode")
+            ) {
+                WakeWordListeningMode.entries.forEach { mode ->
+                    WakeWordModeRow(
+                        mode = mode,
+                        selected = wakeWordListeningMode == mode,
+                        onSelect = {
+                            wakeWordListeningMode = mode
+                            onSave { settings -> settings.copy(wakeWordListeningMode = mode) }
+                        }
+                    )
+                }
+            }
+            Text(
+                "The listener is only active while the screen matches the chosen " +
+                    "state, so the microphone and its indicator are off the rest of " +
+                    "the time.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
             Spacer(modifier = Modifier.height(8.dp))
             Row(
                 modifier = Modifier.fillMaxWidth()
@@ -152,6 +216,52 @@ private fun sensitivityLabel(sensitivity: Float): String = when {
     sensitivity < 0.185f -> "High precision"
     sensitivity < 0.741f -> "Balanced"
     else -> "High sensitivity"
+}
+
+/** One selectable row of the "When to listen" wake-word mode group. */
+@Composable
+private fun WakeWordModeRow(
+    mode: WakeWordListeningMode,
+    selected: Boolean,
+    onSelect: () -> Unit
+) {
+    val label: String
+    val summary: String
+    when (mode) {
+        WakeWordListeningMode.ALWAYS -> {
+            label = "Always"
+            summary = "Listen with the screen on or off. Full hands-free, highest battery use."
+        }
+        WakeWordListeningMode.SCREEN_ON -> {
+            label = "Only while the screen is on"
+            summary = "Saves battery — the microphone and its indicator are off while the screen is off."
+        }
+        WakeWordListeningMode.SCREEN_OFF -> {
+            label = "Only while the screen is off"
+            summary = "Hands-free when you are not already looking at the phone; the screen being on means the mic is off."
+        }
+    }
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .selectable(
+                selected = selected,
+                role = Role.RadioButton,
+                onClick = onSelect
+            )
+            .testTag("settings_wake_word_mode_${mode.name.lowercase()}")
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            RadioButton(selected = selected, onClick = null)
+            Text(label, style = MaterialTheme.typography.bodyMedium)
+        }
+        Text(
+            summary,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(start = 40.dp, bottom = 4.dp)
+        )
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/gotcha/ui/CallChatWindow.kt
+++ b/app/src/main/java/com/gotcha/ui/CallChatWindow.kt
@@ -1074,7 +1074,7 @@ class CallChatWindow(context: Context) {
     private fun readyTint(): Int = overlaySkin(
         appContext,
         runCatching { SettingsRepository(appContext).load().skinId }
-            .getOrDefault(Skins.DEFAULT_ID)
+            .getOrDefault(Skins.OVERLAY_FALLBACK_ID)
     ).accent
 
     private companion object {

--- a/app/src/main/java/com/gotcha/ui/ClipboardReaderActivity.kt
+++ b/app/src/main/java/com/gotcha/ui/ClipboardReaderActivity.kt
@@ -4,13 +4,14 @@ import android.app.Activity
 import android.content.ClipboardManager
 import android.content.Context
 import android.os.Bundle
+import com.gotcha.util.GotchaLog
 
 class ClipboardReaderActivity : Activity() {
     private var hasAttemptedRead = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        android.util.Log.d("ClipboardReaderActivity", "onCreate")
+        GotchaLog.d("ClipboardReaderActivity") { "onCreate" }
 
         // Create a dummy view and set it to ensure the window has a view that can gain focus
         val dummyView = android.view.View(this).apply {
@@ -22,10 +23,7 @@ class ClipboardReaderActivity : Activity() {
 
         // Delay a bit in case window focus doesn't fire
         window.decorView.postDelayed({
-            android.util.Log.d(
-                "ClipboardReaderActivity",
-                "postDelayed triggered, read=$hasAttemptedRead"
-            )
+            GotchaLog.d("ClipboardReaderActivity") { "postDelayed triggered, read=$hasAttemptedRead" }
             if (!hasAttemptedRead) {
                 readClipboardAndFinish("timeout")
             }
@@ -34,26 +32,20 @@ class ClipboardReaderActivity : Activity() {
 
     override fun onWindowFocusChanged(hasFocus: Boolean) {
         super.onWindowFocusChanged(hasFocus)
-        android.util.Log.d(
-            "ClipboardReaderActivity",
-            "onWindowFocusChanged: $hasFocus, read=$hasAttemptedRead"
-        )
+        GotchaLog.d("ClipboardReaderActivity") { "onWindowFocusChanged: $hasFocus, read=$hasAttemptedRead" }
         if (hasFocus && !hasAttemptedRead) {
             readClipboardAndFinish("focus")
         }
     }
 
     private fun readClipboardAndFinish(source: String) {
-        android.util.Log.d("ClipboardReaderActivity", "readClipboardAndFinish: $source")
+        GotchaLog.d("ClipboardReaderActivity") { "readClipboardAndFinish: $source" }
         hasAttemptedRead = true
         try {
             val cm = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-            android.util.Log.d("ClipboardReaderActivity", "Retrieving primaryClip")
+            GotchaLog.d("ClipboardReaderActivity") { "Retrieving primaryClip" }
             val clip = cm.primaryClip
-            android.util.Log.d(
-                "ClipboardReaderActivity",
-                "clip retrieved: count=${clip?.itemCount ?: 0}"
-            )
+            GotchaLog.d("ClipboardReaderActivity") { "clip retrieved: count=${clip?.itemCount ?: 0}" }
             onClipboardRead?.invoke(clip)
         } catch (e: Exception) {
             android.util.Log.e("ClipboardReaderActivity", "Failed to read clipboard", e)

--- a/app/src/main/java/com/gotcha/ui/ConfirmationOverlay.kt
+++ b/app/src/main/java/com/gotcha/ui/ConfirmationOverlay.kt
@@ -70,7 +70,7 @@ class ConfirmationOverlay(context: Context) {
         val colors = overlaySkin(
             appContext,
             runCatching { SettingsRepository(appContext).load().skinId }
-                .getOrDefault(Skins.DEFAULT_ID)
+                .getOrDefault(Skins.OVERLAY_FALLBACK_ID)
         )
         val container = LinearLayout(appContext).apply {
             orientation = LinearLayout.VERTICAL

--- a/app/src/main/java/com/gotcha/ui/FeedbackSheet.kt
+++ b/app/src/main/java/com/gotcha/ui/FeedbackSheet.kt
@@ -44,8 +44,8 @@ fun FeedbackSheet(
         text = {
             Column {
                 Text(
-                    text = "If you provide successful feedback, after approval you may be eligible " +
-                        "for 2x the current free Samosa AI credits.",
+                    text = "If you provide successful feedback, after validation you may be " +
+                        "eligible for 100 credits per feedback, up to 500 credits per day.",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.padding(bottom = 8.dp)

--- a/app/src/main/java/com/gotcha/ui/PermissionsSection.kt
+++ b/app/src/main/java/com/gotcha/ui/PermissionsSection.kt
@@ -33,15 +33,14 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.health.connect.client.HealthConnectClient
-import androidx.health.connect.client.PermissionController
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import com.gotcha.service.GotchaDeviceAdminReceiver
 import com.gotcha.tools.HealthPermissionState
-import com.gotcha.tools.HealthTool
 import com.gotcha.tools.TermuxTool
 import com.gotcha.tools.ToolResult
+import com.gotcha.tools.healthConnectPermissionIntent
+import com.gotcha.ui.theme.SkinAlertDialog
 import android.provider.Settings as AndroidSettings
 
 @Composable
@@ -154,6 +153,8 @@ private fun PermissionRow(
     onOpenDetails: (() -> Unit)? = null
 ) {
     val context = LocalContext.current
+    val isHealthConnect = item.specialMarker == ToolResult.HEALTH_CONNECT
+    var showHealthConnectDialog by remember { mutableStateOf(false) }
 
     Row(
         modifier = Modifier
@@ -188,7 +189,15 @@ private fun PermissionRow(
                     if (item.androidPermission != null) {
                         onRequestRuntime((listOf(item.androidPermission) + item.extraPermissions).toTypedArray())
                     } else if (item.specialMarker != null) {
-                        openSpecialAccess(context, item.specialMarker, packageName)
+                        // Health Connect cannot be granted from the standard
+                        // runtime flow, and on some OEM builds the permission
+                        // screen opens and closes with no visible result — so
+                        // the toggle first explains where to go, then opens it.
+                        if (isHealthConnect) {
+                            showHealthConnectDialog = true
+                        } else {
+                            openSpecialAccess(context, item.specialMarker, packageName)
+                        }
                     }
                 } else {
                     Toast.makeText(
@@ -197,6 +206,31 @@ private fun PermissionRow(
                         Toast.LENGTH_LONG
                     ).show()
                 }
+            }
+        )
+    }
+
+    if (showHealthConnectDialog) {
+        SkinAlertDialog(
+            onDismissRequest = { showHealthConnectDialog = false },
+            title = { Text("Health Connect permission needed") },
+            text = {
+                Text(
+                    "Gotcha can't read your health data yet. Open Health Connect, " +
+                        "find Gotcha under App permissions, and allow the data types " +
+                        "you're comfortable sharing, then return here."
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showHealthConnectDialog = false
+                        openSpecialAccess(context, ToolResult.HEALTH_CONNECT, packageName)
+                    }
+                ) { Text("Open Health Connect") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showHealthConnectDialog = false }) { Text("Not now") }
             }
         )
     }
@@ -244,20 +278,10 @@ internal fun openSpecialAccess(
                 `package` = it.`package`
             }
         }
-        ToolResult.HEALTH_CONNECT -> {
-            if (HealthConnectClient.getSdkStatus(context) == HealthConnectClient.SDK_AVAILABLE) {
-                PermissionController.createRequestPermissionResultContract()
-                    .createIntent(context, HealthTool.PERMISSIONS)
-            } else {
-                // No provider (or one that is out of date): steer to the Play listing instead of
-                // crash-launching a screen nothing can handle — same journey as the agent path in
-                // MainActivity.requestHealthConnect.
-                Intent(
-                    Intent.ACTION_VIEW,
-                    Uri.parse("market://details?id=com.google.android.apps.healthdata")
-                )
-            }
-        }
+        // Resolves the SDK's permission screen, or a fallback that actually
+        // exists on this device, so the toggle can never crash the app with an
+        // ActivityNotFoundException (see healthConnectPermissionIntent).
+        ToolResult.HEALTH_CONNECT -> healthConnectPermissionIntent(context)
         // Only the Termux half of the journey: this path has no Activity to request the runtime
         // permission from, and the allow-external-apps property can only be set inside Termux.
         // MainActivity.requestTermuxAccess handles both halves when the agent asks.
@@ -266,7 +290,9 @@ internal fun openSpecialAccess(
     }
     if (intent != null) {
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        context.startActivity(intent)
+        // A routing mistake or an OEM quirk must surface as a silent no-op, never
+        // a crash — the settings toggle should degrade, not take the app down.
+        runCatching { context.startActivity(intent) }
     }
     return intent
 }

--- a/app/src/main/java/com/gotcha/ui/PersonalInfoScreen.kt
+++ b/app/src/main/java/com/gotcha/ui/PersonalInfoScreen.kt
@@ -96,6 +96,13 @@ fun PersonalInfoScreen(
                 "assistant at the start of every conversation so it doesn't have to ask.",
             style = MaterialTheme.typography.bodySmall
         )
+        Text(
+            "For more personalized results, keep this profile up to date — or just " +
+                "ask Gotcha to add things like your personal website, GitHub link, " +
+                "or CV (PDF), and it will record them here for you.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
         OutlinedTextField(
             value = userName,
             onValueChange = { userName = it },

--- a/app/src/main/java/com/gotcha/ui/PersonalInfoScreen.kt
+++ b/app/src/main/java/com/gotcha/ui/PersonalInfoScreen.kt
@@ -98,8 +98,8 @@ fun PersonalInfoScreen(
         )
         Text(
             "For more personalized results, keep this profile up to date — or just " +
-                "ask Gotcha to add things like your personal website, GitHub link, " +
-                "or CV (PDF), and it will record them here for you.",
+                "ask Gotcha to record things like your personal website, GitHub link, " +
+                "or CV (PDF) in your profile for you.",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )

--- a/app/src/main/java/com/gotcha/ui/ScreenCompanionPanelOverlay.kt
+++ b/app/src/main/java/com/gotcha/ui/ScreenCompanionPanelOverlay.kt
@@ -71,7 +71,7 @@ class ScreenCompanionPanelOverlay(private val context: Context) {
     private fun skin(): OverlaySkin = overlaySkin(
         appContext,
         runCatching { SettingsRepository(appContext).load().skinId }
-            .getOrDefault(Skins.DEFAULT_ID)
+            .getOrDefault(Skins.OVERLAY_FALLBACK_ID)
     )
 
     fun setVisibleForCapture(visible: Boolean) {

--- a/app/src/main/java/com/gotcha/ui/ScreenReadFlashOverlay.kt
+++ b/app/src/main/java/com/gotcha/ui/ScreenReadFlashOverlay.kt
@@ -34,7 +34,7 @@ class ScreenReadFlashOverlay(context: Context) {
             val colors = overlaySkin(
                 appContext,
                 runCatching { SettingsRepository(appContext).load().skinId }
-                    .getOrDefault(Skins.DEFAULT_ID)
+                    .getOrDefault(Skins.OVERLAY_FALLBACK_ID)
             )
             val flash = ScreenReadFlashView(appContext, colors)
             try {

--- a/app/src/main/java/com/gotcha/ui/SettingsCommon.kt
+++ b/app/src/main/java/com/gotcha/ui/SettingsCommon.kt
@@ -387,6 +387,10 @@ fun SamosaAuthSection(
  * toggleable and no-op silently. [switchContentDescription] names the `Switch`
  * for the same reason — it is what a UiAutomator/Maestro flow, which cannot see
  * test tags, has to aim at.
+ *
+ * [enabled] disables the `Switch` (greyed out, no tap effect) for a row whose
+ * action depends on a prerequisite the user has not met yet; the caller should
+ * also explain the prerequisite nearby.
  */
 @Composable
 fun SettingsToggleRow(
@@ -394,6 +398,7 @@ fun SettingsToggleRow(
     checked: Boolean,
     onCheckedChange: (Boolean) -> Unit,
     isLarge: Boolean = false,
+    enabled: Boolean = true,
     switchTestTag: String? = null,
     switchContentDescription: String? = null,
     modifier: Modifier = Modifier
@@ -405,11 +410,17 @@ fun SettingsToggleRow(
     ) {
         Text(
             label,
-            style = if (isLarge) MaterialTheme.typography.bodyLarge else MaterialTheme.typography.bodyMedium
+            style = if (isLarge) MaterialTheme.typography.bodyLarge else MaterialTheme.typography.bodyMedium,
+            color = if (enabled) {
+                MaterialTheme.colorScheme.onSurface
+            } else {
+                MaterialTheme.colorScheme.onSurfaceVariant
+            }
         )
         Switch(
             checked = checked,
             onCheckedChange = onCheckedChange,
+            enabled = enabled,
             modifier = Modifier
                 .then(if (switchTestTag != null) Modifier.testTag(switchTestTag) else Modifier)
                 .then(

--- a/app/src/main/java/com/gotcha/ui/SkillsScreen.kt
+++ b/app/src/main/java/com/gotcha/ui/SkillsScreen.kt
@@ -55,7 +55,11 @@ fun SkillsScreen(
 ) {
     val initial = remember { load() }
     var disabledSkills by remember { mutableStateOf(initial.disabledSkills) }
-    var communitySkillHosts by remember { mutableStateOf(initial.communitySkillHosts) }
+    // The Samosa AI host is built in and cannot be removed; re-add it in case an
+    // older version let it slip out of the saved set.
+    var communitySkillHosts by remember {
+        mutableStateOf(initial.communitySkillHosts + BuildConfig.SAMOSA_SKILL_HOST)
+    }
     var communitySkillUrl by remember { mutableStateOf("") }
     var communitySkillPasteJson by remember { mutableStateOf("") }
     var communityImportBusy by remember { mutableStateOf(false) }
@@ -74,7 +78,8 @@ fun SkillsScreen(
     /** This page's fields, copied onto [base]. */
     fun applySkills(base: Settings) = base.copy(
         disabledSkills = disabledSkills,
-        communitySkillHosts = communitySkillHosts
+        // The Samosa AI host is pinned; saving always keeps it in the allowlist.
+        communitySkillHosts = communitySkillHosts + BuildConfig.SAMOSA_SKILL_HOST
     )
 
     SettingsScaffold(title = SettingsPage.SKILLS.title, onBack = onBack, overlay = overlay) {
@@ -340,6 +345,7 @@ fun SkillsScreen(
                 "Default: ${BuildConfig.SAMOSA_SKILL_HOST}.",
             style = MaterialTheme.typography.bodySmall
         )
+        val pinnedHost = BuildConfig.SAMOSA_SKILL_HOST
         communitySkillHosts.forEach { host ->
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -347,10 +353,18 @@ fun SkillsScreen(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(host, modifier = Modifier.weight(1f))
-                TextButton(onClick = {
-                    communitySkillHosts = communitySkillHosts - host
-                    onSave { applySkills(it) }
-                }) { Text("Remove") }
+                if (host.equals(pinnedHost, ignoreCase = true)) {
+                    Text(
+                        "Built-in",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                } else {
+                    TextButton(onClick = {
+                        communitySkillHosts = communitySkillHosts - host
+                        onSave { applySkills(it) }
+                    }) { Text("Remove") }
+                }
             }
         }
         var newHost by remember { mutableStateOf("") }

--- a/app/src/main/java/com/gotcha/ui/SkillsScreen.kt
+++ b/app/src/main/java/com/gotcha/ui/SkillsScreen.kt
@@ -55,10 +55,16 @@ fun SkillsScreen(
 ) {
     val initial = remember { load() }
     var disabledSkills by remember { mutableStateOf(initial.disabledSkills) }
-    // The Samosa AI host is built in and cannot be removed; re-add it in case an
-    // older version let it slip out of the saved set.
+    val pinnedHost = BuildConfig.SAMOSA_SKILL_HOST
+    // The Samosa AI host is built in and cannot be removed. Normalize its casing
+    // (an older version may have persisted a case-variant) and re-add it, so it
+    // always renders as exactly one "Built-in" row with no orphan duplicate.
     var communitySkillHosts by remember {
-        mutableStateOf(initial.communitySkillHosts + BuildConfig.SAMOSA_SKILL_HOST)
+        mutableStateOf(
+            initial.communitySkillHosts
+                .filterNot { it.equals(pinnedHost, ignoreCase = true) }
+                .toSet() + pinnedHost
+        )
     }
     var communitySkillUrl by remember { mutableStateOf("") }
     var communitySkillPasteJson by remember { mutableStateOf("") }
@@ -78,8 +84,11 @@ fun SkillsScreen(
     /** This page's fields, copied onto [base]. */
     fun applySkills(base: Settings) = base.copy(
         disabledSkills = disabledSkills,
-        // The Samosa AI host is pinned; saving always keeps it in the allowlist.
-        communitySkillHosts = communitySkillHosts + BuildConfig.SAMOSA_SKILL_HOST
+        // The Samosa AI host is pinned; saving always keeps exactly one
+        // canonical-cased entry in the allowlist.
+        communitySkillHosts = communitySkillHosts
+            .filterNot { it.equals(pinnedHost, ignoreCase = true) }
+            .toSet() + pinnedHost
     )
 
     SettingsScaffold(title = SettingsPage.SKILLS.title, onBack = onBack, overlay = overlay) {
@@ -345,7 +354,6 @@ fun SkillsScreen(
                 "Default: ${BuildConfig.SAMOSA_SKILL_HOST}.",
             style = MaterialTheme.typography.bodySmall
         )
-        val pinnedHost = BuildConfig.SAMOSA_SKILL_HOST
         communitySkillHosts.forEach { host ->
             Row(
                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/gotcha/ui/SpeechScreen.kt
+++ b/app/src/main/java/com/gotcha/ui/SpeechScreen.kt
@@ -157,6 +157,14 @@ fun SpeechScreen(
     }
 
     SettingsScaffold(title = SettingsPage.SPEECH.title, onBack = onBack, overlay = overlay) {
+        // ---- Voice / speech recommendations ----
+        Text(
+            "For high-quality single-language speech (e.g. English primarily), " +
+                "SAMOSA AI's TTS is the recommendation. SAMOSA AI's STT is the " +
+                "recommended transcription engine.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
         val samosaAudioSelected = ttsProvider == AudioProvider.SAMOSA_AI ||
             sttProvider == AudioProvider.SAMOSA_AI
         if (samosaAudioSelected) {

--- a/app/src/main/java/com/gotcha/ui/theme/Skin.kt
+++ b/app/src/main/java/com/gotcha/ui/theme/Skin.kt
@@ -379,7 +379,27 @@ object Skins {
 
     val all = listOf(Aura, Vellum, Orchid, Nocturne, DeepSpaceDark, DeepSpaceLight)
 
+    /**
+     * The skin id a fresh install lands on, and the value the theme uses when
+     * nothing is otherwise chosen.
+     *
+     * This is the *product* default, not the safety fallback. [byId] still
+     * degrades unknown ids to [DeepSpaceDark], and overlays fall back to
+     * [OVERLAY_FALLBACK_ID] when the stored skin cannot be read — the safe
+     * opaque original, so an error path never pops a light panel over an
+     * arbitrary screen.
+     */
     const val DEFAULT_ID = "vellum"
+
+    /**
+     * The skin id an overlay paints when the stored skin cannot be read.
+     *
+     * Deliberately the opaque Deep Space original, not [DEFAULT_ID]: an overlay
+     * floats over somebody else's app, and a light frosted panel appearing over
+     * an arbitrary screen in an error path is worse than the safe opaque dark
+     * one the app has always used.
+     */
+    val OVERLAY_FALLBACK_ID: String get() = DeepSpaceDark.id
 
     fun byId(id: String): Skin = all.firstOrNull { it.id == id } ?: DeepSpaceDark
 }

--- a/app/src/main/java/com/gotcha/ui/theme/Skin.kt
+++ b/app/src/main/java/com/gotcha/ui/theme/Skin.kt
@@ -379,7 +379,7 @@ object Skins {
 
     val all = listOf(Aura, Vellum, Orchid, Nocturne, DeepSpaceDark, DeepSpaceLight)
 
-    const val DEFAULT_ID = "deepspace"
+    const val DEFAULT_ID = "vellum"
 
     fun byId(id: String): Skin = all.firstOrNull { it.id == id } ?: DeepSpaceDark
 }

--- a/app/src/main/java/com/gotcha/util/GotchaLog.kt
+++ b/app/src/main/java/com/gotcha/util/GotchaLog.kt
@@ -10,19 +10,22 @@ import com.gotcha.BuildConfig
  * the field.
  */
 object GotchaLog {
-    fun d(tag: String, message: () -> String) {
+    // inline: in release BuildConfig.DEBUG folds to false, so the whole call
+    // (lambda allocation included) is removed at the call site rather than
+    // paying for a Function0 instance that never runs.
+    inline fun d(tag: String, message: () -> String) {
         if (BuildConfig.DEBUG) Log.d(tag, message())
     }
 
-    fun d(tag: String, throwable: Throwable?, message: () -> String) {
+    inline fun d(tag: String, throwable: Throwable?, message: () -> String) {
         if (BuildConfig.DEBUG) Log.d(tag, message(), throwable)
     }
 
-    fun v(tag: String, message: () -> String) {
+    inline fun v(tag: String, message: () -> String) {
         if (BuildConfig.DEBUG) Log.v(tag, message())
     }
 
-    fun v(tag: String, throwable: Throwable?, message: () -> String) {
+    inline fun v(tag: String, throwable: Throwable?, message: () -> String) {
         if (BuildConfig.DEBUG) Log.v(tag, message(), throwable)
     }
 }

--- a/app/src/main/java/com/gotcha/util/GotchaLog.kt
+++ b/app/src/main/java/com/gotcha/util/GotchaLog.kt
@@ -1,0 +1,28 @@
+package com.gotcha.util
+
+import android.util.Log
+import com.gotcha.BuildConfig
+
+/**
+ * App-wide logging facade. `d`/`v` are no-ops in release builds: `BuildConfig.DEBUG`
+ * folds to a constant `false`, and the message is a lambda so its string is never
+ * built either. Raw `Log.w`/`Log.e` stay in use for failures worth reporting from
+ * the field.
+ */
+object GotchaLog {
+    fun d(tag: String, message: () -> String) {
+        if (BuildConfig.DEBUG) Log.d(tag, message())
+    }
+
+    fun d(tag: String, throwable: Throwable?, message: () -> String) {
+        if (BuildConfig.DEBUG) Log.d(tag, message(), throwable)
+    }
+
+    fun v(tag: String, message: () -> String) {
+        if (BuildConfig.DEBUG) Log.v(tag, message())
+    }
+
+    fun v(tag: String, throwable: Throwable?, message: () -> String) {
+        if (BuildConfig.DEBUG) Log.v(tag, message(), throwable)
+    }
+}

--- a/app/src/test/java/com/gotcha/data/SettingsTest.kt
+++ b/app/src/test/java/com/gotcha/data/SettingsTest.kt
@@ -2,6 +2,8 @@ package com.gotcha.data
 
 import com.gotcha.audio.AudioProvider
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class SettingsTest {
@@ -324,5 +326,36 @@ class SettingsTest {
         assertEquals(0.35f, enabled.wakeWordSensitivity, 0.001f)
         // Untouched fields stay at their defaults.
         assertEquals(false, enabled.assistiveBallEnabled)
+    }
+
+    @Test
+    fun `wake word listening mode defaults to always`() {
+        val defaults = Settings()
+        assertEquals(WakeWordListeningMode.ALWAYS, defaults.wakeWordListeningMode)
+    }
+
+    @Test
+    fun `wake word listening mode is an independent field on copy`() {
+        val defaults = Settings()
+        val screenOn = defaults.copy(wakeWordListeningMode = WakeWordListeningMode.SCREEN_ON)
+        assertEquals(WakeWordListeningMode.SCREEN_ON, screenOn.wakeWordListeningMode)
+        // Untouched fields stay at their defaults.
+        assertEquals(false, screenOn.wakeWordEnabled)
+        assertEquals(0.75f, screenOn.wakeWordSensitivity, 0.001f)
+    }
+
+    @Test
+    fun `wake word listening mode gates on screen interactivity`() {
+        val always = WakeWordListeningMode.ALWAYS
+        assertTrue(always.allows(screenInteractive = true))
+        assertTrue(always.allows(screenInteractive = false))
+
+        val screenOn = WakeWordListeningMode.SCREEN_ON
+        assertTrue(screenOn.allows(screenInteractive = true))
+        assertFalse(screenOn.allows(screenInteractive = false))
+
+        val screenOff = WakeWordListeningMode.SCREEN_OFF
+        assertFalse(screenOff.allows(screenInteractive = true))
+        assertTrue(screenOff.allows(screenInteractive = false))
     }
 }

--- a/app/src/test/java/com/gotcha/data/SkinMigrationTest.kt
+++ b/app/src/test/java/com/gotcha/data/SkinMigrationTest.kt
@@ -21,12 +21,22 @@ class SkinMigrationTest {
     }
 
     /**
-     * SYSTEM was the default, so the overwhelming majority of installs are on
-     * it and never chose a theme. Vellum is the new default landing place.
+     * SYSTEM was the stored default, so it is the theme the app actually showed
+     * for most installs. Flipping that population from dark to light silently
+     * would be a regression — it stays on Deep Space Dark.
      */
     @Test
-    fun `someone who never chose a theme lands on the Vellum default`() {
-        assertEquals(SKIN_VELLUM, migrateSkinId("SYSTEM"))
+    fun `someone on SYSTEM keeps the dark Deep Space original`() {
+        assertEquals(SKIN_DEEP_SPACE_DARK, migrateSkinId("SYSTEM"))
+    }
+
+    /**
+     * A fresh install never writes `theme_mode` (the new skin system replaced
+     * it entirely), so null is the only true "never chose" population. That is
+     * who lands on the Vellum default.
+     */
+    @Test
+    fun `a fresh install that never chose a theme lands on the Vellum default`() {
         assertEquals(SKIN_VELLUM, migrateSkinId(null))
     }
 

--- a/app/src/test/java/com/gotcha/data/SkinMigrationTest.kt
+++ b/app/src/test/java/com/gotcha/data/SkinMigrationTest.kt
@@ -21,21 +21,20 @@ class SkinMigrationTest {
     }
 
     /**
-     * SYSTEM was the default, and the overwhelming majority of installs are on
-     * it. Dark is the honest landing place: it is what the app looked like for
-     * most of them, and it is the skin the picker calls the original.
+     * SYSTEM was the default, so the overwhelming majority of installs are on
+     * it and never chose a theme. Vellum is the new default landing place.
      */
     @Test
-    fun `someone who never changed it lands on the original`() {
-        assertEquals(SKIN_DEEP_SPACE_DARK, migrateSkinId("SYSTEM"))
-        assertEquals(SKIN_DEEP_SPACE_DARK, migrateSkinId(null))
+    fun `someone who never chose a theme lands on the Vellum default`() {
+        assertEquals(SKIN_VELLUM, migrateSkinId("SYSTEM"))
+        assertEquals(SKIN_VELLUM, migrateSkinId(null))
     }
 
     /** A value from a build that no longer exists must not throw. */
     @Test
-    fun `an unrecognised legacy value falls back rather than failing`() {
-        assertEquals(SKIN_DEEP_SPACE_DARK, migrateSkinId("AUTO_BATTERY"))
-        assertEquals(SKIN_DEEP_SPACE_DARK, migrateSkinId(""))
+    fun `an unrecognised legacy value falls back to Vellum rather than failing`() {
+        assertEquals(SKIN_VELLUM, migrateSkinId("AUTO_BATTERY"))
+        assertEquals(SKIN_VELLUM, migrateSkinId(""))
     }
 
     /** The ids it produces have to be ids the picker actually knows. */

--- a/app/src/test/java/com/gotcha/service/WakeWordGateTest.kt
+++ b/app/src/test/java/com/gotcha/service/WakeWordGateTest.kt
@@ -1,0 +1,156 @@
+package com.gotcha.service
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The gate is the one piece of the battery work that can be tested off-device:
+ * it is pure arithmetic over frame levels, with no ONNX and no Android.
+ */
+class WakeWordGateTest {
+
+    /** Enough frames to prime the floor window; the gate is forced open until then. */
+    private fun WakeWordGate.prime(levelDb: Float = QUIET_ROOM_DB) {
+        repeat(PRIMING_FRAMES) { onLevel(levelDb) }
+    }
+
+    @Test
+    fun beforeTheFloorIsLearned_theGateStaysOpen() {
+        val gate = WakeWordGate()
+        // Digital silence, the most gate-able input there is — but with no
+        // learned floor, closing would be a guess, and a wrong guess drops the
+        // first seconds of listening.
+        repeat(PRIMING_FRAMES) { assertTrue(gate.onLevel(WakeWordGate.SILENT_DB)) }
+        assertFalse(gate.priming)
+    }
+
+    @Test
+    fun quietRoom_closesTheGateOnceTheHangoverExpires() {
+        val gate = WakeWordGate()
+        gate.prime()
+
+        // The hangover has to run out first — it is armed by the priming phase.
+        repeat(HANGOVER_FRAMES) { assertTrue(gate.onLevel(QUIET_ROOM_DB)) }
+        assertFalse(gate.onLevel(QUIET_ROOM_DB))
+        assertFalse(gate.onLevel(QUIET_ROOM_DB))
+    }
+
+    @Test
+    fun quietRoomFloor_sitsWellBelowSilenceDetectorsClamp() {
+        val gate = WakeWordGate()
+        gate.prime(levelDb = -72f)
+
+        // SilenceDetector.rmsDb bottoms out at -50 dBFS, so a gate built on it
+        // could never close in a room this quiet. This one can.
+        assertTrue(
+            "threshold ${gate.thresholdDb} should be below -50 dBFS in a quiet room",
+            gate.thresholdDb < -50f
+        )
+        repeat(HANGOVER_FRAMES + 1) { gate.onLevel(-72f) }
+        assertFalse(gate.onLevel(-72f))
+        assertTrue(gate.onLevel(-40f))
+    }
+
+    @Test
+    fun aSingleLoudFrame_opensTheGateImmediately() {
+        val gate = WakeWordGate()
+        gate.prime()
+        repeat(HANGOVER_FRAMES + 1) { gate.onLevel(QUIET_ROOM_DB) }
+        assertFalse(gate.onLevel(QUIET_ROOM_DB))
+
+        // No accept-streak, deliberately: a spurious open costs milliseconds of
+        // CPU, a missed onset costs the user their wake word.
+        assertTrue(gate.onLevel(SPEECH_DB))
+    }
+
+    @Test
+    fun afterSpeechStops_theGateHoldsOpenForTheHangover() {
+        val gate = WakeWordGate()
+        gate.prime()
+        assertTrue(gate.onLevel(SPEECH_DB))
+
+        // A pause inside a sentence must not re-arm the pipeline: each re-arm
+        // replays the classifier window.
+        repeat(HANGOVER_FRAMES) { index ->
+            assertTrue("closed $index frames into the hangover", gate.onLevel(QUIET_ROOM_DB))
+        }
+        assertFalse(gate.onLevel(QUIET_ROOM_DB))
+    }
+
+    @Test
+    fun aLoudRoom_raisesTheThresholdWithIt() {
+        val quiet = WakeWordGate().apply { prime(levelDb = -70f) }
+        val loud = WakeWordGate().apply { prime(levelDb = -30f) }
+
+        assertTrue(
+            "a loud room should demand a louder frame (${quiet.thresholdDb} vs ${loud.thresholdDb})",
+            loud.thresholdDb > quiet.thresholdDb
+        )
+        // Ambient chatter at the room's own level is not an onset.
+        repeat(HANGOVER_FRAMES + 1) { loud.onLevel(-30f) }
+        assertFalse(loud.onLevel(-30f))
+    }
+
+    @Test
+    fun sustainedSpeech_cannotDragTheFloorUpToItsOwnLevel() {
+        val gate = WakeWordGate()
+        gate.prime(levelDb = -70f)
+
+        // Ten seconds of talking. Real speech is not a flat level — syllables,
+        // word gaps and breaths put a good fraction of frames far below the
+        // peaks, and the floor is a low percentile precisely so it tracks those
+        // dips rather than the speech itself.
+        val syllable = listOf(SPEECH_DB, -30f, -58f, SPEECH_DB, -34f, -62f, -40f, SPEECH_DB)
+        repeat(125) { index -> gate.onLevel(syllable[index % syllable.size]) }
+
+        assertTrue(
+            "threshold ${gate.thresholdDb} climbed to speech level",
+            gate.thresholdDb < SPEECH_DB
+        )
+        assertTrue(gate.onLevel(SPEECH_DB))
+    }
+
+    @Test
+    fun anUnbrokenConstantTone_becomesTheFloorAndIsGatedOut() {
+        val gate = WakeWordGate()
+        gate.prime(levelDb = -70f)
+
+        // A fan, a hum, a held note: once it has filled the whole floor window
+        // it *is* the room's ambient level, and gating it out is the point.
+        // Safe to do because re-arming replays the classifier window from
+        // retained mel rows, so even if this were speech, closing the gate
+        // costs CPU on the next onset and never costs a detection.
+        repeat(PRIMING_FRAMES + HANGOVER_FRAMES + 1) { gate.onLevel(-25f) }
+        assertFalse(gate.onLevel(-25f))
+
+        // Anything that rises above the new ambient still gets through.
+        assertTrue(gate.onLevel(-15f))
+    }
+
+    @Test
+    fun rmsDb_isUnclampedAndTracksLevel() {
+        val fullScale = ShortArray(160) { Short.MAX_VALUE }
+        assertEquals(0f, WakeWordGate.rmsDb(fullScale, fullScale.size), 0.1f)
+
+        assertEquals(WakeWordGate.SILENT_DB, WakeWordGate.rmsDb(ShortArray(160), 160), 0.001f)
+        assertEquals(WakeWordGate.SILENT_DB, WakeWordGate.rmsDb(fullScale, 0), 0.001f)
+
+        // The point of not reusing SilenceDetector.rmsDb: this keeps resolving
+        // below -50 dBFS instead of flattening out there.
+        val veryQuiet = ShortArray(160) { 20 }
+        val quieter = ShortArray(160) { 5 }
+        assertTrue(WakeWordGate.rmsDb(veryQuiet, 160) < -50f)
+        assertTrue(WakeWordGate.rmsDb(quieter, 160) < WakeWordGate.rmsDb(veryQuiet, 160))
+    }
+
+    private companion object {
+        /** Mirrors WakeWordGate.FLOOR_WINDOW / HANGOVER_FRAMES (both private). */
+        const val PRIMING_FRAMES = 50
+        const val HANGOVER_FRAMES = 38
+
+        const val QUIET_ROOM_DB = -70f
+        const val SPEECH_DB = -25f
+    }
+}

--- a/app/src/test/java/com/gotcha/service/WakeWordGateTest.kt
+++ b/app/src/test/java/com/gotcha/service/WakeWordGateTest.kt
@@ -130,6 +130,30 @@ class WakeWordGateTest {
     }
 
     @Test
+    fun theThresholdKeepsTrackingTheRoomAfterPriming() {
+        val gate = WakeWordGate()
+        gate.prime(levelDb = -70f)
+        val quietThreshold = gate.thresholdDb
+
+        // The floor is cached and refreshed periodically rather than recomputed
+        // per frame. A cache that never refreshed would leave the gate judging
+        // a loud room against a silent one's threshold forever, so pin that it
+        // still moves — one refresh window is well inside 60 frames.
+        repeat(60) { gate.onLevel(-30f) }
+        assertTrue(
+            "threshold froze at $quietThreshold after the room got louder (now ${gate.thresholdDb})",
+            gate.thresholdDb > quietThreshold
+        )
+
+        // And back down again when the room goes quiet.
+        repeat(60) { gate.onLevel(-70f) }
+        assertTrue(
+            "threshold stayed high (${gate.thresholdDb}) after the room went quiet",
+            gate.thresholdDb < -50f
+        )
+    }
+
+    @Test
     fun rmsDb_isUnclampedAndTracksLevel() {
         val fullScale = ShortArray(160) { Short.MAX_VALUE }
         assertEquals(0f, WakeWordGate.rmsDb(fullScale, fullScale.size), 0.1f)

--- a/app/src/test/java/com/gotcha/ui/PermissionsRoutingTest.kt
+++ b/app/src/test/java/com/gotcha/ui/PermissionsRoutingTest.kt
@@ -1,11 +1,14 @@
 package com.gotcha.ui
 
 import android.content.Context
+import android.content.Intent
 import androidx.health.connect.client.PermissionController
 import androidx.test.core.app.ApplicationProvider
 import com.gotcha.tools.HealthPermissionState
 import com.gotcha.tools.HealthTool
 import com.gotcha.tools.ToolResult
+import com.gotcha.tools.healthConnectManagePermissionsIntent
+import com.gotcha.tools.healthConnectPermissionIntent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -81,5 +84,30 @@ class PermissionsRoutingTest {
         // Health Connect is not installed under Robolectric; the resume-refresh
         // path added to PermissionsSection must not throw on such devices.
         assertFalse(HealthPermissionState.refresh(context))
+    }
+
+    @Test
+    fun healthConnectManagePermissionsIntentTargetsThisApp() {
+        // The Android 14+ per-app permission manager, which OEM controllers
+        // register even when the SDK's RequestMultiplePermissions screen is not
+        // resolvable. Must name the app whose permissions are being managed.
+        val intent = healthConnectManagePermissionsIntent(context)
+        assertEquals(
+            "android.health.connect.action.MANAGE_HEALTH_PERMISSIONS",
+            intent.action
+        )
+        assertEquals(context.packageName, intent.getStringExtra(Intent.EXTRA_PACKAGE_NAME))
+    }
+
+    @Test
+    fun healthConnectPermissionIntentSteersToPlayListingWhenProviderAbsent() {
+        // No Health Connect provider under Robolectric: the helper must pick the
+        // Play listing, not crash or fire an intent nothing can handle.
+        val intent = healthConnectPermissionIntent(context)
+        assertNotNull("there must always be a steer, never a crash", intent)
+        assertEquals(
+            "market://details?id=com.google.android.apps.healthdata",
+            intent?.getData()?.toString()
+        )
     }
 }

--- a/app/src/test/java/com/gotcha/ui/theme/OverlaySkinTest.kt
+++ b/app/src/test/java/com/gotcha/ui/theme/OverlaySkinTest.kt
@@ -68,8 +68,9 @@ class OverlaySkinTest {
 
     @Test
     fun `an unknown skin falls back rather than throwing`() {
+        // byId degrades unknown ids to the original opaque Deep Space skin.
         val fallback = overlaySkin(context, "a-skin-from-a-future-build")
-        assertEquals(overlaySkin(context, Skins.DEFAULT_ID).accent, fallback.accent)
+        assertEquals(overlaySkin(context, Skins.DeepSpaceDark.id).accent, fallback.accent)
     }
 
     /**

--- a/app/src/test/java/com/gotcha/ui/theme/OverlaySkinTest.kt
+++ b/app/src/test/java/com/gotcha/ui/theme/OverlaySkinTest.kt
@@ -74,6 +74,24 @@ class OverlaySkinTest {
     }
 
     /**
+     * When the stored skin cannot be read (e.g. encrypted-prefs corruption), the
+     * overlays paint the safe opaque Deep Space original — not the light Vellum
+     * product default. A light frosted panel popping up over an arbitrary screen
+     * in an error path would be a regression, so the split is pinned here.
+     */
+    @Test
+    fun `the overlay load-failure fallback is the opaque Deep Space original, not the light default`() {
+        assertEquals(Skins.DeepSpaceDark.id, Skins.OVERLAY_FALLBACK_ID)
+        assertTrue(
+            "the load-failure fallback must not drift onto the light ${Skins.DEFAULT_ID} default",
+            Skins.OVERLAY_FALLBACK_ID != Skins.DEFAULT_ID
+        )
+        val fallback = overlaySkin(context, Skins.OVERLAY_FALLBACK_ID)
+        assertEquals(255, Color.alpha(fallback.surface))
+        assertEquals(overlaySkin(context, Skins.DeepSpaceDark.id).surface, fallback.surface)
+    }
+
+    /**
      * Depth over another app's screen comes from the edge, not from blur — so
      * the edge has to actually be visible against the surface it sits on. Which
      * direction that is depends on the skin: a white hairline on Vellum's

--- a/app/src/test/java/com/gotcha/util/GotchaLogTest.kt
+++ b/app/src/test/java/com/gotcha/util/GotchaLogTest.kt
@@ -1,0 +1,52 @@
+package com.gotcha.util
+
+import android.util.Log
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLog
+
+/**
+ * Debug-variant behaviour of [GotchaLog]: messages are evaluated and written to
+ * logcat. The mirror-image release assertions (no output, lambda never invoked)
+ * live in GotchaLogReleaseTest, which only runs under
+ * `:app:testReleaseUnitTest` where `BuildConfig.DEBUG` is false.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class GotchaLogTest {
+
+    @Test
+    fun `d evaluates the message and writes to Log`() {
+        var evaluated = false
+        GotchaLog.d("GotchaLogTest") {
+            evaluated = true
+            "debug message"
+        }
+        assertTrue(evaluated)
+        val entry = ShadowLog.getLogs().last { it.tag == "GotchaLogTest" }
+        assertEquals(Log.DEBUG, entry.type)
+        assertEquals("debug message", entry.msg)
+    }
+
+    @Test
+    fun `d with throwable passes both to Log`() {
+        val cause = RuntimeException("boom")
+        GotchaLog.d("GotchaLogTest", cause) { "with throwable" }
+        val entry = ShadowLog.getLogs().last { it.tag == "GotchaLogTest" }
+        assertEquals("with throwable", entry.msg)
+        assertSame(cause, entry.throwable)
+    }
+
+    @Test
+    fun `v evaluates the message and writes to Log`() {
+        GotchaLog.v("GotchaLogTest") { "verbose message" }
+        val entry = ShadowLog.getLogs().last { it.tag == "GotchaLogTest" }
+        assertEquals(Log.VERBOSE, entry.type)
+        assertEquals("verbose message", entry.msg)
+    }
+}

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -61,6 +61,13 @@ exceptions:
   TooGenericExceptionCaught:
     active: false
 
+gotcha:
+  NoRawDebugLog:
+    active: true
+    # GotchaLog.kt is the one sanctioned place raw Log.d/Log.v appears (behind
+    # BuildConfig.DEBUG). Everything else must route through the facade.
+    excludes: ["**/GotchaLog.kt"]
+
 formatting:
   MaximumLineLength:
     maxLineLength: 140

--- a/detekt-rules/build.gradle.kts
+++ b/detekt-rules/build.gradle.kts
@@ -1,0 +1,12 @@
+// Custom detekt rules for the Gotcha repo. Compiled against detekt-api 1.23.6
+// (the version the app pins) and the same kotlin-compiler-embeddable 1.9.x that
+// detekt bundles, so rule bytecode stays binary-compatible at runtime.
+plugins {
+    `java-library`
+    kotlin("jvm")
+}
+
+dependencies {
+    compileOnly("io.gitlab.arturbosch.detekt:detekt-api:1.23.6")
+    compileOnly("org.jetbrains.kotlin:kotlin-compiler-embeddable:1.9.22")
+}

--- a/detekt-rules/build.gradle.kts
+++ b/detekt-rules/build.gradle.kts
@@ -9,4 +9,7 @@ plugins {
 dependencies {
     compileOnly("io.gitlab.arturbosch.detekt:detekt-api:1.23.6")
     compileOnly("org.jetbrains.kotlin:kotlin-compiler-embeddable:1.9.22")
+    testImplementation("io.gitlab.arturbosch.detekt:detekt-api:1.23.6")
+    testImplementation("io.gitlab.arturbosch.detekt:detekt-test:1.23.6")
+    testImplementation("junit:junit:4.13.2")
 }

--- a/detekt-rules/src/main/kotlin/com/gotcha/detekt/GotchaRules.kt
+++ b/detekt-rules/src/main/kotlin/com/gotcha/detekt/GotchaRules.kt
@@ -1,0 +1,57 @@
+package com.gotcha.detekt
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.RuleSet
+import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+
+/**
+ * Blocks raw `android.util.Log.d` / `Log.v` calls. Those ship into release builds
+ * (`isMinifyEnabled = false`, so R8 keeps them) and always build their message
+ * string, even when nothing consumes the output. Debug-level logging must go
+ * through `com.gotcha.util.GotchaLog`, whose `d`/`v` are compile-time no-ops in
+ * release.
+ */
+class NoRawDebugLog(config: Config) : Rule(config) {
+    override val issue = Issue(
+        id = "NoRawDebugLog",
+        severity = Severity.Security,
+        description = "Raw Log.d/Log.v ships in release builds and always builds its " +
+            "message string. Use com.gotcha.util.GotchaLog.d/v, which is a compile-time " +
+            "no-op in release.",
+        debt = Debt.FIVE_MINS
+    )
+
+    override fun visitCallExpression(expression: KtCallExpression) {
+        super.visitCallExpression(expression)
+        val method = expression.calleeExpression?.text
+        if (method != "d" && method != "v") return
+        val qualified = expression.parent as? KtDotQualifiedExpression ?: return
+        val receiver = qualified.receiverExpression.text
+        if (receiver != "Log" && receiver != "android.util.Log") return
+        report(
+            CodeSmell(
+                issue,
+                Entity.from(qualified),
+                "Use GotchaLog.$method instead of raw android.util.Log.$method."
+            )
+        )
+    }
+}
+
+/** Registers the repo's custom detekt rules. */
+class GotchaRuleSetProvider : RuleSetProvider {
+    override val ruleSetId: String = "gotcha"
+
+    override fun instance(config: Config): RuleSet = RuleSet(
+        ruleSetId,
+        listOf(NoRawDebugLog(config))
+    )
+}

--- a/detekt-rules/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider
+++ b/detekt-rules/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider
@@ -1,0 +1,1 @@
+com.gotcha.detekt.GotchaRuleSetProvider

--- a/detekt-rules/src/test/kotlin/com/gotcha/detekt/NoRawDebugLogTest.kt
+++ b/detekt-rules/src/test/kotlin/com/gotcha/detekt/NoRawDebugLogTest.kt
@@ -1,0 +1,57 @@
+package com.gotcha.detekt
+
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.lint
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NoRawDebugLogTest {
+
+    private val rule = NoRawDebugLog(TestConfig())
+
+    @Test
+    fun `reports Log dot d`() {
+        val code = """
+            import android.util.Log
+            fun f() { Log.d("TAG", "msg") }
+        """.trimIndent()
+        assertEquals(1, rule.lint(code).size)
+    }
+
+    @Test
+    fun `reports Log dot v`() {
+        val code = """
+            import android.util.Log
+            fun f() { Log.v("TAG", "msg") }
+        """.trimIndent()
+        assertEquals(1, rule.lint(code).size)
+    }
+
+    @Test
+    fun `reports fully qualified android util Log d`() {
+        val code = """
+            fun f() { android.util.Log.d("TAG", "msg") }
+        """.trimIndent()
+        assertEquals(1, rule.lint(code).size)
+    }
+
+    @Test
+    fun `does not report GotchaLog d`() {
+        val code = """
+            fun f() { GotchaLog.d("TAG") { "msg" } }
+        """.trimIndent()
+        assertEquals(0, rule.lint(code).size)
+    }
+
+    @Test
+    fun `does not report Log w or Log e`() {
+        val code = """
+            import android.util.Log
+            fun f() {
+                Log.w("TAG", "msg")
+                Log.e("TAG", "msg", IllegalStateException())
+            }
+        """.trimIndent()
+        assertEquals(0, rule.lint(code).size)
+    }
+}

--- a/docs/RUNNING_TESTS.md
+++ b/docs/RUNNING_TESTS.md
@@ -5,6 +5,19 @@ gotcha hit while getting Android 11–16 (API 30–36) coverage working on this
 machine (Windows, SDK at `%LOCALAPPDATA%\Android\Sdk`). For what the suite
 covers, see [`FEATURE_TEST_COVERAGE.md`](FEATURE_TEST_COVERAGE.md).
 
+> ⚠️ **Never run the instrumented suites (`:app:connectedDebugAndroidTest`,
+> `:app:apiNNDebugAndroidTest`, `:app:*GroupDebugAndroidTest`) against a
+> physical phone with real data.** The connected-test task **uninstalls the app
+> under test when it finishes**, which deletes the app's internal storage
+> (`/data/data/<pkg>`) *and* the Android Keystore key that
+> `EncryptedSharedPreferences` uses. Settings (LLM keys, Samosa session,
+> connector credentials, personal info) are **permanently unrecoverable** — even
+> Auto Backup cannot restore them, because the destroyed Keystore key cannot be
+> recreated. This already happened once on this project's test device and wiped
+> the configured settings. Use Gradle Managed Devices or an emulator (throwaway
+> state) for anything instrumented, and only ever `installDebug` (an upgrade,
+> which preserves data) on a real device.
+
 ## 1. One-time environment setup
 
 1. **JDK**: use Android Studio's bundled JBR, not a standalone JDK.
@@ -87,6 +100,13 @@ devices are headless by design. For a visible run, use §4 instead.
 GMD can't do this (see above). Instead, boot a *normal* AVD without the
 `-no-window` flag, then point the plain `connectedDebugAndroidTest` task at
 it (this drives whatever's attached via `adb`, not a GMD ephemeral device).
+
+> ⚠️ `connectedDebugAndroidTest` runs against **every device attached via
+> `adb`** and uninstalls the app under test when the run ends. Point it only at
+> an emulator — running it while a physical phone is connected (USB or wireless
+> adb) wipes that phone's app data and its encrypted settings (see the warning
+> at the top of this doc). Unplug the phone or filter with
+> `ANDROID_SERIAL`/`adb -s` before using this task.
 
 **Using the AVD that's already set up (`Pixel_7`, Android 13):**
 ```bash

--- a/docs/wake-word.md
+++ b/docs/wake-word.md
@@ -31,6 +31,9 @@ Per 80 ms (1280-sample) frame @ 16 kHz mono PCM-16, the
 3. **Classification** — the last 16 embeddings → `hey_gotcha.onnx` → a score
    in [0, 1].
 
+Step 1 runs on every frame. Steps 2 and 3 run only when `WakeWordGate` hears
+something — see [Battery](#battery-and-reliability) below.
+
 A `WakeWordMatcher` then maps the user-facing sensitivity slider to the
 score threshold (`threshold = 0.70 − 0.27 × sensitivity`) and requires two
 consecutive qualifying frames before firing. The default sensitivity of 0.75
@@ -81,6 +84,40 @@ have enough bright pixels/variance to still be sent.
 OEM battery managers may kill the always-on listener. The Assistive Ball
 settings page offers a one-tap link to Android's battery-optimization
 exemption request when the wake word is on.
+
+### What the listener does to stay cheap
+
+Measured on a physical device, one 80 ms frame through the full chain costs
+~4.4 ms, of which the embedding backbone is ~85% and the mel front-end ~8%.
+Five things follow from that (issue #37):
+
+- **The embedding stage is gated on energy.** `WakeWordGate` tracks the room's
+  noise floor from the frame RMS and lets the expensive stages run only when
+  something rises above it, with a ~3 s hangover so a pause mid-sentence does
+  not re-arm the pipeline. In a quiet room the listener is doing a mel run and
+  an RMS, nothing more.
+- **Gating cannot cost a detection.** The mel front-end keeps running while the
+  gate is shut, so the embeddings that were skipped are rebuilt from the mel
+  rows that produced them. The classifier sees exactly the window it would have
+  seen ungated — asserted, not assumed, by `OnnxWakeWordPipelineGateTest`.
+- **The ONNX sessions are single-threaded and do not spin** between runs. ORT's
+  defaults size a thread pool per session to the core count and busy-wait,
+  which suits a busy server and not a 12.5 Hz duty cycle.
+- **The sessions stay loaded across pauses.** The listener is paused on every
+  call transition and every TTS utterance; reloading ~2.6 MB of models each
+  time the app spoke a sentence was pure waste. `pause()` keeps the models and
+  still releases the microphone in full — see §10.3 of the privacy doc.
+- **The microphone is read in 320 ms batches** into a ~1.3 s buffer, waking the
+  CPU 3.1×/s instead of 12.5×/s, at the cost of up to 320 ms of extra trigger
+  latency.
+
+Two things are deliberately still open: the idle-hour `batterystats` figure
+that would quantify all of the above, and `SoundTrigger`/DSP hotword offload,
+which is the only way for the application processor to sleep at all while
+listening.
+
+`WakeWordPipelineBenchmarkTest` regenerates the per-stage numbers on a
+connected device; see its KDoc for the command.
 
 ## Play Store disclosure
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,3 +19,4 @@ dependencyResolutionManagement {
 
 rootProject.name = "gotcha"
 include(":app")
+include(":detekt-rules")


### PR DESCRIPTION
---

### Description

#### 🚀 Summary

This PR aggregates major performance, battery, and stability improvements to the **wakeword listener**, along with key product/UX enhancements, updated developer documentation, and health integrations.

---

### 🔑 Key Changes

#### ⚡ Performance & Battery Optimizations (`wakeword`)

* **Resource Management:** Kept ONNX sessions loaded across pause/resume cycles, avoided continuous thread spinning, and ensured sessions run strictly single-threaded.
* **Memory & Allocations:** Eliminated repeated heap allocations (~2.4k array allocations per frame removed).
* **Gating & Noise Floor:** Gated the embedding backbone behind an energy check and removed per-frame noise floor recomputation to minimize continuous compute.
* **Concurrency:** Moved inference execution outside the main state lock (without early freeing) and ensured ONNX sessions are claimed securely under the reading lock.
* **Benchmarking:** Added a per-stage benchmark harness to track energy consumption and execution speed.

#### 🎯 Feature & Product/UX Updates

* **Screen-Aware Modes:** Added screen-aware wake-word listening modes and synchronized wake-word state accordingly.
* **Product Pass:** Updated model guidance, pinned skill host, added a new feedback surface, and migrated to SYSTEM skin with safe overlay fallbacks.
* **Health Connect:** Refactored direct Health Connect permission contracts into a robust architecture.

#### 🐛 Bug Fixes & Telemetry

* Fixed a issue where the listener wouldn't re-arm if a wake-word call failed to start.
* Added debug-only audio audio/listener logging via `BuildConfig.DEBUG` / `GotchaLog` to ensure zero telemetry overhead in production builds.

#### 🧪 Testing & Documentation

* Added unit test coverage for batched audio feeds and end-to-end spoken positives.
* Documented listener optimizations and added warnings regarding potential data loss when running instrumentation tests.

---

### 🧪 How to Test

1. **Wake-word Performance:**
* Run the new per-stage benchmark harness (`wakeword` module).
* Verify CPU and battery utilization on background/active listening states.


2. **Audio Pipeline:**
* Test screen off/on state transitions to verify screen-aware wake-word triggers and proper state sync.
* Simulate audio start failure to ensure the listener successfully re-arms.


3. **UX & Permissions:**
* Verify new model guidance, pinned skill host layout, and feedback flows.
* Test Health Connect permission flow for clean fallback handling.