### PR TITLE
chore: bump version to 1.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,13 @@ jobs:
   release:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      # What the release asset is called on GitHub - i.e. the filename a user ends
+      # up with after downloading it. Deliberately NOT the Gradle output name:
+      # renaming that would move app/build/outputs/apk/release/app-release.apk for
+      # every local build and every script and doc pointing at it. Only the upload
+      # is renamed.
+      PUBLISHED_APK_NAME: Gotcha.apk
     permissions:
       contents: write
       pull-requests: write
@@ -85,10 +92,13 @@ jobs:
           FAILED=0
           note() { echo "  - $1"; FAILED=1; }
 
+          # Releases through v1.1.0 shipped the asset as app-release.apk; v1.1.1
+          # onward publishes Gotcha.apk. Accept either, so re-running against an
+          # older tag does not report a perfectly good release as missing its APK.
           ASSET=$(gh release view "$TAG" --json assets \
-            --jq '.assets[] | select(.name == "app-release.apk")' 2>/dev/null || true)
+            --jq '.assets[] | select(.name == "'"$PUBLISHED_APK_NAME"'" or .name == "app-release.apk")' 2>/dev/null || true)
           if [ -z "$ASSET" ]; then
-            note "no GitHub release for $TAG, or it carries no app-release.apk asset"
+            note "no GitHub release for $TAG, or it carries no APK asset"
           fi
 
           MANIFEST_NAME=$(jq -r '.versionName' update.json)
@@ -299,10 +309,13 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # gh names the asset after the file it uploads, so stage a renamed copy.
+          cp app/build/outputs/apk/release/app-release.apk "$PUBLISHED_APK_NAME"
           gh release create "${{ steps.version.outputs.tag }}" \
-            app/build/outputs/apk/release/app-release.apk \
+            "$PUBLISHED_APK_NAME" \
             --title "${{ steps.version.outputs.tag }}" \
             --notes-file release_notes.md
+          rm -f "$PUBLISHED_APK_NAME"
 
       - name: Regenerate update.json
         if: steps.check.outputs.should_release == 'true'
@@ -312,7 +325,7 @@ jobs:
         run: |
           APK_SHA256=$(sha256sum app/build/outputs/apk/release/app-release.apk | cut -d' ' -f1)
           echo "sha256=$APK_SHA256" >> "$GITHUB_OUTPUT"
-          DOWNLOAD_URL="https://github.com/$GH_REPO/releases/download/${{ steps.version.outputs.tag }}/app-release.apk"
+          DOWNLOAD_URL="https://github.com/$GH_REPO/releases/download/${{ steps.version.outputs.tag }}/$PUBLISHED_APK_NAME"
           jq -n \
             --argjson versionCode "${{ steps.version.outputs.code }}" \
             --arg versionName "${{ steps.version.outputs.name }}" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Gotcha are documented here.
 
 ## [Unreleased]
+### Fixed
+- The influencer program card now appears in release builds. 1.1.0 was assembled
+  without its form configuration, so the card was hidden and there was no way to
+  apply from inside the app.
 
 ## [1.1.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to Gotcha are documented here.
   without its form configuration, so the card was hidden and there was no way to
   apply from inside the app.
 
+### Changed
+- The download on GitHub Releases is now named `Gotcha.apk` instead of
+  `app-release.apk`. Existing installs are unaffected — "Check for Updates"
+  follows the link in the update manifest, whatever the file is called — and
+  the older releases keep their original filename.
+
 ## [1.1.0]
 ### Added
 - **Referral program.** You can now share your referral code from a dedicated

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,8 +35,8 @@ android {
         applicationId = "com.gotcha"
         minSdk = 30
         targetSdk = 34
-        versionCode = 4
-        versionName = "1.1.0"
+        versionCode = 5
+        versionName = "1.1.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
Ships the influencer program card, which 1.1.0 was built without.

- `versionCode` 4 → 5, `versionName` 1.1.0 → 1.1.1
- `CHANGELOG.md` — `[Unreleased]` entry describing the fix

Depends on #59, which is merged: without it the build would resolve `INFLUENCER_FORM_URL` to the blank placeholder again and the card would stay hidden.

**Merging this fires the release workflow** (it triggers on pushes to `main` touching `app/build.gradle.kts`). It will build and publish v1.1.1, then — thanks to #58 — open a follow-up PR carrying `update.json`. That PR must also be squash-merged before any device can see the update.

Worth watching in the run log: the new `::warning::INFLUENCER_* is empty` line should **not** appear. If it does, the secrets did not reach the build and the card will be missing again.