### PR TITLE
chore: keep 1.2.0 notes under Unreleased for the release workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@
 All notable changes to Gotcha are documented here.
 
 ## [Unreleased]
-
-## [1.2.0]
 ### Added
 - **Podcast generation.** Gotcha can now turn text into listenable audio. Ask
   for a topic, an article or your notes as a podcast and the assistant writes


### PR DESCRIPTION
The 1.2.0 release run failed at *Roll CHANGELOG.md Unreleased section into this version*: the bump commit had already moved the notes into a `## [1.2.0]` section, leaving `## [Unreleased]` empty, which that step rejects.

This restores the notes under `## [Unreleased]` so the workflow can roll them itself.

After merge, the release must be re-triggered by hand (`Release` workflow → Run workflow, `dry_run` = false), since the workflow only fires on pushes that touch `app/build.gradle.kts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)