### PR TITLE
Tell the agent how to stop a stuck Termux command via the notification Exit acti

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to Gotcha are documented here.
 
 ## [Unreleased]
+### Fixed
+- The agent is now told how to stop a stuck Termux command: a `run_termux_command`
+  cannot kill a previously running one, so the instructions guide it to open the
+  notifications shade and tap Exit on the Termux notification (asking the user to
+  do so when it cannot reach it), instead of failing or starting more commands.
 
 ## [1.0.2]
 ### Fixed

--- a/app/src/main/java/com/gotcha/tools/TermuxMessages.kt
+++ b/app/src/main/java/com/gotcha/tools/TermuxMessages.kt
@@ -65,8 +65,11 @@ internal object TermuxMessages {
 
     fun tooManyInFlight(limit: Int) = ToolResult.error(
         "$limit Termux commands are already running and none has finished yet. Earlier commands keep running " +
-            "even after they time out — I cannot kill them. Wait for them to finish (use the sleep tool), or " +
-            "check Termux directly, rather than starting another."
+            "even after they time out — a run_termux_command cannot kill them. To stop them, open the " +
+            "notifications shade (global_action or press_key 'notifications') and tap the Exit action on the " +
+            "Termux notification, which ends every Termux session. If you cannot reach it, ask the user to tap " +
+            "Exit on the Termux notification. Otherwise wait for them to finish (use the sleep tool) rather " +
+            "than starting another."
     )
 
     /**
@@ -85,7 +88,10 @@ internal object TermuxMessages {
                 append("here. Retry with a non-interactive flag (e.g. -y) or pass the answer in stdin.")
             }
             append("\n- or it is genuinely slow. Retry with a larger timeout_seconds. Note it keeps running ")
-            append("either way — I cannot kill another app's process — so check Termux before starting again.")
+            append("either way — a run_termux_command cannot stop it. To stop it, open the notifications shade ")
+            append("(global_action or press_key 'notifications') and tap the Exit action on the Termux ")
+            append("notification, which ends every Termux session. If you cannot reach it, ask the user to tap ")
+            append("Exit on the Termux notification.")
         }
     )
 

--- a/app/src/main/java/com/gotcha/tools/ToolDefinitions.kt
+++ b/app/src/main/java/com/gotcha/tools/ToolDefinitions.kt
@@ -1877,7 +1877,13 @@ object ToolDefinitions {
             "Termux runs under its own user id, so Gotcha's working directory and app files are NOT " +
             "visible here — use run_command for those. Shared storage (/sdcard) is only reachable if " +
             "the user has run `termux-setup-storage` in Termux; if a /sdcard path fails, say so " +
-            "rather than retrying.",
+            "rather than retrying.\n" +
+            "You cannot stop a command with this tool — there is no kill, each call only starts a new " +
+            "background shell, and a previous one that has not finished (e.g. after a timeout) keeps " +
+            "running. To stop a stuck one, open the notifications shade (global_action or press_key " +
+            "'notifications') and tap the Exit action on the Termux notification, which ends every " +
+            "Termux session. If you cannot reach that, ask the user to tap Exit on the Termux " +
+            "notification.",
         schema {
             putJsonObject("properties") {
                 putJsonObject("command") {


### PR DESCRIPTION
## Problem

A `run_termux_command` cannot stop a previously running `run_termux_command`.
Termux runs each command as its own background shell, and once one is accepted
(or times out while still running) there is no way for another call to kill it.
The model would either keep trying `run_termux_command` (and keep failing or
hitting the concurrency cap) or do nothing, leaving a stuck `pkg`/script holding
Termux's locks with no path forward.

## Fix

This is an agent-instruction fix. The model now knows it cannot stop old Termux
processes through the tool, and is given a concrete procedure for stopping them
itself before falling back to asking the user:

1. **Preferred:** open the notifications shade (`global_action` or
   `press_key 'notifications'`) and tap the **Exit** action on the Termux
   notification, which ends every Termux session (and therefore the stuck
   command).
2. **Fallback:** if the Exit action cannot be reached, ask the user to tap Exit
   on the Termux notification.

Changes:

- `app/src/main/java/com/gotcha/tools/ToolDefinitions.kt` — the
  `run_termux_command` tool description now states that the tool has no kill
  (each call only starts a new background shell, previous unfinished commands
  keep running) and describes the notification-shade Exit procedure, so the
  knowledge is always present whenever the tool is offered.
- `app/src/main/java/com/gotcha/tools/TermuxMessages.kt` — the two error paths
  where the model actually discovers it cannot stop a command now carry the same
  instruction:
  - `tooManyInFlight` ("N Termux commands are already running…") — explains a
    `run_termux_command` cannot kill them and points at the Exit procedure.
  - `timedOut` ("No result from Termux after Ns…") — explains the command keeps
    running and a `run_termux_command` cannot stop it, with the same procedure.
- `CHANGELOG.md` — added a Fixed entry under [Unreleased].

No new tools or behaviour changes were introduced; the accessibility- and
notification-listener-based tools the agent already has (`press_key`,
`global_action`, `tap`) are sufficient to perform the Exit action.

## Caveats

- Tapping "Exit" on the Termux notification ends **all** Termux sessions, so a
  command the model wanted to keep (e.g. one it merely needs more time on) is
  interrupted too. The wording steers the model to only do this for genuinely
  stuck commands, and to otherwise wait with the `sleep` tool or retry with a
  larger `timeout_seconds`.
- Unit tests could not be run in the task environment (no Android SDK available);
  the existing `TermuxToolTest` assertions on the `tooManyInFlight` and
  `timedOut` messages were preserved (they only assert substrings like
  "already running", "cannot kill", "genuinely slow").

Closes #48

🦦 Opened by [Jalebi](https://github.com/samosa-ai-com/jalebi) — your self-hosted AI coding agent by [Samosa AI](https://github.com/samosa-ai-com).

Co-authored-by: Jalebi <jalebi@samosa-ai.com>