### PR TITLE
feat(settings): reorganise the settings tree into hubs and tell the three languages apart (#72, #73, #74)

### DIFF
--- a/.maestro/flows/02-settings-toggle.yaml
+++ b/.maestro/flows/02-settings-toggle.yaml
@@ -7,5 +7,6 @@ appId: com.gotcha
 - assertVisible: "Light"
 - tapOn: "Dark"
 - assertVisible: "Dark"
+- tapOn: "AI"
 - tapOn: "AI Configuration"
 - assertVisible: "Base URL (OpenAI-compatible)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to Gotcha are documented here.
 
 ## [Unreleased]
+### Changed
+- **Settings → About.** The hub that collects the company page, the legal
+  agreements and the app updater is now titled `About` rather than `About Us`:
+  it holds more than company information, so the old title undersold it.
+  `About Samosa AI` and `Legal` still sit underneath it, unchanged.
 
 ## [1.2.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Gotcha are documented here.
 
 ## [Unreleased]
 ### Changed
+- **Settings → AI.** The model and the voice used to sit as two unrelated rows on
+  the settings list, as if choosing what Gotcha thinks with had nothing to do with
+  choosing what it speaks with. Both now live under a single `AI` row:
+  `AI Configuration` for the provider and models, `Speech (TTS / STT)` for voices
+  and transcription. The pages themselves are unchanged, and so is everything
+  already saved on them.
+- **Advanced settings are collapsed by default.** The knobs almost nobody needs —
+  sub-agent and navigator model overrides, the agent-loop limits, the API timeout,
+  the cache-clearing buttons, the podcast host voices — are now behind an
+  `Advanced settings` disclosure on the page they belong to, instead of standing
+  between a new install and the Save button. Nothing moved pages, and expanding
+  the section is never required to save.
 - **Settings → About.** The hub that collects the company page, the legal
   agreements and the app updater is now titled `About` rather than `About Us`:
   it holds more than company information, so the old title undersold it.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -452,11 +452,11 @@ dependencies {
 
     // Instrumented tests
     androidTestImplementation(composeBom)
-    androidTestImplementation("androidx.test:core-ktx:1.6.1")
-    androidTestImplementation("androidx.test:runner:1.6.2")
-    androidTestImplementation("androidx.test:rules:1.6.1")
-    androidTestImplementation("androidx.test.ext:junit-ktx:1.2.1")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
+    androidTestImplementation("androidx.test:core-ktx:1.7.0")
+    androidTestImplementation("androidx.test:runner:1.7.0")
+    androidTestImplementation("androidx.test:rules:1.7.0")
+    androidTestImplementation("androidx.test.ext:junit-ktx:1.3.0")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.7.0")
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     androidTestImplementation("androidx.test.uiautomator:uiautomator:2.3.0")
     androidTestImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")

--- a/app/src/androidTest/java/com/gotcha/SettingsFlowTest.kt
+++ b/app/src/androidTest/java/com/gotcha/SettingsFlowTest.kt
@@ -10,6 +10,7 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.gotcha.data.SettingsRepository
+import com.gotcha.i18n.Language
 import com.gotcha.testutil.TestSeed
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -91,6 +92,51 @@ class SettingsFlowTest {
         val persisted = SettingsRepository(context).load()
         assertEquals("Ada", persisted.userName)
         assertEquals("No bullet lists.", persisted.userResponseStyle)
+    }
+
+    @Test
+    fun languagePage_showsTheThreeLanguagesApartAndPersistsThem() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        TestSeed.seedUnconfigured(context)
+
+        scenario = ActivityScenario.launch(MainActivity::class.java)
+        composeRule.waitForIdle()
+
+        // First run opens on AI Configuration inside the AI hub — two Backs to the list.
+        composeRule.onNodeWithTag("settings_back").performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag("settings_back").performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag("settings_language_row").performScrollTo().performClick()
+        composeRule.waitForIdle()
+
+        // The point of the page (issue #74): all three named and visible at once.
+        composeRule.onNodeWithText("App display language").assertExists()
+        composeRule.onNodeWithTag("settings_voice_language").performScrollTo().assertExists()
+        composeRule.onNodeWithTag("settings_reply_language").performScrollTo().assertExists()
+
+        // Untouched, the voice follows the reply language — what a pre-#74 install did.
+        composeRule.onNodeWithText("Same as AI reply language").assertExists()
+
+        // The whole point of the split: answers written in one language, spoken in
+        // another. Pick Hindi for the voice and leave the reply language English.
+        composeRule.onNodeWithTag("settings_voice_language").performScrollTo().performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText("Hindi").performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithTag("settings_save_language").performScrollTo().performClick()
+        composeRule.waitForIdle()
+        scenario?.close()
+
+        // Round-trips through EncryptedSharedPreferences, which no JVM test reaches.
+        val persisted = SettingsRepository(context).load()
+        assertEquals("Hindi", persisted.voiceLanguage)
+        assertEquals("English", persisted.preferredLanguage)
+        // TTS and STT follow the voice; the prompt still follows preferredLanguage.
+        assertEquals(Language.HINDI, persisted.effectiveVoiceLanguage)
+        assertEquals("hi-IN", persisted.effectiveVoiceLanguage.bcp47)
+        assertEquals("hi", persisted.effectiveVoiceLanguage.iso639)
     }
 
     @Test

--- a/app/src/androidTest/java/com/gotcha/SettingsFlowTest.kt
+++ b/app/src/androidTest/java/com/gotcha/SettingsFlowTest.kt
@@ -70,7 +70,10 @@ class SettingsFlowTest {
         scenario = ActivityScenario.launch(MainActivity::class.java)
         composeRule.waitForIdle()
 
-        // First run opens on AI Configuration; Back reaches the category list.
+        // First run opens on AI Configuration, which sits inside the AI hub, so
+        // reaching the category list takes two Backs.
+        composeRule.onNodeWithTag("settings_back").performClick()
+        composeRule.waitForIdle()
         composeRule.onNodeWithTag("settings_back").performClick()
         composeRule.waitForIdle()
         composeRule.onNodeWithTag("settings_personal_info_row").performScrollTo().performClick()
@@ -99,16 +102,42 @@ class SettingsFlowTest {
         composeRule.waitForIdle()
 
         // First run opens on AI Configuration; Back from a sub-page lands on the
-        // category list rather than leaving Settings.
+        // hub it hangs off rather than leaving Settings...
         composeRule.onNodeWithTag("settings_base_url").assertExists()
         composeRule.onNodeWithTag("settings_back").performClick()
         composeRule.waitForIdle()
         composeRule.onNodeWithTag("settings_ai_config_row").assertExists()
 
-        // Opening another category replaces the list with that page.
+        // ...and Back again from the hub lands on the category list.
+        composeRule.onNodeWithTag("settings_back").performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag("settings_ai_row").assertExists()
+        composeRule.onNodeWithTag("settings_ai_config_row").assertDoesNotExist()
+
+        // Opening a category replaces the list with that page.
+        composeRule.onNodeWithTag("settings_ai_row").performScrollTo().performClick()
+        composeRule.waitForIdle()
         composeRule.onNodeWithTag("settings_speech_row").performScrollTo().performClick()
         composeRule.waitForIdle()
         composeRule.onNodeWithTag("settings_ai_config_row").assertDoesNotExist()
         composeRule.onNodeWithText("TTS Provider").assertExists()
+    }
+
+    @Test
+    fun aiConfig_keepsTheAdvancedKnobsCollapsedUntilAsked() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        TestSeed.seedUnconfigured(context)
+
+        scenario = ActivityScenario.launch(MainActivity::class.java)
+        composeRule.waitForIdle()
+
+        // First run opens on AI Configuration. The agent-loop limits are one tap
+        // away, not in the way of the fields that make the app work.
+        composeRule.onNodeWithTag("settings_model").assertExists()
+        composeRule.onNodeWithText("Max tool rounds").assertDoesNotExist()
+
+        composeRule.onNodeWithTag("settings_ai_advanced").performScrollTo().performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText("Max tool rounds").performScrollTo().assertExists()
     }
 }

--- a/app/src/main/assets/company/about-samosa-ai.md
+++ b/app/src/main/assets/company/about-samosa-ai.md
@@ -72,7 +72,7 @@ AI-PCP, ConsensusAI, Listener, and Watcher are announced but not yet released.
 
 Gotcha ships three legal documents in the app: Terms and Conditions, a Disclaimer and Declaration, and a Data Retention and Privacy Policy. In short: the assistant is powered by a generative AI model, so its output can be wrong and should be verified before you act on it — especially for actions with real-world consequences. You are responsible for the instructions you give the agent and the actions it takes on your behalf, and the app must only be used lawfully. Gotcha is privacy-first and runs on-device wherever it can.
 
-These summaries are not the agreements themselves. The full, authoritative text is bundled in the app under Settings > About Us > Legal. Read it there before relying on any summary.
+These summaries are not the agreements themselves. The full, authoritative text is bundled in the app under Settings > About > Legal. Read it there before relying on any summary.
 
 ## Pricing
 

