### PR TITLE
Address PR review: redact PDF password from audit log, silence SdCardPath lint

### DIFF
--- a/app/src/main/java/com/gotcha/agent/AgentEngine.kt
+++ b/app/src/main/java/com/gotcha/agent/AgentEngine.kt
@@ -1123,6 +1123,28 @@ class AgentEngine(
                     "unfamiliar apps or complex operations to learn the optimal steps. " +
                     "When you have the answer, call finish_task with it — that is what actually " +
                     "delivers it to the user. " +
+                    "Gotcha also has an Operator mode that CAN act on the device. Its abilities:\n" +
+                    "- Communication: place calls, send SMS, compose/send email and mark mail read, " +
+                    "add contacts.\n" +
+                    "- Screen control: tap, long-press, swipe, type text, press keys, back/home/" +
+                    "recents — i.e. drive any app on screen, including via the App Navigator " +
+                    "sub-agent.\n" +
+                    "- Calendar & reminders: create/edit/delete events, alarms and timers, snooze " +
+                    "and dismiss them, manage the task list.\n" +
+                    "- Files & media: write and edit files, read images, take photos, record and " +
+                    "pause/stop audio, edit or convert media and PDFs, set the wallpaper.\n" +
+                    "- Device settings: volume, brightness, ringer, Do Not Disturb, Wi-Fi, torch, " +
+                    "vibrate, clipboard, lock the screen, open any Settings page, write secure " +
+                    "settings, uninstall apps, disable the camera and set password policy.\n" +
+                    "- Notifications: dismiss them.\n" +
+                    "- Shell: run shell commands, Termux commands and root commands when available.\n" +
+                    "- Connectors: write actions on connected services (e.g. create, update and " +
+                    "delete Notion pages) alongside the read tools you already have.\n" +
+                    "- Delegation: hand multi-step work to the General and App Navigator " +
+                    "sub-agents.\n" +
+                    "When the user asks for something that needs any of the above, say it is doable " +
+                    "in Operator mode and that they can switch with the mode badge at the top of " +
+                    "the chat — do not attempt it yourself. " +
                     "Keep replies short and conversational."
             AgentMode.OPERATOR ->
                 "You are Gotcha (operating in Operator mode), an AI assistant " +

--- a/app/src/main/java/com/gotcha/connectors/ConnectorRefreshScheduler.kt
+++ b/app/src/main/java/com/gotcha/connectors/ConnectorRefreshScheduler.kt
@@ -47,7 +47,9 @@ class ConnectorRefreshScheduler(
 
         val results = refreshAction.invoke(settings.disabledConnectors)
 
-        store.save(store.load().copy(connectorLastRefreshedAt = now))
+        // Only the stamp: a full save here would rewrite the interval the user
+        // may have just moved, from a Settings read taken before they moved it.
+        store.saveConnectorLastRefreshedAt(now)
         results
     }
 }

--- a/app/src/main/java/com/gotcha/data/SettingsRepository.kt
+++ b/app/src/main/java/com/gotcha/data/SettingsRepository.kt
@@ -31,6 +31,36 @@ enum class WakeWordListeningMode {
     }
 }
 
