### PR TITLE
ci: pass INFLUENCER_* secrets to the release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,6 +195,8 @@ jobs:
           FEEDBACK_ENTRY_ANDROID_VERSION: ${{ secrets.FEEDBACK_ENTRY_ANDROID_VERSION }}
           FEEDBACK_ENTRY_USAGE_STATS: ${{ secrets.FEEDBACK_ENTRY_USAGE_STATS }}
           FEEDBACK_ENTRY_CHAT_LOG: ${{ secrets.FEEDBACK_ENTRY_CHAT_LOG }}
+          INFLUENCER_FORM_URL: ${{ secrets.INFLUENCER_FORM_URL }}
+          INFLUENCER_ENTRY_EMAIL: ${{ secrets.INFLUENCER_ENTRY_EMAIL }}
         run: |
           # samosaConfig() in app/build.gradle.kts silently falls back to inert
           # *.example placeholders when a value is missing, which produces an APK
@@ -203,6 +205,16 @@ jobs:
             if [ -z "${!name}" ]; then
               echo "::error::$name is not set in repo secrets — the release would ship placeholder config"
               exit 1
+            fi
+          done
+
+          # A blank INFLUENCER_* is a legitimate default for a public checkout (the card
+          # renders nothing), so this cannot be fatal — but on an official release it means
+          # the influencer card silently disappears, which is how 1.1.0 shipped without it.
+          # Nothing in the built APK distinguishes "blank" from "unset", so warn here.
+          for name in INFLUENCER_FORM_URL INFLUENCER_ENTRY_EMAIL; do
+            if [ -z "${!name}" ]; then
+              echo "::warning::$name is empty — the influencer program card will not appear in this release"
             fi
           done
           ./gradlew :app:assembleRelease --stacktrace


### PR DESCRIPTION
## Problem

`INFLUENCER_FORM_URL` and `INFLUENCER_ENTRY_EMAIL` exist as repo secrets, but the `Assemble release APK` step never put them in its `env:` block. `samosaConfig()` resolves env var → `local.properties` → placeholder, and CI has no `local.properties`, so both resolved to the `""` placeholder.

v1.1.0 shipped that way. `InfluencerProgramCard` does `if (formUrl.isBlank()) return`, so the card renders nothing — nothing is broken or pointed at a dead endpoint, the feature is simply absent from the release that announced it.

Adding the secrets alone does not fix this; without these two lines the next release builds blank again.

## Changes

- Pass both secrets to the Gradle build.
- Warn (non-fatally) when either is empty.

The warning deliberately does not `exit 1` the way the `SAMOSA_*` check does: blank is a legitimate default for a public checkout, where the card is meant to stay inert. Nothing in the built APK distinguishes "blank" from "unset" — a blank value leaves no string for the existing placeholder grep to find — so a warning in the log is the only signal available at build time.

## Verification

- YAML parses; the extracted step passes `bash -n`.
- Confirmed both secret names are present in repo settings.

## Follow-up

Ship 1.1.1 once this merges so the card actually reaches users. v1.1.0 needs no recall — the feature is missing, not broken.