--- a/app/src/main/java/com/gotcha/MainActivity.kt
+++ b/app/src/main/java/com/gotcha/MainActivity.kt
@@ -96,6 +96,7 @@ private fun tourPlaceOf(route: Route, page: SettingsPage?, drawerOpen: Boolean):
     route == Route.HOME -> TourPlace.CHAT
     route == Route.SETTINGS -> when (page) {
         null -> TourPlace.SETTINGS_HOME
+        SettingsPage.AI -> TourPlace.AI_HUB
         SettingsPage.AI_CONFIG -> TourPlace.AI_CONFIG
         SettingsPage.PERMISSIONS -> TourPlace.PERMISSIONS
         SettingsPage.PERSONAL_INFO -> TourPlace.PERSONAL_INFO
@@ -108,6 +109,7 @@ private fun tourPlaceOf(route: Route, page: SettingsPage?, drawerOpen: Boolean):
 private fun routeForTourPlace(place: TourPlace): Pair<Route, SettingsPage?> = when (place) {
     TourPlace.CHAT, TourPlace.CHAT_DRAWER -> Route.HOME to null
     TourPlace.SETTINGS_HOME -> Route.SETTINGS to null
+    TourPlace.AI_HUB -> Route.SETTINGS to SettingsPage.AI
     TourPlace.AI_CONFIG -> Route.SETTINGS to SettingsPage.AI_CONFIG
     TourPlace.PERMISSIONS -> Route.SETTINGS to SettingsPage.PERMISSIONS
     TourPlace.PERSONAL_INFO -> Route.SETTINGS to SettingsPage.PERSONAL_INFO

--- a/app/src/main/java/com/gotcha/agent/AgentEngine.kt
+++ b/app/src/main/java/com/gotcha/agent/AgentEngine.kt
@@ -1362,7 +1362,7 @@ class AgentEngine(
             fact("Location", s.userLocation)
             fact("Occupation", s.userOccupation)
             fact("Background", s.userBackground)
-            fact("Preferred language", s.preferredLanguage)
+            fact("Reply language", s.preferredLanguage)
             fact("Preferred currency", s.preferredCurrency)
         }
         return buildString {

--- a/app/src/main/java/com/gotcha/agent/ChatViewModel.kt
+++ b/app/src/main/java/com/gotcha/agent/ChatViewModel.kt
@@ -864,7 +864,7 @@ class ChatViewModel(application: Application) : AndroidViewModel(application), A
             ttsEngine.stop()
             _uiState.update { it.copy(isSpeaking = true) }
             try {
-                val language = Language.fromLabel(settings.preferredLanguage)
+                val language = settings.effectiveVoiceLanguage
                 val defaultVoice = _uiState.value.ttsModels
                     .firstOrNull { it.id == settings.ttsApiModel }
                     ?.defaultVoiceFor(language) ?: "af_heart"
@@ -925,7 +925,7 @@ class ChatViewModel(application: Application) : AndroidViewModel(application), A
                     )
                     return
                 }
-                val started = sttEngine.startAndroidListening(Language.fromLabel(settings.preferredLanguage))
+                val started = sttEngine.startAndroidListening(settings.effectiveVoiceLanguage)
                 if (started) {
                     _uiState.update { it.copy(isListening = true) }
                 } else {
@@ -978,7 +978,7 @@ class ChatViewModel(application: Application) : AndroidViewModel(application), A
                             return@launch
                         }
                         val sttLanguage = settings.sttLanguage.ifBlank {
-                            Language.fromLabel(settings.preferredLanguage).iso639
+                            settings.effectiveVoiceLanguage.iso639
                         }
                         transcript = sttEngine.transcribeApi(
                             audioFile, settings.sttApiModel, sttLanguage
@@ -999,7 +999,7 @@ class ChatViewModel(application: Application) : AndroidViewModel(application), A
                     // cleanText is redundant there and would cost an extra LLM round-trip.
                     val cleaned = if (provider == AudioProvider.ANDROID) {
                         val navModel = settings.navigatorModel.ifEmpty { settings.model }
-                        client?.cleanText(transcript, navModel, Language.fromLabel(settings.preferredLanguage))
+                        client?.cleanText(transcript, navModel, settings.effectiveVoiceLanguage)
                             ?: transcript
                     } else {
                         transcript

--- a/app/src/main/java/com/gotcha/data/SettingsRepository.kt
+++ b/app/src/main/java/com/gotcha/data/SettingsRepository.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import com.gotcha.BuildConfig
 import com.gotcha.audio.AudioProvider
+import com.gotcha.i18n.Language
 
 /**
  * When the wake-word listener is allowed to run, relative to the screen state.
@@ -170,7 +171,22 @@ data class Settings(
      * directive rather than into the profile block.
      */
     val userResponseStyle: String = "",
+    /**
+     * The language the assistant *writes* its answers in — the reply directive
+     * and the `<user_profile>` fact in `AgentEngine`. Persisted as a
+     * [com.gotcha.i18n.Language] label; the value must stay stable.
+     */
     val preferredLanguage: String = "English",
+    /**
+     * The language speech is spoken and heard in, or blank to follow
+     * [preferredLanguage] — see [effectiveVoiceLanguage].
+     *
+     * Split out from [preferredLanguage] because the two are genuinely separate
+     * choices: plenty of people want answers written in English but read aloud
+     * (and dictated) in their own language. Blank by default so every install
+     * that predates the split keeps behaving exactly as it did.
+     */
+    val voiceLanguage: String = "",
     val preferredCurrency: String = "USD",
     val communitySkillHosts: Set<String> = setOf(BuildConfig.SAMOSA_SKILL_HOST),
     /**
@@ -280,6 +296,14 @@ data class Settings(
             AudioProvider.API -> sttApiKey.ifBlank { effectiveApiKey }
             else -> ""
         }
+
+    /**
+     * The language TTS speaks and STT listens in: the explicit [voiceLanguage]
+     * when one is set, otherwise the reply language. [sttLanguage] still wins
+     * for transcription specifically, since it is a per-model override.
+     */
+    val effectiveVoiceLanguage: Language
+        get() = Language.fromLabel(voiceLanguage.ifBlank { preferredLanguage })
 
     /** True when Samosa AI is selected and a session token exists. */
     val isSamosaAuthenticated: Boolean
@@ -503,6 +527,7 @@ class SettingsRepository(context: Context) : SettingsStore {
         userBackground = string(KEY_USER_BACKGROUND),
         userResponseStyle = string(KEY_USER_RESPONSE_STYLE),
         preferredLanguage = string(KEY_PREFERRED_LANGUAGE, "English"),
+        voiceLanguage = string(KEY_VOICE_LANGUAGE),
         preferredCurrency = string(KEY_PREFERRED_CURRENCY, "USD"),
         communitySkillHosts = stringSet(KEY_COMMUNITY_SKILL_HOSTS, defaultCommunitySkillHosts),
         legalAcceptedVersion = string(KEY_LEGAL_ACCEPTED_VERSION),
@@ -575,6 +600,7 @@ class SettingsRepository(context: Context) : SettingsStore {
             .putString(KEY_USER_BACKGROUND, settings.userBackground)
             .putString(KEY_USER_RESPONSE_STYLE, settings.userResponseStyle)
             .putString(KEY_PREFERRED_LANGUAGE, settings.preferredLanguage)
+            .putString(KEY_VOICE_LANGUAGE, settings.voiceLanguage)
             .putString(KEY_PREFERRED_CURRENCY, settings.preferredCurrency)
             .putStringSet(KEY_COMMUNITY_SKILL_HOSTS, settings.communitySkillHosts)
             .putString(KEY_LEGAL_ACCEPTED_VERSION, settings.legalAcceptedVersion)
@@ -690,6 +716,7 @@ class SettingsRepository(context: Context) : SettingsStore {
         const val KEY_USER_BACKGROUND = "user_background"
         const val KEY_USER_RESPONSE_STYLE = "user_response_style"
         const val KEY_PREFERRED_LANGUAGE = "preferred_language"
+        const val KEY_VOICE_LANGUAGE = "voice_language"
         const val KEY_PREFERRED_CURRENCY = "preferred_currency"
         const val KEY_COMMUNITY_SKILL_HOSTS = "community_skill_hosts"
         const val KEY_LEGAL_ACCEPTED_VERSION = "legal_accepted_version"

--- a/app/src/main/java/com/gotcha/service/AssistiveBallService.kt
+++ b/app/src/main/java/com/gotcha/service/AssistiveBallService.kt
@@ -23,7 +23,6 @@ import com.gotcha.data.ChatHistoryRepository
 import com.gotcha.data.SettingsRepository
 import com.gotcha.data.WakeWordListeningMode
 import com.gotcha.data.settingsChangeNotifier
-import com.gotcha.i18n.Language
 import com.gotcha.ui.AssistiveBallOverlay
 import com.gotcha.ui.CallChatWindow
 import com.gotcha.util.GotchaLog
@@ -807,7 +806,7 @@ class AssistiveBallService : Service() {
                     screenCompanionPanel.setListening(false)
                     return
                 }
-                if (sttEngine.startAndroidListening(Language.fromLabel(s.preferredLanguage))) {
+                if (sttEngine.startAndroidListening(s.effectiveVoiceLanguage)) {
                     panelVoiceActive = true
                 } else {
                     overlay.showError("Failed to start speech recognition.")
@@ -861,7 +860,7 @@ class AssistiveBallService : Service() {
         }
         sttEngine.configureApi(s.effectiveSttBaseUrl, s.effectiveSttApiKey)
         scope.launch {
-            val sttLanguage = s.sttLanguage.ifBlank { Language.fromLabel(s.preferredLanguage).iso639 }
+            val sttLanguage = s.sttLanguage.ifBlank { s.effectiveVoiceLanguage.iso639 }
             val result = sttEngine.stopListeningAndTranscribe(provider, s.sttApiModel, sttLanguage)
             screenCompanionPanel.setListening(false)
             result
@@ -885,7 +884,7 @@ class AssistiveBallService : Service() {
                 provider = s.ttsProvider,
                 apiModel = s.ttsApiModel,
                 voice = s.ttsVoice,
-                language = Language.fromLabel(s.preferredLanguage)
+                language = s.effectiveVoiceLanguage
             )
             // Playback completed (or was stopped) — reset the speaker icon.
             screenCompanionPanel.setSpeaking(false)

--- a/app/src/main/java/com/gotcha/service/CallSessionController.kt
+++ b/app/src/main/java/com/gotcha/service/CallSessionController.kt
@@ -213,7 +213,7 @@ class CallSessionController(
         narrationErrorReported = false
         _state.value = CallState.STARTING
         scope.launch {
-            val language = Language.fromLabel(s.preferredLanguage)
+            val language = s.effectiveVoiceLanguage
             if (!speakText(startGreeting(handsFree, language), language)) {
                 reportError("Couldn't play voice audio — check your Text-to-Speech settings.")
             }
@@ -453,7 +453,7 @@ class CallSessionController(
             _state.value = CallState.THINKING
             val s = settingsRepository.load()
             sttEngine.configureApi(s.effectiveSttBaseUrl, s.effectiveSttApiKey)
-            val language = Language.fromLabel(s.preferredLanguage)
+            val language = s.effectiveVoiceLanguage
             val sttLanguage = s.sttLanguage.ifBlank { language.iso639 }
             val result = sttEngine.stopListeningAndTranscribe(s.sttProvider, s.sttApiModel, sttLanguage)
             val text = result.getOrDefault("")
@@ -480,7 +480,7 @@ class CallSessionController(
      */
     private suspend fun finishTurn(text: String) {
         val s = settingsRepository.load()
-        val language = Language.fromLabel(s.preferredLanguage)
+        val language = s.effectiveVoiceLanguage
         _state.value = CallState.THINKING
 
         // API STT (Whisper-class) output is already punctuated and cased —
@@ -737,9 +737,9 @@ class CallSessionController(
         _transcript.value = _transcript.value + CallTranscriptItem(nextTranscriptId++, kind, text)
     }
 
-    /** Resolve the persisted [preferredLanguage] to a [Language]. */
+    /** The language this call is spoken and heard in — see `Settings.effectiveVoiceLanguage`. */
     private fun currentLanguage(): Language =
-        Language.fromLabel(settingsRepository.load().preferredLanguage)
+        settingsRepository.load().effectiveVoiceLanguage
 
     /** Surface an error the same way everywhere: transcript entry + dialog + haptic. */
     private fun reportError(message: String) {

--- a/app/src/main/java/com/gotcha/tools/CompanyInfoTool.kt
+++ b/app/src/main/java/com/gotcha/tools/CompanyInfoTool.kt
@@ -8,7 +8,7 @@ import android.content.Context
  *
  * The content is bundled as an asset rather than fetched, so the agent can
  * answer offline and the answer never drifts with the network. The same
- * document backs the Settings > About Us page, which reads it directly.
+ * document backs the Settings > About page, which reads it directly.
  */
 class CompanyInfoTool(private val context: Context) {
 

--- a/app/src/main/java/com/gotcha/ui/AboutScreen.kt
+++ b/app/src/main/java/com/gotcha/ui/AboutScreen.kt
@@ -34,7 +34,7 @@ import com.gotcha.updater.UpdateStatus
 import kotlinx.coroutines.launch
 
 /**
- * About Us: the hub for everything about who made this app and what using it
+ * About: the hub for everything about who made this app and what using it
  * commits you to. Shaped like the settings home list rather than a content page,
  * so the two things underneath it — the company and the agreements — stay
  * separate reads instead of one long scroll.

--- a/app/src/main/java/com/gotcha/ui/AiConfigScreen.kt
+++ b/app/src/main/java/com/gotcha/ui/AiConfigScreen.kt
@@ -36,6 +36,12 @@ import kotlinx.coroutines.launch
  * The AI Configuration page: which LLM backend to talk to, which models to use
  * for the main agent and its sub-agents, and the agent loop's limits.
  *
+ * Only the three things a working install needs — provider, credentials, main
+ * model — are on the page itself. The sub-agent and navigator overrides, the loop
+ * limits and the cache-clearing buttons sit inside a collapsed
+ * [SettingsAdvancedSection]: they are worth having, but not worth scrolling past
+ * on the way to Save.
+ *
  * Saves write only the fields on this page (see [SettingsScreen]'s `onSave`), so
  * edits left half-finished on another page are never dragged into storage here.
  */
@@ -341,150 +347,172 @@ fun AiConfigScreen(
                 )
             }
         }
-        ExposedDropdownMenuBox(
-            expanded = subAgentModelExpanded,
-            onExpandedChange = {
-                subAgentModelExpanded = it
-                if (it) refreshChatModelsAction()
-            }
-        ) {
-            val subLabel = if (subAgentModel.isBlank()) "Same as main agent" else subAgentModel
-            OutlinedTextField(
-                value = subLabel,
-                onValueChange = {},
-                readOnly = true,
-                label = { Text("Sub-agent model") },
-                trailingIcon = {
-                    ExposedDropdownMenuDefaults.TrailingIcon(
-                        expanded = subAgentModelExpanded
-                    )
-                },
-                modifier = Modifier.fillMaxWidth().menuAnchor()
-            )
-            SkinExposedDropdownMenu(
+        // ---- Advanced: model overrides, agent-loop limits, maintenance ----
+        // Collapsed by default. The fields' state lives at the top of this
+        // composable and `applyAiConfig` reads it either way, so folding the
+        // section away never drops an edit or changes what Save writes.
+        SettingsAdvancedSection(testTag = "settings_ai_advanced") {
+            ExposedDropdownMenuBox(
                 expanded = subAgentModelExpanded,
-                onDismissRequest = { subAgentModelExpanded = false }
-            ) {
-                DropdownMenuItem(
-                    text = { Text(if (refreshingChatModels) "Refreshing…" else "🔄 Refresh models…") },
-                    onClick = { refreshChatModelsAction() }
-                )
-                DropdownMenuItem(
-                    text = { Text("Same as main agent") },
-                    onClick = {
-                        subAgentModel = ""
-                        subAgentModelExpanded = false
-                    }
-                )
-                if (availableChatModels.isNotEmpty()) {
-                    availableChatModels.forEach { m ->
-                        DropdownMenuItem(
-                            text = { Text(m) },
-                            onClick = {
-                                subAgentModel = m
-                                subAgentModelExpanded = false
-                            }
-                        )
-                    }
+                onExpandedChange = {
+                    subAgentModelExpanded = it
+                    if (it) refreshChatModelsAction()
                 }
-            }
-        }
-        ExposedDropdownMenuBox(
-            expanded = navigatorModelExpanded,
-            onExpandedChange = {
-                navigatorModelExpanded = it
-                if (it) refreshChatModelsAction()
-            }
-        ) {
-            val navLabel = if (navigatorModel.isBlank()) "Same as main model" else navigatorModel
-            OutlinedTextField(
-                value = navLabel,
-                onValueChange = {},
-                readOnly = true,
-                label = { Text("Navigator model") },
-                trailingIcon = {
-                    ExposedDropdownMenuDefaults.TrailingIcon(
-                        expanded = navigatorModelExpanded
+            ) {
+                val subLabel = if (subAgentModel.isBlank()) "Same as main agent" else subAgentModel
+                OutlinedTextField(
+                    value = subLabel,
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text("Sub-agent model") },
+                    trailingIcon = {
+                        ExposedDropdownMenuDefaults.TrailingIcon(
+                            expanded = subAgentModelExpanded
+                        )
+                    },
+                    modifier = Modifier.fillMaxWidth().menuAnchor()
+                )
+                SkinExposedDropdownMenu(
+                    expanded = subAgentModelExpanded,
+                    onDismissRequest = { subAgentModelExpanded = false }
+                ) {
+                    DropdownMenuItem(
+                        text = { Text(if (refreshingChatModels) "Refreshing…" else "🔄 Refresh models…") },
+                        onClick = { refreshChatModelsAction() }
                     )
-                },
-                modifier = Modifier.fillMaxWidth().menuAnchor()
-            )
-            SkinExposedDropdownMenu(
-                expanded = navigatorModelExpanded,
-                onDismissRequest = { navigatorModelExpanded = false }
-            ) {
-                DropdownMenuItem(
-                    text = { Text(if (refreshingChatModels) "Refreshing…" else "🔄 Refresh models…") },
-                    onClick = { refreshChatModelsAction() }
-                )
-                DropdownMenuItem(
-                    text = { Text("Same as main model") },
-                    onClick = {
-                        navigatorModel = ""
-                        navigatorModelExpanded = false
-                    }
-                )
-                if (availableChatModels.isNotEmpty()) {
-                    availableChatModels.forEach { m ->
-                        DropdownMenuItem(
-                            text = { Text(m) },
-                            onClick = {
-                                navigatorModel = m
-                                navigatorModelExpanded = false
-                            }
-                        )
+                    DropdownMenuItem(
+                        text = { Text("Same as main agent") },
+                        onClick = {
+                            subAgentModel = ""
+                            subAgentModelExpanded = false
+                        }
+                    )
+                    if (availableChatModels.isNotEmpty()) {
+                        availableChatModels.forEach { m ->
+                            DropdownMenuItem(
+                                text = { Text(m) },
+                                onClick = {
+                                    subAgentModel = m
+                                    subAgentModelExpanded = false
+                                }
+                            )
+                        }
                     }
                 }
             }
+            ExposedDropdownMenuBox(
+                expanded = navigatorModelExpanded,
+                onExpandedChange = {
+                    navigatorModelExpanded = it
+                    if (it) refreshChatModelsAction()
+                }
+            ) {
+                val navLabel = if (navigatorModel.isBlank()) "Same as main model" else navigatorModel
+                OutlinedTextField(
+                    value = navLabel,
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text("Navigator model") },
+                    trailingIcon = {
+                        ExposedDropdownMenuDefaults.TrailingIcon(
+                            expanded = navigatorModelExpanded
+                        )
+                    },
+                    modifier = Modifier.fillMaxWidth().menuAnchor()
+                )
+                SkinExposedDropdownMenu(
+                    expanded = navigatorModelExpanded,
+                    onDismissRequest = { navigatorModelExpanded = false }
+                ) {
+                    DropdownMenuItem(
+                        text = { Text(if (refreshingChatModels) "Refreshing…" else "🔄 Refresh models…") },
+                        onClick = { refreshChatModelsAction() }
+                    )
+                    DropdownMenuItem(
+                        text = { Text("Same as main model") },
+                        onClick = {
+                            navigatorModel = ""
+                            navigatorModelExpanded = false
+                        }
+                    )
+                    if (availableChatModels.isNotEmpty()) {
+                        availableChatModels.forEach { m ->
+                            DropdownMenuItem(
+                                text = { Text(m) },
+                                onClick = {
+                                    navigatorModel = m
+                                    navigatorModelExpanded = false
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+            OutlinedTextField(
+                value = maxToolRounds,
+                onValueChange = { maxToolRounds = it },
+                label = { Text("Max tool rounds") },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                modifier = Modifier.fillMaxWidth()
+            )
+            OutlinedTextField(
+                value = maxRepeatedToolCalls,
+                onValueChange = { maxRepeatedToolCalls = it },
+                label = { Text("Max repeated tool calls") },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                modifier = Modifier.fillMaxWidth()
+            )
+            OutlinedTextField(
+                value = maxNavigationToolCalls,
+                onValueChange = { maxNavigationToolCalls = it },
+                label = { Text("Max navigation tool calls") },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                modifier = Modifier.fillMaxWidth()
+            )
+            OutlinedTextField(
+                value = maxConsecutiveDelegations,
+                onValueChange = { maxConsecutiveDelegations = it },
+                label = { Text("Max consecutive delegations") },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                modifier = Modifier.fillMaxWidth()
+            )
+            OutlinedTextField(
+                value = maxContextTokens,
+                onValueChange = { maxContextTokens = it },
+                label = { Text("Max context tokens") },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                modifier = Modifier.fillMaxWidth()
+            )
+            OutlinedTextField(
+                value = apiTimeoutSeconds,
+                onValueChange = { apiTimeoutSeconds = it },
+                label = { Text("API Timeout (seconds, 0 for infinite)") },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                modifier = Modifier.fillMaxWidth()
+            )
+            OutlinedButton(
+                onClick = {
+                    onClearLlmCache()
+                    overlay.show("LLM response cache cleared.")
+                    status = null
+                },
+                modifier = Modifier.fillMaxWidth()
+            ) { Text("Clear LLM cache") }
+            OutlinedButton(
+                onClick = {
+                    onClearDebugScreenshots()
+                    overlay.show("Debug screenshots cleared.")
+                    status = null
+                },
+                modifier = Modifier.fillMaxWidth()
+            ) { Text("Clear debug screenshots") }
         }
-        OutlinedTextField(
-            value = maxToolRounds,
-            onValueChange = { maxToolRounds = it },
-            label = { Text("Max tool rounds") },
-            singleLine = true,
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-            modifier = Modifier.fillMaxWidth()
-        )
-        OutlinedTextField(
-            value = maxRepeatedToolCalls,
-            onValueChange = { maxRepeatedToolCalls = it },
-            label = { Text("Max repeated tool calls") },
-            singleLine = true,
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-            modifier = Modifier.fillMaxWidth()
-        )
-        OutlinedTextField(
-            value = maxNavigationToolCalls,
-            onValueChange = { maxNavigationToolCalls = it },
-            label = { Text("Max navigation tool calls") },
-            singleLine = true,
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-            modifier = Modifier.fillMaxWidth()
-        )
-        OutlinedTextField(
-            value = maxConsecutiveDelegations,
-            onValueChange = { maxConsecutiveDelegations = it },
-            label = { Text("Max consecutive delegations") },
-            singleLine = true,
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-            modifier = Modifier.fillMaxWidth()
-        )
-        OutlinedTextField(
-            value = maxContextTokens,
-            onValueChange = { maxContextTokens = it },
-            label = { Text("Max context tokens") },
-            singleLine = true,
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-            modifier = Modifier.fillMaxWidth()
-        )
-        OutlinedTextField(
-            value = apiTimeoutSeconds,
-            onValueChange = { apiTimeoutSeconds = it },
-            label = { Text("API Timeout (seconds, 0 for infinite)") },
-            singleLine = true,
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-            modifier = Modifier.fillMaxWidth()
-        )
         Button(
             onClick = {
                 onSave { applyAiConfig(it) }
@@ -524,22 +552,6 @@ fun AiConfigScreen(
             },
             modifier = Modifier.fillMaxWidth()
         ) { Text("Test connection") }
-        OutlinedButton(
-            onClick = {
-                onClearLlmCache()
-                overlay.show("LLM response cache cleared.")
-                status = null
-            },
-            modifier = Modifier.fillMaxWidth()
-        ) { Text("Clear LLM cache") }
-        OutlinedButton(
-            onClick = {
-                onClearDebugScreenshots()
-                overlay.show("Debug screenshots cleared.")
-                status = null
-            },
-            modifier = Modifier.fillMaxWidth()
-        ) { Text("Clear debug screenshots") }
         status?.let {
             Text(it, style = MaterialTheme.typography.bodyMedium)
         }

--- a/app/src/main/java/com/gotcha/ui/AiHubScreen.kt
+++ b/app/src/main/java/com/gotcha/ui/AiHubScreen.kt
@@ -1,0 +1,55 @@
+package com.gotcha.ui
+
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.gotcha.ui.tour.TourAnchor
+import com.gotcha.ui.tour.tourAnchor
+
+/**
+ * AI: the hub for everything the assistant thinks, hears and speaks with — the
+ * language model on one page, speech and transcription on the other.
+ *
+ * They used to be two unrelated rows on the settings home list, which read as if
+ * choosing a voice had nothing to do with choosing a brain; both are the same
+ * decision about which provider does the work, and both are usually configured
+ * in one sitting.
+ */
+@Composable
+fun AiHubScreen(
+    onBack: () -> Unit,
+    onOpenPage: (SettingsPage) -> Unit
+) {
+    val overlay = rememberSettingsOverlayState()
+
+    SettingsScaffold(title = SettingsPage.AI.title, onBack = onBack, overlay = overlay) {
+        Text(
+            "The model does the thinking; speech gives it a voice and ears. " +
+                "One provider can cover both.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        listOf(SettingsPage.AI_CONFIG, SettingsPage.SPEECH).forEach { page ->
+            HorizontalDivider(thickness = 1.dp)
+            SettingsNavRow(
+                page = page,
+                onClick = { onOpenPage(page) },
+                modifier = Modifier
+                    .testTag(page.testTag)
+                    .then(
+                        // The tour walks the user to the model page from here.
+                        if (page == SettingsPage.AI_CONFIG) {
+                            Modifier.tourAnchor(TourAnchor.SETTINGS_AI_CONFIG)
+                        } else {
+                            Modifier
+                        }
+                    )
+            )
+        }
+        HorizontalDivider(thickness = 1.dp)
+    }
+}

--- a/app/src/main/java/com/gotcha/ui/AiHubScreen.kt
+++ b/app/src/main/java/com/gotcha/ui/AiHubScreen.kt
@@ -29,7 +29,8 @@ fun AiHubScreen(
     SettingsScaffold(title = SettingsPage.AI.title, onBack = onBack, overlay = overlay) {
         Text(
             "The model does the thinking; speech gives it a voice and ears. " +
-                "One provider can cover both.",
+                "One provider can cover both. Which language it speaks and answers " +
+                "in lives under Settings → Language.",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )

--- a/app/src/main/java/com/gotcha/ui/LanguageScreen.kt
+++ b/app/src/main/java/com/gotcha/ui/LanguageScreen.kt
@@ -1,0 +1,308 @@
+package com.gotcha.ui
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.gotcha.data.Settings
+import com.gotcha.i18n.Language
+import com.gotcha.ui.theme.SkinAlertDialog
+import com.gotcha.ui.theme.SkinExposedDropdownMenu
+import kotlinx.coroutines.launch
+import android.provider.Settings as AndroidSettings
+
+/** Voice-language dropdown entry meaning "no explicit choice — follow the reply language". */
+private const val FOLLOW_REPLY_LANGUAGE = "Same as AI reply language"
+
+/**
+ * The Language page: the three language choices, told apart.
+ *
+ * They used to be scattered and ambiguously named — "Preferred Language" sat in
+ * Personal Info reading like an app-UI setting when it actually drove the LLM
+ * *and* the voice, while "STT Language" sat on the Speech page with no statement
+ * of what it overrode (issue #74). Gathering them here is the only place a user
+ * can see all three at once, which is what makes the difference between them
+ * legible:
+ *
+ *  1. **App display language** — Android's, not ours. The interface is English
+ *     only, so this section is honest about that and hands the user off to the
+ *     system screen rather than pretending to a picker that would do nothing.
+ *  2. **Voice language** — what TTS speaks and STT listens in
+ *     ([Settings.effectiveVoiceLanguage]). Blank follows the reply language.
+ *  3. **AI reply language** — what the model writes in
+ *     ([Settings.preferredLanguage]).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LanguageScreen(
+    load: () -> Settings,
+    onSave: ((Settings) -> Settings) -> Unit,
+    onBack: () -> Unit,
+    onTestVoice: suspend (Language) -> Boolean? = { null }
+) {
+    val initial = remember { load() }
+    var preferredLanguage by remember { mutableStateOf(initial.preferredLanguage) }
+    var voiceLanguage by remember { mutableStateOf(initial.voiceLanguage) }
+
+    var replyExpanded by remember { mutableStateOf(false) }
+    var voiceExpanded by remember { mutableStateOf(false) }
+    var testingVoice by remember { mutableStateOf(false) }
+
+    /** Last [Language] whose voice data was reported missing, or null when not shown. */
+    var voiceDataMissing by remember { mutableStateOf<Language?>(null) }
+
+    val overlay = rememberSettingsOverlayState()
+    val scope = rememberCoroutineScope()
+    val localContext = LocalContext.current
+
+    /** This page's fields, copied onto [base]. */
+    fun applyLanguages(base: Settings) = base.copy(
+        preferredLanguage = preferredLanguage,
+        voiceLanguage = voiceLanguage
+    )
+
+    /** What the voice would actually use right now, without waiting for a save. */
+    val resolvedVoiceLanguage = Language.fromLabel(voiceLanguage.ifBlank { preferredLanguage })
+
+    SettingsScaffold(title = SettingsPage.LANGUAGE.title, onBack = onBack, overlay = overlay) {
+        Text(
+            "Three separate choices: what the app's own screens are written in, " +
+                "what Gotcha speaks and hears, and what it writes its answers in.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        HorizontalDivider(thickness = 1.dp)
+
+        // ---- 1. App display language ----
+        Text(
+            "App display language",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold
+        )
+        Text(
+            "Gotcha's own buttons, labels and settings are in English only for now — " +
+                "changing this affects the rest of your phone, not this app.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        OutlinedButton(
+            onClick = { openLanguageSettings(localContext) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("settings_open_app_locale")
+        ) { Text("Open Android language settings") }
+
+        HorizontalDivider(thickness = 1.dp)
+
+        // ---- 2. Voice language ----
+        Text(
+            "Voice language",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold
+        )
+        Text(
+            "What Gotcha speaks aloud and listens for during voice input and calls. " +
+                "Leave it following the reply language unless you want answers written " +
+                "in one language and spoken in another.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        ExposedDropdownMenuBox(
+            expanded = voiceExpanded,
+            onExpandedChange = { voiceExpanded = it }
+        ) {
+            OutlinedTextField(
+                value = voiceLanguage.ifBlank { FOLLOW_REPLY_LANGUAGE },
+                onValueChange = {},
+                readOnly = true,
+                label = { Text("Voice language") },
+                trailingIcon = {
+                    ExposedDropdownMenuDefaults.TrailingIcon(expanded = voiceExpanded)
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .menuAnchor()
+                    .testTag("settings_voice_language")
+            )
+            SkinExposedDropdownMenu(
+                expanded = voiceExpanded,
+                onDismissRequest = { voiceExpanded = false }
+            ) {
+                DropdownMenuItem(
+                    text = { Text(FOLLOW_REPLY_LANGUAGE) },
+                    onClick = {
+                        voiceLanguage = ""
+                        voiceExpanded = false
+                    }
+                )
+                Language.labels.forEach { lang ->
+                    DropdownMenuItem(
+                        text = { Text(lang) },
+                        onClick = {
+                            voiceLanguage = lang
+                            voiceExpanded = false
+                        }
+                    )
+                }
+            }
+        }
+        Text(
+            "Which voice reads it out is picked per model under Settings → AI → " +
+                "Speech, and the transcription language override on that page wins " +
+                "over this one when it is set.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        OutlinedButton(
+            onClick = {
+                testingVoice = true
+                scope.launch {
+                    // Track which language triggered the missing-data state so
+                    // rapid language-switch clicks don't surface a stale dialog.
+                    val lang = resolvedVoiceLanguage
+                    val ok = onTestVoice(lang)
+                    voiceDataMissing = if (ok == false) lang else null
+                    testingVoice = false
+                }
+            },
+            enabled = !testingVoice,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(if (testingVoice) "Playing…" else "Test voice")
+        }
+        voiceDataMissing?.let { missingLang ->
+            SkinAlertDialog(
+                onDismissRequest = { voiceDataMissing = null },
+                title = { Text("Voice data not installed") },
+                text = {
+                    Text(
+                        "Your device doesn't have Android's built-in voice for " +
+                            "${missingLang.label}. It was spoken in English instead. " +
+                            "Install the voice data to fix pronunciation."
+                    )
+                },
+                confirmButton = {
+                    Button(
+                        onClick = {
+                            voiceDataMissing = null
+                            try {
+                                localContext.startActivity(
+                                    Intent(
+                                        android.speech.tts.TextToSpeech.Engine.ACTION_INSTALL_TTS_DATA
+                                    ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                                )
+                            } catch (_: Exception) { }
+                        }
+                    ) { Text("Install") }
+                },
+                dismissButton = {
+                    TextButton(onClick = { voiceDataMissing = null }) { Text("Cancel") }
+                }
+            )
+        }
+
+        HorizontalDivider(thickness = 1.dp)
+
+        // ---- 3. AI reply language ----
+        Text(
+            "AI reply language",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold
+        )
+        Text(
+            "The language the assistant writes its answers in. Tool names, commands " +
+                "and file paths stay in English so they keep working.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        ExposedDropdownMenuBox(
+            expanded = replyExpanded,
+            onExpandedChange = { replyExpanded = it }
+        ) {
+            OutlinedTextField(
+                value = preferredLanguage,
+                onValueChange = {},
+                readOnly = true,
+                label = { Text("AI reply language") },
+                trailingIcon = {
+                    ExposedDropdownMenuDefaults.TrailingIcon(expanded = replyExpanded)
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .menuAnchor()
+                    .testTag("settings_reply_language")
+            )
+            SkinExposedDropdownMenu(
+                expanded = replyExpanded,
+                onDismissRequest = { replyExpanded = false }
+            ) {
+                Language.labels.forEach { lang ->
+                    DropdownMenuItem(
+                        text = { Text(lang) },
+                        onClick = {
+                            preferredLanguage = lang
+                            replyExpanded = false
+                        }
+                    )
+                }
+            }
+        }
+
+        Button(
+            onClick = {
+                onSave { applyLanguages(it) }
+                overlay.show("Saved language settings.")
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("settings_save_language")
+        ) { Text("Save Language Settings") }
+    }
+}
+
+/**
+ * Open the per-app language screen where the platform has one (API 33+), falling
+ * back to the device-wide language list. Both are ordinary system activities that
+ * a heavily-skinned OEM build may simply not have, hence the catch — the same
+ * shape as the TTS-data launch above.
+ */
+private fun openLanguageSettings(context: android.content.Context) {
+    val intents = buildList {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            add(
+                Intent(AndroidSettings.ACTION_APP_LOCALE_SETTINGS)
+                    .setData(Uri.fromParts("package", context.packageName, null))
+            )
+        }
+        add(Intent(AndroidSettings.ACTION_LOCALE_SETTINGS))
+    }
+    for (intent in intents) {
+        try {
+            context.startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+            return
+        } catch (_: Exception) { }
+    }
+}

--- a/app/src/main/java/com/gotcha/ui/LanguageScreen.kt
+++ b/app/src/main/java/com/gotcha/ui/LanguageScreen.kt
@@ -1,8 +1,10 @@
 package com.gotcha.ui
 
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
+import android.widget.Toast
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenuItem
@@ -20,6 +22,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -63,11 +66,11 @@ fun LanguageScreen(
     onTestVoice: suspend (Language) -> Boolean? = { null }
 ) {
     val initial = remember { load() }
-    var preferredLanguage by remember { mutableStateOf(initial.preferredLanguage) }
-    var voiceLanguage by remember { mutableStateOf(initial.voiceLanguage) }
+    var preferredLanguage by rememberSaveable { mutableStateOf(initial.preferredLanguage) }
+    var voiceLanguage by rememberSaveable { mutableStateOf(initial.voiceLanguage) }
 
-    var replyExpanded by remember { mutableStateOf(false) }
-    var voiceExpanded by remember { mutableStateOf(false) }
+    var replyExpanded by rememberSaveable { mutableStateOf(false) }
+    var voiceExpanded by rememberSaveable { mutableStateOf(false) }
     var testingVoice by remember { mutableStateOf(false) }
 
     /** Last [Language] whose voice data was reported missing, or null when not shown. */
@@ -214,7 +217,13 @@ fun LanguageScreen(
                                         android.speech.tts.TextToSpeech.Engine.ACTION_INSTALL_TTS_DATA
                                     ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                                 )
-                            } catch (_: Exception) { }
+                            } catch (_: Exception) {
+                                Toast.makeText(
+                                    localContext,
+                                    "Could not open text-to-speech settings.",
+                                    Toast.LENGTH_SHORT
+                                ).show()
+                            }
                         }
                     ) { Text("Install") }
                 },
@@ -286,10 +295,10 @@ fun LanguageScreen(
 /**
  * Open the per-app language screen where the platform has one (API 33+), falling
  * back to the device-wide language list. Both are ordinary system activities that
- * a heavily-skinned OEM build may simply not have, hence the catch — the same
- * shape as the TTS-data launch above.
+ * a heavily-skinned OEM build may simply not have; if neither activity resolves,
+ * a toast informs the user.
  */
-private fun openLanguageSettings(context: android.content.Context) {
+internal fun openLanguageSettings(context: Context) {
     val intents = buildList {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             add(
@@ -305,4 +314,9 @@ private fun openLanguageSettings(context: android.content.Context) {
             return
         } catch (_: Exception) { }
     }
+    Toast.makeText(
+        context,
+        "Could not open language settings.",
+        Toast.LENGTH_SHORT
+    ).show()
 }

--- a/app/src/main/java/com/gotcha/ui/PersonalInfoScreen.kt
+++ b/app/src/main/java/com/gotcha/ui/PersonalInfoScreen.kt
@@ -8,28 +8,21 @@ import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.gotcha.data.Settings
-import com.gotcha.i18n.Language
-import com.gotcha.ui.theme.SkinAlertDialog
 import com.gotcha.ui.theme.SkinExposedDropdownMenu
 import com.gotcha.ui.tour.TourAnchor
 import com.gotcha.ui.tour.tourAnchor
-import kotlinx.coroutines.launch
 
 /** Currencies offered for [Settings.preferredCurrency]. */
 private val CURRENCIES = listOf("USD", "EUR", "GBP", "INR", "CAD", "AUD", "JPY", "CNY")
@@ -42,9 +35,12 @@ private val CURRENCIES = listOf("USD", "EUR", "GBP", "INR", "CAD", "AUD", "JPY",
  * language one (see `AgentEngine`). Nothing on this page changes what the agent
  * is *allowed* to do; it only changes what it knows about the person asking.
  *
- * Language and currency live here rather than under Proactive Assistance, where
- * they started: they describe the user, not whether the assistant volunteers
- * help, and they apply to every reply whether proactive or not.
+ * Currency lives here rather than under Proactive Assistance, where it started:
+ * it describes the user, not whether the assistant volunteers help, and it
+ * applies to every reply whether proactive or not. The language settings used to
+ * sit here too and now have their own page (issue #74) — "Preferred Language"
+ * next to a name and an occupation read as the app's UI language, which it never
+ * was; this page keeps only a pointer to them.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -52,7 +48,7 @@ fun PersonalInfoScreen(
     load: () -> Settings,
     onSave: ((Settings) -> Settings) -> Unit,
     onBack: () -> Unit,
-    onTestVoice: suspend (Language) -> Boolean? = { null }
+    onOpenLanguage: () -> Unit = {}
 ) {
     val initial = remember { load() }
     var userName by remember { mutableStateOf(initial.userName) }
@@ -60,19 +56,11 @@ fun PersonalInfoScreen(
     var userOccupation by remember { mutableStateOf(initial.userOccupation) }
     var userBackground by remember { mutableStateOf(initial.userBackground) }
     var userResponseStyle by remember { mutableStateOf(initial.userResponseStyle) }
-    var preferredLanguage by remember { mutableStateOf(initial.preferredLanguage) }
     var preferredCurrency by remember { mutableStateOf(initial.preferredCurrency) }
 
-    var languageExpanded by remember { mutableStateOf(false) }
     var currencyExpanded by remember { mutableStateOf(false) }
-    var testingVoice by remember { mutableStateOf(false) }
-
-    /** Last [Language] whose voice data was reported missing, or null when not shown. */
-    var voiceDataMissing by remember { mutableStateOf<Language?>(null) }
 
     val overlay = rememberSettingsOverlayState()
-    val scope = rememberCoroutineScope()
-    val localContext = LocalContext.current
 
     /** This page's fields, copied onto [base]. */
     fun applyPersonalInfo(base: Settings) = base.copy(
@@ -81,7 +69,6 @@ fun PersonalInfoScreen(
         userOccupation = userOccupation.trim(),
         userBackground = userBackground.trim(),
         userResponseStyle = userResponseStyle.trim(),
-        preferredLanguage = preferredLanguage,
         preferredCurrency = preferredCurrency
     )
 
@@ -175,85 +162,6 @@ fun PersonalInfoScreen(
         )
 
         ExposedDropdownMenuBox(
-            expanded = languageExpanded,
-            onExpandedChange = { languageExpanded = it }
-        ) {
-            OutlinedTextField(
-                value = preferredLanguage,
-                onValueChange = {},
-                readOnly = true,
-                label = { Text("Preferred Language") },
-                trailingIcon = {
-                    ExposedDropdownMenuDefaults.TrailingIcon(expanded = languageExpanded)
-                },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .menuAnchor()
-            )
-            SkinExposedDropdownMenu(
-                expanded = languageExpanded,
-                onDismissRequest = { languageExpanded = false }
-            ) {
-                Language.labels.forEach { lang ->
-                    DropdownMenuItem(
-                        text = { Text(lang) },
-                        onClick = {
-                            preferredLanguage = lang
-                            languageExpanded = false
-                        }
-                    )
-                }
-            }
-        }
-        OutlinedButton(
-            onClick = {
-                testingVoice = true
-                scope.launch {
-                    val lang = Language.fromLabel(preferredLanguage)
-                    // Track which language triggered the missing-data state so
-                    // rapid language-switch clicks don't surface a stale dialog.
-                    val ok = onTestVoice(lang)
-                    voiceDataMissing = if (ok == false) lang else null
-                    testingVoice = false
-                }
-            },
-            enabled = !testingVoice,
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Text(if (testingVoice) "Playing…" else "Test voice")
-        }
-        voiceDataMissing?.let { missingLang ->
-            SkinAlertDialog(
-                onDismissRequest = { voiceDataMissing = null },
-                title = { Text("Voice data not installed") },
-                text = {
-                    Text(
-                        "Your device doesn't have Android's built-in voice for " +
-                            "${missingLang.label}. It was spoken in English instead. " +
-                            "Install the voice data to fix pronunciation."
-                    )
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            voiceDataMissing = null
-                            try {
-                                localContext.startActivity(
-                                    android.content.Intent(
-                                        android.speech.tts.TextToSpeech.Engine.ACTION_INSTALL_TTS_DATA
-                                    ).addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
-                                )
-                            } catch (_: Exception) { }
-                        }
-                    ) { Text("Install") }
-                },
-                dismissButton = {
-                    TextButton(onClick = { voiceDataMissing = null }) { Text("Cancel") }
-                }
-            )
-        }
-
-        ExposedDropdownMenuBox(
             expanded = currencyExpanded,
             onExpandedChange = { currencyExpanded = it }
         ) {
@@ -284,6 +192,21 @@ fun PersonalInfoScreen(
                 }
             }
         }
+
+        HorizontalDivider(thickness = 1.dp)
+
+        // Language moved out of this page (issue #74); a pointer keeps it findable
+        // for anyone who still comes here looking for "Preferred Language".
+        Text(
+            "Reply, voice and app display language now live on their own page.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        SettingsNavRow(
+            page = SettingsPage.LANGUAGE,
+            onClick = onOpenLanguage,
+            modifier = Modifier.testTag("settings_personal_info_language_row")
+        )
 
         Button(
             onClick = {

--- a/app/src/main/java/com/gotcha/ui/ProactiveScreen.kt
+++ b/app/src/main/java/com/gotcha/ui/ProactiveScreen.kt
@@ -15,8 +15,9 @@ import com.gotcha.data.Settings
  * The Proactive Assistance page: whether the assistant volunteers help, and
  * which surfaces it may scan for the context to do so.
  *
- * Language and currency used to live here; they moved to
- * [PersonalInfoScreen] — they describe the user rather than this feature.
+ * Language and currency used to live here; they describe the user rather than
+ * this feature, so currency moved to [PersonalInfoScreen] and language on to
+ * [LanguageScreen].
  */
 @Composable
 fun ProactiveScreen(

--- a/app/src/main/java/com/gotcha/ui/SettingsCommon.kt
+++ b/app/src/main/java/com/gotcha/ui/SettingsCommon.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -82,8 +83,9 @@ import kotlin.math.round
  *
  * Most pages hang directly off the home list. The exceptions declare a [parent]:
  * they are full pages, routed and titled like any other, but reached from inside
- * that parent instead of from the home list. [ABOUT] is the only such hub today,
- * collecting "who made this app and what did I agree to" into one row.
+ * that parent instead of from the home list. Two hubs exist: [AI], which collects
+ * everything the assistant thinks, hears and speaks with, and [ABOUT], which
+ * collects "who made this app and what did I agree to".
  */
 enum class SettingsPage(
     val title: String,
@@ -102,15 +104,22 @@ enum class SettingsPage(
         "Who you are, language, currency, reply style",
         "settings_personal_info_row"
     ),
+    AI(
+        "AI",
+        "Model, provider, voice and transcription",
+        "settings_ai_row"
+    ),
     AI_CONFIG(
         "AI Configuration",
         "Provider, models, agent limits",
-        "settings_ai_config_row"
+        "settings_ai_config_row",
+        { AI }
     ),
     SPEECH(
         "Speech (TTS / STT)",
         "Voices, transcription, read replies aloud",
-        "settings_speech_row"
+        "settings_speech_row",
+        { AI }
     ),
     PERMISSIONS(
         "Permissions",
@@ -729,6 +738,57 @@ fun SamosaAuthSection(
                     .then(signInModifier)
             ) { Text(if (busy) "Signing in…" else "Sign in with Google") }
         }
+    }
+}
+
+/**
+ * A collapsed-by-default disclosure for the knobs a page has but most people
+ * never touch — model overrides, loop limits, timeouts. Keeps them one tap away
+ * without letting them crowd out the two or three controls that actually decide
+ * whether the app works.
+ *
+ * Uses the same text triangle as the permission groups rather than an icon font,
+ * so the settings pages keep one disclosure idiom.
+ *
+ * [testTag] tags the header row, which is the part a test clicks to expand.
+ * Expansion is remembered per page visit (`rememberSaveable`), so a rotation or
+ * a trip to Android Settings doesn't fold the section back up mid-edit. The
+ * fields inside stay hoisted in the calling screen, so collapsing the section
+ * never discards what was typed into it.
+ */
+@Composable
+fun SettingsAdvancedSection(
+    testTag: String,
+    title: String = "Advanced settings",
+    content: @Composable ColumnScope.() -> Unit
+) {
+    var expanded by rememberSaveable { mutableStateOf(false) }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { expanded = !expanded }
+            .padding(vertical = 8.dp)
+            .testTag(testTag),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = if (expanded) "▼ " else "▶ ",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Text(
+            text = title,
+            style = MaterialTheme.typography.bodyLarge,
+            fontWeight = FontWeight.Medium
+        )
+    }
+    AnimatedVisibility(visible = expanded) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            content = content
+        )
     }
 }
 

--- a/app/src/main/java/com/gotcha/ui/SettingsCommon.kt
+++ b/app/src/main/java/com/gotcha/ui/SettingsCommon.kt
@@ -148,7 +148,7 @@ enum class SettingsPage(
         "settings_notifications_row"
     ),
     ABOUT(
-        "About Us",
+        "About",
         "Samosa AI, other products, legal, contact",
         "settings_about_row"
     ),

--- a/app/src/main/java/com/gotcha/ui/SettingsCommon.kt
+++ b/app/src/main/java/com/gotcha/ui/SettingsCommon.kt
@@ -101,8 +101,13 @@ enum class SettingsPage(
 ) {
     PERSONAL_INFO(
         "Personal Info",
-        "Who you are, language, currency, reply style",
+        "Who you are, currency, reply style",
         "settings_personal_info_row"
+    ),
+    LANGUAGE(
+        "Language",
+        "App display, voice, and AI reply language",
+        "settings_language_row"
     ),
     AI(
         "AI",

--- a/app/src/main/java/com/gotcha/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/gotcha/ui/SettingsScreen.kt
@@ -123,6 +123,12 @@ fun SettingsScreen(
             load = load,
             onSave = onSave,
             onBack = backToHome,
+            onOpenLanguage = { onPageChange(SettingsPage.LANGUAGE) }
+        )
+        SettingsPage.LANGUAGE -> LanguageScreen(
+            load = load,
+            onSave = onSave,
+            onBack = backToHome,
             onTestVoice = onTestVoice
         )
         SettingsPage.AI -> AiHubScreen(

--- a/app/src/main/java/com/gotcha/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/gotcha/ui/SettingsScreen.kt
@@ -125,6 +125,10 @@ fun SettingsScreen(
             onBack = backToHome,
             onTestVoice = onTestVoice
         )
+        SettingsPage.AI -> AiHubScreen(
+            onBack = backToHome,
+            onOpenPage = onPageChange
+        )
         SettingsPage.AI_CONFIG -> AiConfigScreen(
             load = load,
             onSave = onSave,
@@ -240,7 +244,7 @@ private fun SettingsHome(
 @Composable
 private fun SettingsPage.tourAnchorModifier(): Modifier = when (this) {
     SettingsPage.PERSONAL_INFO -> Modifier.tourAnchor(TourAnchor.SETTINGS_PERSONAL_INFO)
-    SettingsPage.AI_CONFIG -> Modifier.tourAnchor(TourAnchor.SETTINGS_AI_CONFIG)
+    SettingsPage.AI -> Modifier.tourAnchor(TourAnchor.SETTINGS_AI)
     SettingsPage.PERMISSIONS -> Modifier.tourAnchor(TourAnchor.SETTINGS_PERMISSIONS)
     else -> Modifier
 }

--- a/app/src/main/java/com/gotcha/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/gotcha/ui/SettingsScreen.kt
@@ -220,7 +220,7 @@ private fun SettingsHome(
                     .testTag(entry.testTag)
                     .then(entry.tourAnchorModifier())
             )
-            // Re-entry into the guided setup sits just above About Us, so the menu
+            // Re-entry into the guided setup sits just above About, so the menu
             // ends on the two rows a returning user is least likely to need.
             if (entry == SettingsPage.NOTIFICATIONS) {
                 HorizontalDivider(thickness = 1.dp)

--- a/app/src/main/java/com/gotcha/ui/SpeechScreen.kt
+++ b/app/src/main/java/com/gotcha/ui/SpeechScreen.kt
@@ -456,6 +456,13 @@ fun SpeechScreen(
                     },
                     onClearLanguage = { sttLanguage = "" }
                 )
+                Text(
+                    "Leave this empty and transcription follows the voice language " +
+                        "set under Settings → Language. Set it to force one language, " +
+                        "which helps accuracy when the model tends to guess wrong.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
             }
             AudioProvider.API -> {
                 OutlinedTextField(
@@ -507,6 +514,13 @@ fun SpeechScreen(
                         sttLanguageExpanded = false
                     },
                     onClearLanguage = { sttLanguage = "" }
+                )
+                Text(
+                    "Leave this empty and transcription follows the voice language " +
+                        "set under Settings → Language. Set it to force one language, " +
+                        "which helps accuracy when the model tends to guess wrong.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
             AudioProvider.ANDROID, AudioProvider.NONE -> Unit
@@ -729,7 +743,14 @@ private fun SttModelPicker(
     }
 }
 
-/** STT language picker — uses the model's languages when available, otherwise [COMMON_STT_LANGUAGES]. */
+/**
+ * Transcription language override — uses the model's languages when available,
+ * otherwise [COMMON_STT_LANGUAGES].
+ *
+ * An override, not the language setting: left empty, transcription follows the
+ * voice language on Settings → Language. It lives here rather than there because
+ * the list of codes it offers comes from the selected STT model (issue #74).
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun SttLanguagePicker(
@@ -751,8 +772,8 @@ private fun SttLanguagePicker(
         OutlinedTextField(
             value = selectedLanguage,
             onValueChange = onSelect,
-            label = { Text("STT Language (optional)") },
-            placeholder = { Text("Auto-detect / Default (or select below)") },
+            label = { Text("Transcription language override") },
+            placeholder = { Text("Follow voice language / auto-detect") },
             trailingIcon = {
                 ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
             },
@@ -763,7 +784,7 @@ private fun SttLanguagePicker(
             onDismissRequest = { onExpandedChange(false) }
         ) {
             DropdownMenuItem(
-                text = { Text("Auto-detect / Default (empty)") },
+                text = { Text("Follow voice language / auto-detect") },
                 onClick = onClearLanguage
             )
             languagesList.forEach { lang ->

--- a/app/src/main/java/com/gotcha/ui/SpeechScreen.kt
+++ b/app/src/main/java/com/gotcha/ui/SpeechScreen.kt
@@ -359,40 +359,45 @@ fun SpeechScreen(
             AudioProvider.ANDROID, AudioProvider.NONE -> Unit
         }
         // ---- Podcast hosts (synthesize_podcast_dialogue) ----
+        // Advanced: only two-host podcast generation reads these, and the
+        // defaults (the TTS voice for host A, an automatically chosen second
+        // voice for host B) already work.
         if (ttsProvider.isApiBased()) {
-            Text(
-                "Podcast hosts — the two voices used when the assistant generates a two-host " +
-                    "podcast dialogue. Leave blank to use the TTS voice for host A and an " +
-                    "automatically chosen different voice for host B.",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            TtsVoicePicker(
-                selectedModel = ttsApiModel,
-                selectedVoice = podcastHostAVoice,
-                availableModels = availableTtsModels,
-                expanded = hostAVoiceExpanded,
-                onExpandedChange = { hostAVoiceExpanded = it },
-                onSelect = {
-                    podcastHostAVoice = it
-                    hostAVoiceExpanded = false
-                },
-                onClearVoice = { podcastHostAVoice = "" },
-                label = "Podcast Host A Voice (optional)"
-            )
-            TtsVoicePicker(
-                selectedModel = ttsApiModel,
-                selectedVoice = podcastHostBVoice,
-                availableModels = availableTtsModels,
-                expanded = hostBVoiceExpanded,
-                onExpandedChange = { hostBVoiceExpanded = it },
-                onSelect = {
-                    podcastHostBVoice = it
-                    hostBVoiceExpanded = false
-                },
-                onClearVoice = { podcastHostBVoice = "" },
-                label = "Podcast Host B Voice (optional)"
-            )
+            SettingsAdvancedSection(testTag = "settings_speech_advanced") {
+                Text(
+                    "Podcast hosts — the two voices used when the assistant generates a two-host " +
+                        "podcast dialogue. Leave blank to use the TTS voice for host A and an " +
+                        "automatically chosen different voice for host B.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                TtsVoicePicker(
+                    selectedModel = ttsApiModel,
+                    selectedVoice = podcastHostAVoice,
+                    availableModels = availableTtsModels,
+                    expanded = hostAVoiceExpanded,
+                    onExpandedChange = { hostAVoiceExpanded = it },
+                    onSelect = {
+                        podcastHostAVoice = it
+                        hostAVoiceExpanded = false
+                    },
+                    onClearVoice = { podcastHostAVoice = "" },
+                    label = "Podcast Host A Voice (optional)"
+                )
+                TtsVoicePicker(
+                    selectedModel = ttsApiModel,
+                    selectedVoice = podcastHostBVoice,
+                    availableModels = availableTtsModels,
+                    expanded = hostBVoiceExpanded,
+                    onExpandedChange = { hostBVoiceExpanded = it },
+                    onSelect = {
+                        podcastHostBVoice = it
+                        hostBVoiceExpanded = false
+                    },
+                    onClearVoice = { podcastHostBVoice = "" },
+                    label = "Podcast Host B Voice (optional)"
+                )
+            }
         }
         ExposedDropdownMenuBox(
             expanded = sttProviderExpanded,

--- a/app/src/main/java/com/gotcha/ui/tour/TourAnchors.kt
+++ b/app/src/main/java/com/gotcha/ui/tour/TourAnchors.kt
@@ -25,6 +25,11 @@ import androidx.compose.ui.layout.onGloballyPositioned
 enum class TourAnchor {
     DRAWER_SETTINGS,
     SETTINGS_PERSONAL_INFO,
+
+    /** The AI hub's row on the settings home list. */
+    SETTINGS_AI,
+
+    /** The AI Configuration row, which lives inside the AI hub. */
     SETTINGS_AI_CONFIG,
     SETTINGS_PERMISSIONS,
     AI_PROVIDER,

--- a/app/src/main/java/com/gotcha/ui/tour/TourStep.kt
+++ b/app/src/main/java/com/gotcha/ui/tour/TourStep.kt
@@ -20,6 +20,9 @@ enum class TourPlace {
 
     /** The settings category list. */
     SETTINGS_HOME,
+
+    /** The AI hub: the model page and the speech page, one level under Settings. */
+    AI_HUB,
     AI_CONFIG,
     PERMISSIONS,
     PERSONAL_INFO
@@ -96,13 +99,21 @@ private fun brainSteps(): List<TourStep> = listOf(
         hint = "Tip: the same swipe works from anywhere in the chat."
     ),
     TourStep(
-        id = "open_ai_config",
+        id = "open_ai",
         place = TourPlace.SETTINGS_HOME,
+        autoNavigate = false,
+        anchor = TourAnchor.SETTINGS_AI,
+        title = "Start with AI",
+        body = "Everything Gotcha thinks, hears and says with is behind this row. Open it."
+    ),
+    TourStep(
+        id = "open_ai_config",
+        place = TourPlace.AI_HUB,
         autoNavigate = false,
         anchor = TourAnchor.SETTINGS_AI_CONFIG,
         title = "Give Gotcha a brain",
         body = "AI Configuration is where the model lives. Open it — you'll come back here to " +
-            "change models later."
+            "change models later, and to pick a voice."
     ),
     TourStep(
         id = "choose_provider",

--- a/app/src/test/java/com/gotcha/agent/AgentPromptTest.kt
+++ b/app/src/test/java/com/gotcha/agent/AgentPromptTest.kt
@@ -109,11 +109,24 @@ class AgentPromptTest {
     }
 
     @Test
-    fun `user profile block carries preferred language and currency facts`() = runTest {
+    fun `user profile block carries reply language and currency facts`() = runTest {
         val body = requestBodyFor(AgentMode.OPERATOR)
         assertTrue(body.contains("<user_profile>"))
-        assertTrue(body.contains("Preferred language: Hindi"))
+        assertTrue(body.contains("Reply language: Hindi"))
         assertTrue(body.contains("Preferred currency:"))
+    }
+
+    @Test
+    fun `voice language does not affect the written reply language`() = runTest {
+        // Issue #74 split the two: voiceLanguage drives TTS and STT only, so a
+        // German voice must not leak into the directive or the profile block.
+        val body = requestBodyFor(
+            AgentMode.OPERATOR,
+            testSettings { copy(voiceLanguage = "German") }
+        )
+        assertTrue(body.contains("Respond to the user in Hindi"))
+        assertTrue(body.contains("Reply language: Hindi"))
+        assertFalse(body.contains("German"))
     }
 
     @Test

--- a/app/src/test/java/com/gotcha/data/SettingsTest.kt
+++ b/app/src/test/java/com/gotcha/data/SettingsTest.kt
@@ -1,6 +1,7 @@
 package com.gotcha.data
 
 import com.gotcha.audio.AudioProvider
+import com.gotcha.i18n.Language
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -357,5 +358,29 @@ class SettingsTest {
         val screenOff = WakeWordListeningMode.SCREEN_OFF
         assertFalse(screenOff.allows(screenInteractive = true))
         assertTrue(screenOff.allows(screenInteractive = false))
+    }
+
+    @Test
+    fun `effectiveVoiceLanguage follows the reply language while voiceLanguage is blank`() {
+        val settings = Settings(preferredLanguage = "Hindi", voiceLanguage = "")
+        assertEquals(Language.HINDI, settings.effectiveVoiceLanguage)
+    }
+
+    @Test
+    fun `effectiveVoiceLanguage prefers an explicit voiceLanguage over the reply language`() {
+        val settings = Settings(preferredLanguage = "Hindi", voiceLanguage = "German")
+        assertEquals(Language.GERMAN, settings.effectiveVoiceLanguage)
+    }
+
+    @Test
+    fun `effectiveVoiceLanguage falls back to English when neither value resolves`() {
+        val settings = Settings(preferredLanguage = "Klingon", voiceLanguage = "Sindarin")
+        assertEquals(Language.ENGLISH, settings.effectiveVoiceLanguage)
+    }
+
+    @Test
+    fun `voiceLanguage defaults to blank so existing installs keep todays behaviour`() {
+        assertEquals("", Settings().voiceLanguage)
+        assertEquals(Language.ENGLISH, Settings().effectiveVoiceLanguage)
     }
 }

--- a/app/src/test/java/com/gotcha/i18n/LanguageTest.kt
+++ b/app/src/test/java/com/gotcha/i18n/LanguageTest.kt
@@ -37,8 +37,9 @@ class LanguageTest {
 
     @Test
     fun `labels matches the Settings dropdown source of truth`() {
-        // Drift guard for design decision D1: the Settings dropdown is derived
-        // from Language.labels, so this list is the single source of truth.
+        // Drift guard for design decision D1: both dropdowns on LanguageScreen
+        // (reply language and voice language) are derived from Language.labels,
+        // so this list is the single source of truth.
         val expected = listOf(
             "English", "Spanish", "French", "German", "Hindi",
             "Japanese", "Chinese", "Italian", "Portuguese"

--- a/app/src/test/java/com/gotcha/ui/LanguageScreenTest.kt
+++ b/app/src/test/java/com/gotcha/ui/LanguageScreenTest.kt
@@ -1,0 +1,55 @@
+package com.gotcha.ui
+
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.Intent
+import android.net.Uri
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowToast
+import android.provider.Settings as AndroidSettings
+
+@RunWith(RobolectricTestRunner::class)
+class LanguageScreenTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    @Config(sdk = [34])
+    fun `openLanguageSettings targets per-app locale settings on API 34`() {
+        openLanguageSettings(context)
+        val intent = Shadows.shadowOf(context as android.app.Application).nextStartedActivity
+        assertNotNull(intent)
+        assertEquals(AndroidSettings.ACTION_APP_LOCALE_SETTINGS, intent.action)
+        assertEquals(Uri.parse("package:${context.packageName}"), intent.data)
+        assertTrue(intent.flags and Intent.FLAG_ACTIVITY_NEW_TASK != 0)
+    }
+
+    @Test
+    @Config(sdk = [30])
+    fun `openLanguageSettings falls back to device locale settings on API 30`() {
+        openLanguageSettings(context)
+        val intent = Shadows.shadowOf(context as android.app.Application).nextStartedActivity
+        assertNotNull(intent)
+        assertEquals(AndroidSettings.ACTION_LOCALE_SETTINGS, intent.action)
+        assertTrue(intent.flags and Intent.FLAG_ACTIVITY_NEW_TASK != 0)
+    }
+
+    @Test
+    fun `openLanguageSettings shows toast when activities cannot be launched`() {
+        val failingContext = object : ContextWrapper(context) {
+            override fun startActivity(intent: Intent?) {
+                throw android.content.ActivityNotFoundException("Activity not found")
+            }
+        }
+        openLanguageSettings(failingContext)
+        assertEquals("Could not open language settings.", ShadowToast.getTextOfLatestToast())
+    }
+}


### PR DESCRIPTION
Closes #72. Closes #73. Closes #74.

Three related passes over the Settings tree, plus the test-infra bump that was needed to verify them on a device. Each is a self-contained commit and they read best in order.

---

## 1. Rename the About Us hub to About (#72) — `ea2dab0`

The hub collects the company page, the legal agreements and the app updater, so "About Us" read as company-only and undersold what sits under it. Its children — *About Samosa AI* and *Legal* — keep their titles, and the external `samosa-ai.com/about-us` link keeps its own label, since that really is the company page.

## 2. Group AI configuration under one hub (#73) — `7ac1d01`

The model and the voice sat as two unrelated rows on the settings list, as if choosing what Gotcha thinks with had nothing to do with choosing what it speaks with. Both now hang off a single **AI** row: *AI Configuration* for the provider and models, *Speech (TTS / STT)* for voices and transcription. This reuses the `parentPage` mechanism the About hub already has, so Back from either page returns to the hub and `topLevel` keeps them off the home list on its own.

The knobs almost nobody touches — sub-agent and navigator model overrides, the agent-loop limits, the API timeout, the cache-clearing buttons, the podcast host voices — move behind a collapsed `SettingsAdvancedSection` on the page they already belonged to, styled on the disclosure the permission groups use. Their state stays hoisted in the calling screen and the save mutators are untouched, so collapsing the section never drops an edit and expanding it is never required to save.

Presentation and navigation only: no `SettingsRepository` key, `Settings` field, load/save or migration changes. The tour gains an `AI_HUB` place and a `SETTINGS_AI` anchor so guided setup still walks Settings → AI → AI Configuration; `SettingsFlowTest` follows the extra level and gains a test that the advanced knobs stay collapsed until asked for; the Maestro flow, which drives by visible text, taps the new row first.

## 3. Update androidx.test so instrumented tests run on API 36 — `a45dc1b`

Espresso 3.6.1 calls `InputManager.getInstance`, removed in Android 15, so every instrumented test failed immediately on an API 36 emulator with `NoSuchMethodException` before any assertion ran. Moves espresso-core to 3.7.0 and androidx.test core-ktx/runner/rules to 1.7.0 with ext:junit-ktx 1.3.0, which is where that call site was fixed. androidTest only; the Robolectric tier keeps core-ktx 1.6.1.

## 4. Tell app, voice and reply language apart (#74) — `859c05f`

Language was one knob wearing three hats. `Settings.preferredLanguage` drove the LLM reply directive (`AgentEngine`), the TTS voice locale (`TtsEngine.setLanguage`) and the STT fallback all at once — and it sat in Personal Info labelled **"Preferred Language"**, next to a name and an occupation, which reads as the app's UI language. It never was one: the app has no UI localization at all (no `values-<lang>`, no `locales_config.xml`, no `AppCompatDelegate.setApplicationLocales`), so that label promised something nothing implemented. Meanwhile `sttLanguage` sat on the Speech page as "STT Language (optional)" without saying what it was optional *to*.

**New `voiceLanguage` pref** (`voice_language`), blank by default, resolved by `Settings.effectiveVoiceLanguage` as *"the explicit voice language, else the reply language"*. Blank means every existing install keeps behaving exactly as it does today — no migration. Every TTS/STT call site now reads it (`ChatViewModel` speak/listen/transcribe/cleanText, `CallSessionController.currentLanguage()`, `AssistiveBallService`); `preferredLanguage` is left to the text/LLM paths alone, and its `<user_profile>` fact is renamed `Preferred language` → **`Reply language`** to match.

**New Settings → Language page** carrying all three with helper text:
1. *App display language* — honest that the interface is English only, with a button through to Android's per-app language screen (`ACTION_APP_LOCALE_SETTINGS` on API 33+, falling back to `ACTION_LOCALE_SETTINGS`).
2. *Voice language* — what it speaks and hears, defaulting to "Same as AI reply language".
3. *AI reply language* — what the model writes in.

The Test-voice button and its TTS-data dialog move here from Personal Info, which keeps a pointer row. Speech keeps the transcription override — its options come from the selected STT model, so it belongs there — but now says what it overrides.

---

## Testing

- **API 34 emulator** (`:app:api34DebugAndroidTest`): `SettingsFlowTest` green 5/5, covering the hub navigation from #73 and the new Language page. `languagePage_showsTheThreeLanguagesApartAndPersistsThem` drives the UI to pick Hindi for the voice while leaving the reply language English, then asserts the round-trip through `EncryptedSharedPreferences` — `effectiveVoiceLanguage` resolves to `hi-IN` for TTS and `hi` for STT while `preferredLanguage` stays English. No JVM test can reach that path.
- **`AgentPromptTest`** holds the other half: with `voiceLanguage = "German"` the prompt still says "Respond to the user in Hindi", carries `Reply language: Hindi`, and contains no "German" at all — a voice choice cannot leak into what the model writes.
- Four `effectiveVoiceLanguage` cases in `SettingsTest` (explicit wins, blank follows, junk falls back to English, default is blank).
- `./gradlew :app:testDebugUnitTest` — 1552 tests; `detekt` and `:app:assembleDebug` clean.

## Notes for the reviewer

- **Pre-existing flake, not from this branch:** `PodcastToolTest > sharing hands over a content URI chooser` and `AppUpdateManagerRobolectricTest > installUpdate_withInstallPermission_launchesPackageInstaller` poison each other depending on run order. Reproduced on a clean tree at `a45dc1b` with the #74 changes stashed.
- **Wider instrumented suite is partially verified.** Beyond `SettingsFlowTest` I got 7/13 through the UI suite with 0 failures before stopping the run. The stall is almost certainly `ChatRoundTripTest`'s own known hang, documented in `a45dc1b`: `drainSince` loops on `requestCount`, which counts requests *received* and so never falls back below `previousCount`, and the no-argument `MockWebServer.takeRequest()` blocks forever once the queue drains. That is left for its own change, but it means a fully green instrumented suite isn't achievable on this branch — worth confirming the remaining tests individually rather than as a suite.
- **Expected consequence of the language split:** reply=English + voice=Hindi means English text read by a Hindi TTS voice, i.e. English words with Hindi phonetics. That is what the setting promises rather than a bug, but it means the mixed configuration is most useful the other way round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