+/**
+ * Chat context budget, in tokens, for a fresh install.
+ */
+const val DEFAULT_MAX_CONTEXT_TOKENS = 256_000
+
+/**
+ * The budget before [DEFAULT_MAX_CONTEXT_TOKENS] was raised. A stored copy of
+ * exactly this value is lifted once by [SettingsRepository.resolvedMaxContextTokens];
+ * see the note there for why raising the default alone was not enough.
+ */
+private const val LEGACY_MAX_CONTEXT_TOKENS = 70_000
+
+/** What the one-shot context-budget lift decided: the value to use, and whether to store it. */
+internal data class MaxContextTokensLift(val value: Int, val writeBack: Boolean)
+
+/**
+ * Decides whether a stored context budget should be lifted to the current default.
+ *
+ * Only a stored value equal to the old default is lifted, and only while
+ * [alreadyLifted] is false, so a user who deliberately picks 70k afterwards
+ * keeps it. Kept pure and separate from the prefs read because
+ * `EncryptedSharedPreferences` cannot be built under Robolectric, which would
+ * otherwise leave a silent one-shot migration with no test at all.
+ */
+internal fun liftMaxContextTokens(stored: Int, alreadyLifted: Boolean): MaxContextTokensLift = when {
+    alreadyLifted -> MaxContextTokensLift(stored, writeBack = false)
+    stored == LEGACY_MAX_CONTEXT_TOKENS -> MaxContextTokensLift(DEFAULT_MAX_CONTEXT_TOKENS, writeBack = true)
+    else -> MaxContextTokensLift(stored, writeBack = false)
+}
+
 data class Settings(
     // Which LLM backend is active. Defaults to the Samosa AI flow.
     val provider: LlmProvider = LlmProvider.SAMOSA_AI,
@@ -55,7 +85,7 @@ data class Settings(
      * each call carries a freshly rephrased task string.
      */
     val maxConsecutiveDelegations: Int = 3,
-    val maxContextTokens: Int = 256000,
+    val maxContextTokens: Int = DEFAULT_MAX_CONTEXT_TOKENS,
     val apiTimeoutSeconds: Long = 0L,
     // TTS / STT settings
     val ttsProvider: AudioProvider = AudioProvider.ANDROID,
@@ -380,6 +410,33 @@ class SettingsRepository(context: Context) : SettingsStore {
         return migrated
     }
 
+    /**
+     * Reads the context budget, lifting a stored 70k to the current default once.
+     *
+     * Raising the default in [Settings] only reaches installs that never wrote
+     * the key, and an APK update -- from Android Studio or a GitHub release --
+     * keeps the app's data directory, so every existing user kept 70k. Anyone
+     * who has opened AI Config and pressed Save has the old default written out
+     * explicitly, which is indistinguishable from having chosen it.
+     *
+     * So this runs exactly once, tracked by its own flag rather than by the
+     * value: after it has run, a user is free to set 70k back and keep it.
+     */
+    private fun resolvedMaxContextTokens(): Int {
+        val alreadyLifted = prefs.getBoolean(KEY_MAX_CONTEXT_TOKENS_RAISED, false)
+        val lift = liftMaxContextTokens(
+            stored = prefs.getInt(KEY_MAX_CONTEXT_TOKENS, DEFAULT_MAX_CONTEXT_TOKENS),
+            alreadyLifted = alreadyLifted
+        )
+        if (!alreadyLifted) {
+            prefs.edit().apply {
+                putBoolean(KEY_MAX_CONTEXT_TOKENS_RAISED, true)
+                if (lift.writeBack) putInt(KEY_MAX_CONTEXT_TOKENS, lift.value)
+            }.apply()
+        }
+        return lift.value
+    }
+
     override fun load(): Settings = Settings(
         provider = LlmProvider.fromName(prefs.getString(KEY_PROVIDER, null)),
         apiKey = string(KEY_API_KEY),
@@ -393,7 +450,7 @@ class SettingsRepository(context: Context) : SettingsStore {
         maxRepeatedToolCalls = prefs.getInt(KEY_MAX_REPEATED_TOOL_CALLS, 20),
         maxNavigationToolCalls = prefs.getInt(KEY_MAX_NAVIGATION_TOOL_CALLS, 30),
         maxConsecutiveDelegations = prefs.getInt(KEY_MAX_CONSECUTIVE_DELEGATIONS, 3),
-        maxContextTokens = prefs.getInt(KEY_MAX_CONTEXT_TOKENS, 256000),
+        maxContextTokens = resolvedMaxContextTokens(),
         apiTimeoutSeconds = prefs.getLong(KEY_API_TIMEOUT, 0L),
         ttsProvider = runCatching {
             AudioProvider.valueOf(string(KEY_TTS_PROVIDER, "ANDROID"))
@@ -577,6 +634,9 @@ class SettingsRepository(context: Context) : SettingsStore {
         const val KEY_MAX_NAVIGATION_TOOL_CALLS = "max_navigation_tool_calls"
         const val KEY_MAX_CONSECUTIVE_DELEGATIONS = "max_consecutive_delegations"
         const val KEY_MAX_CONTEXT_TOKENS = "max_context_tokens"
+
+        /** Whether the one-shot 70k -> 256k lift has already run. */
+        const val KEY_MAX_CONTEXT_TOKENS_RAISED = "max_context_tokens_raised"
         const val KEY_API_TIMEOUT = "api_timeout"
         const val KEY_TTS_PROVIDER = "tts_provider"
         const val KEY_TTS_API_URL = "tts_api_url"

--- a/app/src/main/java/com/gotcha/data/SettingsRepository.kt
+++ b/app/src/main/java/com/gotcha/data/SettingsRepository.kt
@@ -55,7 +55,7 @@ data class Settings(
      * each call carries a freshly rephrased task string.
      */
     val maxConsecutiveDelegations: Int = 3,
-    val maxContextTokens: Int = 70000,
+    val maxContextTokens: Int = 256000,
     val apiTimeoutSeconds: Long = 0L,
     // TTS / STT settings
     val ttsProvider: AudioProvider = AudioProvider.ANDROID,
@@ -373,7 +373,7 @@ class SettingsRepository(context: Context) : SettingsStore {
         maxRepeatedToolCalls = prefs.getInt(KEY_MAX_REPEATED_TOOL_CALLS, 20),
         maxNavigationToolCalls = prefs.getInt(KEY_MAX_NAVIGATION_TOOL_CALLS, 30),
         maxConsecutiveDelegations = prefs.getInt(KEY_MAX_CONSECUTIVE_DELEGATIONS, 3),
-        maxContextTokens = prefs.getInt(KEY_MAX_CONTEXT_TOKENS, 70000),
+        maxContextTokens = prefs.getInt(KEY_MAX_CONTEXT_TOKENS, 256000),
         apiTimeoutSeconds = prefs.getLong(KEY_API_TIMEOUT, 0L),
         ttsProvider = runCatching {
             AudioProvider.valueOf(string(KEY_TTS_PROVIDER, "ANDROID"))

--- a/app/src/main/java/com/gotcha/data/SettingsRepository.kt
+++ b/app/src/main/java/com/gotcha/data/SettingsRepository.kt
@@ -331,6 +331,26 @@ private const val LEGACY_THEME_MODE_SYSTEM = "SYSTEM"
 interface SettingsStore {
     fun load(): Settings
     fun save(settings: Settings)
+
+    /**
+     * Write just the auto-refresh interval.
+     *
+     * [save] rewrites all 58 keys, so the usual load-copy-save clobbers any
+     * field another writer changed in between. The connector screen sets this
+     * from a slider while [saveConnectorLastRefreshedAt] is being written by a
+     * refresh on another thread, and whichever load ran first used to win.
+     *
+     * The default keeps that old read-modify-write, which is fine for stores
+     * with no concurrency; [SettingsRepository] narrows it to one key.
+     */
+    fun saveConnectorAutoRefreshIntervalMinutes(minutes: Int) {
+        save(load().copy(connectorAutoRefreshIntervalMinutes = minutes))
+    }
+
+    /** Write just the last-refreshed stamp. See [saveConnectorAutoRefreshIntervalMinutes]. */
+    fun saveConnectorLastRefreshedAt(millis: Long) {
+        save(load().copy(connectorLastRefreshedAt = millis))
+    }
 }
 
 /** Stores credentials in EncryptedSharedPreferences (PRD R6). Never logged. */
@@ -426,6 +446,14 @@ class SettingsRepository(context: Context) : SettingsStore {
         tourStepId = string(KEY_TOUR_STEP),
         onboardingVersion = prefs.getInt(KEY_ONBOARDING_VERSION, 0)
     )
+
+    override fun saveConnectorAutoRefreshIntervalMinutes(minutes: Int) {
+        prefs.edit().putInt(KEY_CONNECTOR_AUTO_REFRESH_INTERVAL, minutes).apply()
+    }
+
+    override fun saveConnectorLastRefreshedAt(millis: Long) {
+        prefs.edit().putLong(KEY_CONNECTOR_LAST_REFRESHED, millis).apply()
+    }
 
     override fun save(settings: Settings) {
         prefs.edit()

--- a/app/src/main/java/com/gotcha/tools/FfmpegCommand.kt
+++ b/app/src/main/java/com/gotcha/tools/FfmpegCommand.kt
@@ -1,5 +1,6 @@
 package com.gotcha.tools
 
+import android.annotation.SuppressLint
 import java.util.Locale
 
 /**
@@ -33,7 +34,12 @@ object FfmpegCommand {
      */
     const val DEFAULT_SHARED_STORAGE_ROOT = "/storage/emulated/0"
 
-    /** The same tree as Termux must address it. */
+    /**
+     * The same tree as Termux must address it. Lint's `SdCardPath` flags the
+     * hardcoded prefix, but here it is required: Termux only exposes the primary
+     * user's shared storage at `/sdcard`, so suppressing the check is correct.
+     */
+    @SuppressLint("SdCardPath")
     const val TERMUX_STORAGE_ROOT = "/sdcard"
 
     /** Default bitrate for the lossy targets that do not name their own. */

--- a/app/src/main/java/com/gotcha/tools/ToolExecutor.kt
+++ b/app/src/main/java/com/gotcha/tools/ToolExecutor.kt
@@ -33,8 +33,12 @@ class ToolExecutor(
     private companion object {
         const val TAG = "Gotcha"
 
-        /** Argument names never written verbatim to the audit log. See [redactedForAudit]. */
-        val REDACTED_AUDIT_KEYS = setOf("stdin")
+        /**
+         * Argument names never written verbatim to the audit log. See [redactedForAudit].
+         * `password` is a PDF owner/user password for `pdf_edit` — passwords are often
+         * reused across bank statements and payslips, so never persist them in plaintext.
+         */
+        val REDACTED_AUDIT_KEYS = setOf("stdin", "password")
     }
 
     private val appContext = context.applicationContext

--- a/app/src/main/java/com/gotcha/ui/AiConfigScreen.kt
+++ b/app/src/main/java/com/gotcha/ui/AiConfigScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
+import com.gotcha.data.DEFAULT_MAX_CONTEXT_TOKENS
 import com.gotcha.data.LlmProvider
 import com.gotcha.data.Settings
 import com.gotcha.ui.theme.SkinExposedDropdownMenu
@@ -129,7 +130,7 @@ fun AiConfigScreen(
         maxRepeatedToolCalls = maxRepeatedToolCalls.toIntOrNull()?.takeIf { it > 0 } ?: 20,
         maxNavigationToolCalls = maxNavigationToolCalls.toIntOrNull()?.takeIf { it > 0 } ?: 30,
         maxConsecutiveDelegations = maxConsecutiveDelegations.toIntOrNull()?.takeIf { it > 0 } ?: 3,
-        maxContextTokens = maxContextTokens.toIntOrNull()?.takeIf { it > 0 } ?: 256000,
+        maxContextTokens = maxContextTokens.toIntOrNull()?.takeIf { it > 0 } ?: DEFAULT_MAX_CONTEXT_TOKENS,
         apiTimeoutSeconds = apiTimeoutSeconds.toLongOrNull()?.takeIf { it >= 0 } ?: 0L
     )
 

--- a/app/src/main/java/com/gotcha/ui/AiConfigScreen.kt
+++ b/app/src/main/java/com/gotcha/ui/AiConfigScreen.kt
@@ -129,7 +129,7 @@ fun AiConfigScreen(
         maxRepeatedToolCalls = maxRepeatedToolCalls.toIntOrNull()?.takeIf { it > 0 } ?: 20,
         maxNavigationToolCalls = maxNavigationToolCalls.toIntOrNull()?.takeIf { it > 0 } ?: 30,
         maxConsecutiveDelegations = maxConsecutiveDelegations.toIntOrNull()?.takeIf { it > 0 } ?: 3,
-        maxContextTokens = maxContextTokens.toIntOrNull()?.takeIf { it > 0 } ?: 70000,
+        maxContextTokens = maxContextTokens.toIntOrNull()?.takeIf { it > 0 } ?: 256000,
         apiTimeoutSeconds = apiTimeoutSeconds.toLongOrNull()?.takeIf { it >= 0 } ?: 0L
     )
 

--- a/app/src/main/java/com/gotcha/ui/ConnectorsSection.kt
+++ b/app/src/main/java/com/gotcha/ui/ConnectorsSection.kt
@@ -88,7 +88,14 @@ fun ConnectorsSection() {
                 autoSyncing = false
             }
             if (refreshed.isNotEmpty()) {
-                settings = withContext(Dispatchers.IO) { settingsRepo.load() }
+                // Take the new stamp and nothing else. Reassigning all of
+                // Settings from disk would also overwrite the interval held in
+                // memory -- with a value read before the slider's write landed,
+                // which snapped the thumb back to where it started.
+                val stamp = withContext(Dispatchers.IO) {
+                    settingsRepo.load().connectorLastRefreshedAt
+                }
+                settings = settings.copy(connectorLastRefreshedAt = stamp)
             }
             delay(60_000L)
         }
@@ -113,10 +120,7 @@ fun ConnectorsSection() {
             onIntervalChange = { newInterval ->
                 settings = settings.copy(connectorAutoRefreshIntervalMinutes = newInterval)
                 scope.launch(Dispatchers.IO) {
-                    val current = settingsRepo.load()
-                    settingsRepo.save(
-                        current.copy(connectorAutoRefreshIntervalMinutes = newInterval)
-                    )
+                    settingsRepo.saveConnectorAutoRefreshIntervalMinutes(newInterval)
                 }
             },
             onRefreshAll = {

--- a/app/src/main/java/com/gotcha/ui/ConnectorsSection.kt
+++ b/app/src/main/java/com/gotcha/ui/ConnectorsSection.kt
@@ -68,9 +68,6 @@ fun ConnectorsSection() {
     var disabled by remember { mutableStateOf(settings.disabledConnectors) }
     val scope = rememberCoroutineScope()
     val refreshScheduler = remember(context) { ConnectorRefreshScheduler(context) }
-    // True while the scheduled refresh below is in flight, so the header can say
-    // so instead of just looking stuck.
-    var autoSyncing by remember { mutableStateOf(false) }
 
     // Automatic background scheduler loop while screen is open.
     //
@@ -81,12 +78,7 @@ fun ConnectorsSection() {
     LaunchedEffect(settings.connectorAutoRefreshIntervalMinutes) {
         if (settings.connectorAutoRefreshIntervalMinutes <= 0) return@LaunchedEffect
         while (isActive) {
-            autoSyncing = true
-            val refreshed = try {
-                refreshScheduler.refreshIfNeeded()
-            } finally {
-                autoSyncing = false
-            }
+            val refreshed = refreshScheduler.refreshIfNeeded()
             if (refreshed.isNotEmpty()) {
                 // Take the new stamp and nothing else. Reassigning all of
                 // Settings from disk would also overwrite the interval held in
@@ -112,7 +104,6 @@ fun ConnectorsSection() {
         AutoRefreshHeader(
             intervalMinutes = settings.connectorAutoRefreshIntervalMinutes,
             lastRefreshedAt = settings.connectorLastRefreshedAt,
-            isAutoSyncing = autoSyncing,
             // Reflected in the UI immediately and persisted off the main thread.
             // Settings lives in EncryptedSharedPreferences, so the read-modify-
             // write behind this is ~60 AES reads plus 58 writes -- long enough
@@ -179,7 +170,6 @@ private fun indexOfInterval(minutes: Int): Int {
 private fun AutoRefreshHeader(
     intervalMinutes: Int,
     lastRefreshedAt: Long,
-    isAutoSyncing: Boolean,
     onIntervalChange: (Int) -> Unit,
     onRefreshAll: suspend () -> Map<String, String>
 ) {
@@ -290,16 +280,6 @@ private fun AutoRefreshHeader(
                 steps = AUTO_REFRESH_INTERVALS.size - 2,
                 modifier = Modifier.fillMaxWidth()
             )
-            // A new interval saves in milliseconds; what takes a moment is the
-            // sync it starts when one is already due. Name that rather than the
-            // save, so the pause is explained instead of looking like a hang.
-            if (isAutoSyncing) {
-                Text(
-                    "Syncing connectors…",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
         }
     }
 }

--- a/app/src/main/java/com/gotcha/ui/ConnectorsSection.kt
+++ b/app/src/main/java/com/gotcha/ui/ConnectorsSection.kt
@@ -163,6 +163,10 @@ private val AUTO_REFRESH_INTERVALS = listOf(
  * steps -- written by an older build, or by a settings import -- snaps to the
  * nearest one rather than resetting the user to Off.
  */
+/** Slider position to a valid index into [AUTO_REFRESH_INTERVALS]. */
+private fun Float.toIndex(): Int =
+    roundToInt().coerceIn(0, AUTO_REFRESH_INTERVALS.lastIndex)
+
 private fun indexOfInterval(minutes: Int): Int {
     val exact = AUTO_REFRESH_INTERVALS.indexOfFirst { it.first == minutes }
     if (exact >= 0) return exact
@@ -183,13 +187,12 @@ private fun AutoRefreshHeader(
     var isRefreshing by remember { mutableStateOf(false) }
     var syncFeedback by remember { mutableStateOf("") }
     var tick by remember { mutableStateOf(0) }
-    // Position is held locally so the thumb tracks the finger; it is re-seeded
-    // whenever the stored interval changes underneath us.
-    var sliderPosition by remember(intervalMinutes) {
-        mutableStateOf(indexOfInterval(intervalMinutes).toFloat())
-    }
-    val sliderIndex = sliderPosition.roundToInt()
-        .coerceIn(0, AUTO_REFRESH_INTERVALS.lastIndex)
+    // Seeded once from the stored interval and authoritative from then on. It is
+    // deliberately not keyed on intervalMinutes: this screen is the only writer
+    // while it is open, and re-seeding from a reload gives a stale read a way to
+    // drag the thumb back out from under the user.
+    var sliderPosition by remember { mutableStateOf(indexOfInterval(intervalMinutes).toFloat()) }
+    val sliderIndex = sliderPosition.toIndex()
 
     // Live recomposition ticker for "X min ago" display
     LaunchedEffect(lastRefreshedAt) {
@@ -272,8 +275,16 @@ private fun AutoRefreshHeader(
                 // The interval only reaches Settings once the thumb is let go;
                 // dragging would otherwise write SharedPreferences every frame
                 // and restart the refresh loop on each one.
+                //
+                // Read the position here rather than closing over sliderIndex.
+                // Slider calls onValueChange and then onValueChangeFinished
+                // within the one gesture, so this lambda can still be the
+                // instance built by the composition *before* the tap -- and the
+                // index it captured is where the thumb used to be. That is what
+                // made a first tap commit the old value and appear to do
+                // nothing, while a second tap on the same spot worked.
                 onValueChangeFinished = {
-                    onIntervalChange(AUTO_REFRESH_INTERVALS[sliderIndex].first)
+                    onIntervalChange(AUTO_REFRESH_INTERVALS[sliderPosition.toIndex()].first)
                 },
                 valueRange = 0f..(AUTO_REFRESH_INTERVALS.size - 1).toFloat(),
                 steps = AUTO_REFRESH_INTERVALS.size - 2,

--- a/app/src/main/java/com/gotcha/ui/ConnectorsSection.kt
+++ b/app/src/main/java/com/gotcha/ui/ConnectorsSection.kt
@@ -2,6 +2,8 @@ package com.gotcha.ui
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -116,6 +118,7 @@ fun ConnectorsSection() {
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun AutoRefreshHeader(
     intervalMinutes: Int,
@@ -186,13 +189,29 @@ private fun AutoRefreshHeader(
             Text(syncFeedback, style = MaterialTheme.typography.bodySmall)
         }
 
-        Row(
+        // Eight choices no longer fit one phone-width line, so the chips wrap.
+        FlowRow(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalAlignment = Alignment.CenterVertically
+            verticalArrangement = Arrangement.spacedBy(4.dp)
         ) {
-            Text("Interval:", style = MaterialTheme.typography.bodyMedium)
-            val intervals = listOf(0 to "Off", 15 to "15m", 30 to "30m", 120 to "2h")
+            Text(
+                "Interval:",
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.align(Alignment.CenterVertically)
+            )
+            // Anything under a minute would be finer than the 60s poll tick in
+            // ConnectorsSection can honour, so 1m is the floor.
+            val intervals = listOf(
+                0 to "Off",
+                1 to "1m",
+                2 to "2m",
+                5 to "5m",
+                10 to "10m",
+                15 to "15m",
+                30 to "30m",
+                120 to "2h"
+            )
             intervals.forEach { (mins, label) ->
                 FilterChip(
                     selected = intervalMinutes == mins,

--- a/app/src/main/java/com/gotcha/ui/ConnectorsSection.kt
+++ b/app/src/main/java/com/gotcha/ui/ConnectorsSection.kt
@@ -41,6 +41,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * The body of the Connectors screen: one card per connector, built from the two
@@ -67,19 +68,29 @@ fun ConnectorsSection() {
     var disabled by remember { mutableStateOf(settings.disabledConnectors) }
     val scope = rememberCoroutineScope()
     val refreshScheduler = remember(context) { ConnectorRefreshScheduler(context) }
+    // True while the scheduled refresh below is in flight, so the header can say
+    // so instead of just looking stuck.
+    var autoSyncing by remember { mutableStateOf(false) }
 
-    // Automatic background scheduler loop while screen is open
+    // Automatic background scheduler loop while screen is open.
+    //
+    // Changing the interval restarts this effect, so everything in it has to
+    // stay off the main thread: a Settings load is ~60 AES-decrypted reads and
+    // takes the same prefs lock the interval write holds, which is what used to
+    // freeze the slider for a moment after each change.
     LaunchedEffect(settings.connectorAutoRefreshIntervalMinutes) {
-        refreshScheduler.refreshIfNeeded()
-        settings = settingsRepo.load()
-        if (settings.connectorAutoRefreshIntervalMinutes > 0) {
-            while (isActive) {
-                delay(60_000L)
-                val refreshed = refreshScheduler.refreshIfNeeded()
-                if (refreshed.isNotEmpty()) {
-                    settings = settingsRepo.load()
-                }
+        if (settings.connectorAutoRefreshIntervalMinutes <= 0) return@LaunchedEffect
+        while (isActive) {
+            autoSyncing = true
+            val refreshed = try {
+                refreshScheduler.refreshIfNeeded()
+            } finally {
+                autoSyncing = false
             }
+            if (refreshed.isNotEmpty()) {
+                settings = withContext(Dispatchers.IO) { settingsRepo.load() }
+            }
+            delay(60_000L)
         }
     }
 
@@ -94,6 +105,7 @@ fun ConnectorsSection() {
         AutoRefreshHeader(
             intervalMinutes = settings.connectorAutoRefreshIntervalMinutes,
             lastRefreshedAt = settings.connectorLastRefreshedAt,
+            isAutoSyncing = autoSyncing,
             // Reflected in the UI immediately and persisted off the main thread.
             // Settings lives in EncryptedSharedPreferences, so the read-modify-
             // write behind this is ~60 AES reads plus 58 writes -- long enough
@@ -159,6 +171,7 @@ private fun indexOfInterval(minutes: Int): Int {
 private fun AutoRefreshHeader(
     intervalMinutes: Int,
     lastRefreshedAt: Long,
+    isAutoSyncing: Boolean,
     onIntervalChange: (Int) -> Unit,
     onRefreshAll: suspend () -> Map<String, String>
 ) {
@@ -262,6 +275,16 @@ private fun AutoRefreshHeader(
                 steps = AUTO_REFRESH_INTERVALS.size - 2,
                 modifier = Modifier.fillMaxWidth()
             )
+            // A new interval saves in milliseconds; what takes a moment is the
+            // sync it starts when one is already due. Name that rather than the
+            // save, so the pause is explained instead of looking like a hang.
+            if (isAutoSyncing) {
+                Text(
+                    "Syncing connectors…",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/gotcha/ui/ConnectorsSection.kt
+++ b/app/src/main/java/com/gotcha/ui/ConnectorsSection.kt
@@ -37,6 +37,7 @@ import com.gotcha.connectors.notion.NotionConnector
 import com.gotcha.connectors.oauth.OAuthConnectFlow
 import com.gotcha.data.SettingsRepository
 import kotlin.math.roundToInt
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -93,10 +94,18 @@ fun ConnectorsSection() {
         AutoRefreshHeader(
             intervalMinutes = settings.connectorAutoRefreshIntervalMinutes,
             lastRefreshedAt = settings.connectorLastRefreshedAt,
+            // Reflected in the UI immediately and persisted off the main thread.
+            // Settings lives in EncryptedSharedPreferences, so the read-modify-
+            // write behind this is ~60 AES reads plus 58 writes -- long enough
+            // to drop frames while a finger is still on the slider.
             onIntervalChange = { newInterval ->
-                val current = settingsRepo.load()
-                settings = current.copy(connectorAutoRefreshIntervalMinutes = newInterval)
-                settingsRepo.save(settings)
+                settings = settings.copy(connectorAutoRefreshIntervalMinutes = newInterval)
+                scope.launch(Dispatchers.IO) {
+                    val current = settingsRepo.load()
+                    settingsRepo.save(
+                        current.copy(connectorAutoRefreshIntervalMinutes = newInterval)
+                    )
+                }
             },
             onRefreshAll = {
                 val results = refreshScheduler.refreshIfNeeded(force = true)

--- a/app/src/main/java/com/gotcha/ui/ConnectorsSection.kt
+++ b/app/src/main/java/com/gotcha/ui/ConnectorsSection.kt
@@ -2,17 +2,15 @@ package com.gotcha.ui
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Checkbox
-import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -38,6 +36,7 @@ import com.gotcha.connectors.microsoft.MicrosoftConnector
 import com.gotcha.connectors.notion.NotionConnector
 import com.gotcha.connectors.oauth.OAuthConnectFlow
 import com.gotcha.data.SettingsRepository
+import kotlin.math.roundToInt
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -118,7 +117,35 @@ fun ConnectorsSection() {
     }
 }
 
-@OptIn(ExperimentalLayoutApi::class)
+/**
+ * The auto-sync intervals the slider offers, in minutes, with the label shown
+ * for each. 1m is the floor: the loop driving auto-sync in [ConnectorsSection]
+ * ticks every 60s, so anything finer would be a setting the app cannot honour.
+ */
+private val AUTO_REFRESH_INTERVALS = listOf(
+    0 to "Off",
+    1 to "1m",
+    2 to "2m",
+    5 to "5m",
+    10 to "10m",
+    15 to "15m",
+    30 to "30m",
+    120 to "2h"
+)
+
+/**
+ * Slider index for a stored interval. A value that is not one of the offered
+ * steps -- written by an older build, or by a settings import -- snaps to the
+ * nearest one rather than resetting the user to Off.
+ */
+private fun indexOfInterval(minutes: Int): Int {
+    val exact = AUTO_REFRESH_INTERVALS.indexOfFirst { it.first == minutes }
+    if (exact >= 0) return exact
+    return AUTO_REFRESH_INTERVALS.indices.minByOrNull {
+        kotlin.math.abs(AUTO_REFRESH_INTERVALS[it].first - minutes)
+    } ?: 0
+}
+
 @Composable
 private fun AutoRefreshHeader(
     intervalMinutes: Int,
@@ -130,6 +157,13 @@ private fun AutoRefreshHeader(
     var isRefreshing by remember { mutableStateOf(false) }
     var syncFeedback by remember { mutableStateOf("") }
     var tick by remember { mutableStateOf(0) }
+    // Position is held locally so the thumb tracks the finger; it is re-seeded
+    // whenever the stored interval changes underneath us.
+    var sliderPosition by remember(intervalMinutes) {
+        mutableStateOf(indexOfInterval(intervalMinutes).toFloat())
+    }
+    val sliderIndex = sliderPosition.roundToInt()
+        .coerceIn(0, AUTO_REFRESH_INTERVALS.lastIndex)
 
     // Live recomposition ticker for "X min ago" display
     LaunchedEffect(lastRefreshedAt) {
@@ -189,36 +223,36 @@ private fun AutoRefreshHeader(
             Text(syncFeedback, style = MaterialTheme.typography.bodySmall)
         }
 
-        // Eight choices no longer fit one phone-width line, so the chips wrap.
-        FlowRow(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalArrangement = Arrangement.spacedBy(4.dp)
-        ) {
-            Text(
-                "Interval:",
-                style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.align(Alignment.CenterVertically)
-            )
-            // Anything under a minute would be finer than the 60s poll tick in
-            // ConnectorsSection can honour, so 1m is the floor.
-            val intervals = listOf(
-                0 to "Off",
-                1 to "1m",
-                2 to "2m",
-                5 to "5m",
-                10 to "10m",
-                15 to "15m",
-                30 to "30m",
-                120 to "2h"
-            )
-            intervals.forEach { (mins, label) ->
-                FilterChip(
-                    selected = intervalMinutes == mins,
-                    onClick = { onIntervalChange(mins) },
-                    label = { Text(label) }
+        // Eight choices are too many to sit on one phone-width line as chips, so
+        // the interval is a slider that snaps to the steps below. The spacing is
+        // deliberately not proportional to the durations -- every step is one
+        // notch, so the far end stays reachable without a 2h-wide gap.
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text("Interval", style = MaterialTheme.typography.bodyMedium)
+                Text(
+                    AUTO_REFRESH_INTERVALS[sliderIndex].second,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Bold
                 )
             }
+            Slider(
+                value = sliderPosition,
+                onValueChange = { sliderPosition = it },
+                // The interval only reaches Settings once the thumb is let go;
+                // dragging would otherwise write SharedPreferences every frame
+                // and restart the refresh loop on each one.
+                onValueChangeFinished = {
+                    onIntervalChange(AUTO_REFRESH_INTERVALS[sliderIndex].first)
+                },
+                valueRange = 0f..(AUTO_REFRESH_INTERVALS.size - 1).toFloat(),
+                steps = AUTO_REFRESH_INTERVALS.size - 2,
+                modifier = Modifier.fillMaxWidth()
+            )
         }
     }
 }

--- a/app/src/test/java/com/gotcha/data/MaxContextTokensLiftTest.kt
+++ b/app/src/test/java/com/gotcha/data/MaxContextTokensLiftTest.kt
@@ -1,0 +1,68 @@
+package com.gotcha.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Raising the default context budget reaches nobody on its own: an APK update
+ * keeps the app's data directory, so every existing install reads back the 70k
+ * it already stored. This lift is what actually moves them — silently, once,
+ * writing its result back. Same reasoning as [SkinMigrationTest]: a mistake
+ * here is one nobody reports.
+ */
+class MaxContextTokensLiftTest {
+
+    @Test
+    fun `an install still on the old default is raised and the new value stored`() {
+        val lift = liftMaxContextTokens(stored = 70_000, alreadyLifted = false)
+        assertEquals(DEFAULT_MAX_CONTEXT_TOKENS, lift.value)
+        assertTrue("the raised value has to be persisted, not just returned", lift.writeBack)
+    }
+
+    /**
+     * A fresh install has never written the key, so the read already returns the
+     * current default. Nothing to lift, and nothing worth a write.
+     */
+    @Test
+    fun `a fresh install is left alone`() {
+        val lift = liftMaxContextTokens(
+            stored = DEFAULT_MAX_CONTEXT_TOKENS,
+            alreadyLifted = false
+        )
+        assertEquals(DEFAULT_MAX_CONTEXT_TOKENS, lift.value)
+        assertFalse(lift.writeBack)
+    }
+
+    /**
+     * The whole point of the one-shot flag. Someone who wants a small context
+     * window gets to keep it — the lift must not chase them back up on the next
+     * load.
+     */
+    @Test
+    fun `70k chosen deliberately after the lift has run is kept`() {
+        val lift = liftMaxContextTokens(stored = 70_000, alreadyLifted = true)
+        assertEquals(70_000, lift.value)
+        assertFalse(lift.writeBack)
+    }
+
+    /**
+     * Only the exact old default is treated as "never chose". A tuned value is
+     * a decision, and survives even on the run where the lift fires.
+     */
+    @Test
+    fun `a hand-tuned budget is never rewritten`() {
+        val lift = liftMaxContextTokens(stored = 32_000, alreadyLifted = false)
+        assertEquals(32_000, lift.value)
+        assertFalse(lift.writeBack)
+    }
+
+    /** A budget above the new default is a decision too, and must not be lowered. */
+    @Test
+    fun `a budget larger than the new default is left where it is`() {
+        val lift = liftMaxContextTokens(stored = 400_000, alreadyLifted = false)
+        assertEquals(400_000, lift.value)
+        assertFalse(lift.writeBack)
+    }
+}

--- a/app/src/test/java/com/gotcha/tools/ActionLogRedactionTest.kt
+++ b/app/src/test/java/com/gotcha/tools/ActionLogRedactionTest.kt
@@ -60,6 +60,30 @@ class ActionLogRedactionTest {
     }
 
     @Test
+    fun `pdf password is redacted from the audit log but the operation survives`() = runTest {
+        // The input does not exist, so the tool fails at file resolution — the audit line is
+        // written either way, which is exactly the path a PDF password would leak through.
+        executor.execute(
+            "pdf_edit",
+            JsonObject(
+                mapOf(
+                    "operation" to JsonPrimitive("info"),
+                    "input" to JsonPrimitive("/nonexistent/statement.pdf"),
+                    "password" to JsonPrimitive("hunter2-super-secret")
+                )
+            ),
+            agent = AgentMode.OPERATOR,
+            isSubAgent = true
+        )
+
+        val logged = logFile.readText()
+        assertFalse("the password must not reach disk: $logged", logged.contains("hunter2-super-secret"))
+        assertTrue("the redaction should be visible, not silent", logged.contains("(redacted)"))
+        assertTrue("the audit trail must still say what ran", logged.contains("\"operation\":\"info\""))
+        assertTrue(logged.contains("pdf_edit"))
+    }
+
+    @Test
     fun `arguments without a redacted key are logged unchanged`() = runTest {
         executor.execute(
             "run_termux_command",


### PR DESCRIPTION
Two review fixes from PR #64 review findings #1 and #2.

## 1. Audit log no longer leaks `pdf_edit` passwords in plaintext

`ToolExecutor.REDACTED_AUDIT_KEYS` previously redacted only `stdin`, so a
`password` argument to `pdf_edit` was written verbatim to the sandbox audit
file — and PDF passwords are often reused bank-statement/payslip passwords.
`password` is now added to the redaction set, so the audit line keeps the
argument name and operation while the value becomes `(redacted)`.

`PdfTool` result messages never echoed the actual password value, so the
audit log was the only leak.

Test: added a `pdf_edit` case to `ActionLogRedactionTest` mirroring the
existing `stdin` test — a failing `info` call (nonexistent input) with a
password asserts the password never reaches disk, `(redacted)` appears, and
the operation/audit trail survives.

## 2. `SdCardPath` lint warning suppressed on `TERMUX_STORAGE_ROOT`

`FfmpegCommand.TERMUX_STORAGE_ROOT = "/sdcard"` tripped `SdCardPath`, but the
hardcoded prefix is required: Termux only exposes the primary user's shared
storage at `/sdcard`. Added `@SuppressLint("SdCardPath")` on the constant with
a justification comment, removing the warning from the lint report (verified
in `lintDebug`; the pre-existing `SdCardPath` in `TermuxTool.kt:400` is
untouched and out of scope).

## Verification

- `:app:testDebugUnitTest --tests FfmpegCommandTest` and `--tests ActionLogRedactionTest` pass.
- `:app:compileDebugKotlin` clean.
- `:app:lintDebug` no longer reports `SdCardPath` for `FfmpegCommand.kt`.

🦦 Opened by [Jalebi](https://github.com/samosa-ai-com/jalebi) — your self-hosted AI coding agent by [Samosa AI](https://github.com/samosa-ai-com).

Co-authored-by: Jalebi <jalebi@samosa-ai.com>