### PR TITLE
feat: starter prompts, sample chats, a clearer wake-word setting, and an about_gotcha tool

### DIFF
--- a/.maestro/flows/04-assistive-ball.yaml
+++ b/.maestro/flows/04-assistive-ball.yaml
@@ -3,13 +3,13 @@ appId: com.gotcha
 # Requires testing/scripts/maestro_run.sh to have granted the SYSTEM_ALERT_WINDOW appop first
 # (Maestro cannot send shell/appops commands itself).
 - launchApp
-# The toggle lives in Settings ▸ Assistive Ball.
+# The toggle lives in Settings ▸ Assistive Ball and Wake Word.
 - tapOn: "Open menu"
 - tapOn: "Settings"
 - scrollUntilVisible:
-    element: "Assistive Ball"
+    element: "Assistive Ball and Wake Word"
     direction: DOWN
-- tapOn: "Assistive Ball"
+- tapOn: "Assistive Ball and Wake Word"
 - tapOn: "Turn on assistive ball"
 - pressKey: Home
 - assertVisible: "Gotcha assistive ball"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ All notable changes to Gotcha are documented here.
 
 ## [1.2.0]
 ### Added
+- **Starter prompts on the home screen.** A new chat used to be a greeting and an
+  empty composer, which says nothing about what Gotcha can be asked for. Three
+  suggestion chips now sit under the agent selector — drawn per session from a
+  set covering the things people least expect: driving the device, reading the
+  screen, going through the filesystem (`Find the largest files in my Downloads
+  folder and tell me what's safe to delete`, `Read the most recent PDF in my
+  Downloads and summarise it`) and handling messages. Tapping one **fills the
+  composer and stops there**: nothing is sent until you've read it, edited the
+  parts left blank, and pressed send yourself. Nor does a chip change the agent
+  mode on your behalf — the two device actions need Operator, the rest answer in
+  Monitor, and which mode you're in stays the selector's business.
 - **Podcast generation.** Gotcha can now turn text into listenable audio. Ask
   for a topic, an article or your notes as a podcast and the assistant writes
   the script and speaks it through your configured text-to-speech API — as a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to Gotcha are documented here.
 
 ## [Unreleased]
+### Added
+- **Starter prompts on the home screen.** A new chat used to be a greeting and an
+  empty composer, which says nothing about what Gotcha can be asked for. Three
+  suggestion chips now sit under the agent selector — drawn per session from a
+  set covering the things people least expect: driving the device, reading the
+  screen, going through the filesystem (`Find the largest files in my Downloads
+  folder and tell me what's safe to delete`, `Read the most recent PDF in my
+  Downloads and summarise it`) and handling messages. Tapping one **fills the
+  composer and stops there**: nothing is sent until you've read it, edited the
+  parts left blank, and pressed send yourself. Nor does a chip change the agent
+  mode on your behalf — the two device actions need Operator, the rest answer in
+  Monitor, and which mode you're in stays the selector's business.
+
 ### Changed
 - **Settings → AI.** The model and the voice used to sit as two unrelated rows on
   the settings list, as if choosing what Gotcha thinks with had nothing to do with
@@ -29,17 +42,6 @@ All notable changes to Gotcha are documented here.
 
 ## [1.2.0]
 ### Added
-- **Starter prompts on the home screen.** A new chat used to be a greeting and an
-  empty composer, which says nothing about what Gotcha can be asked for. Three
-  suggestion chips now sit under the agent selector — drawn per session from a
-  set covering the things people least expect: driving the device, reading the
-  screen, going through the filesystem (`Find the largest files in my Downloads
-  folder and tell me what's safe to delete`, `Read the most recent PDF in my
-  Downloads and summarise it`) and handling messages. Tapping one **fills the
-  composer and stops there**: nothing is sent until you've read it, edited the
-  parts left blank, and pressed send yourself. Nor does a chip change the agent
-  mode on your behalf — the two device actions need Operator, the rest answer in
-  Monitor, and which mode you're in stays the selector's business.
 - **Podcast generation.** Gotcha can now turn text into listenable audio. Ask
   for a topic, an article or your notes as a podcast and the assistant writes
   the script and speaks it through your configured text-to-speech API — as a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ All notable changes to Gotcha are documented here.
   agreements and the app updater is now titled `About` rather than `About Us`:
   it holds more than company information, so the old title undersold it.
   `About Samosa AI` and `Legal` still sit underneath it, unchanged.
+- **Settings → Assistive Ball and Wake Word.** The `Hey Gotcha` wake word has
+  always lived on the assistive-ball page — its listener runs inside the ball's
+  service and cannot outlive it — but the row said only `Assistive Ball`, so
+  there was nothing to tell you where the wake word was or why it switched
+  itself off. The row now names both, and the page states the dependency whether
+  the ball is on or off instead of only once it is already too late.
 
 ## [1.2.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Gotcha are documented here.
 
 ## [Unreleased]
 ### Added
+- **The assistant can now answer questions about Gotcha itself.** There was a
+  tool for the company behind the app (`about_samosa_ai`) but none for the app,
+  so "what can you do?" and "which setting do I change to read replies aloud?"
+  were answered from the model's memory or by driving the Settings screens to
+  rediscover a path — both of which produce confident directions to places that
+  don't exist. A new `about_gotcha` tool reads a bundled handbook covering the
+  capability areas, Monitor vs Operator, the exact path to every settings page,
+  which permission each group of tools waits on and where it's granted, and the
+  safety model. It's read-only, so **Monitor** has it too. The handbook is
+  checked against the `SettingsPage` and `Capability` enums by a test, so
+  renaming a settings page fails the build rather than quietly leaving the agent
+  with a stale path.
 - **Starter prompts on the home screen.** A new chat used to be a greeting and an
   empty composer, which says nothing about what Gotcha can be asked for. Three
   suggestion chips now sit under the agent selector — drawn per session from a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Gotcha are documented here.
 
 ## [Unreleased]
 ### Added
+- **Two sample chats on a fresh install.** The chat list opened on nothing at
+  all, so the one thing a first-time user couldn't find out was what Gotcha is
+  for. A new install now starts with two short transcripts that show it: a
+  device action with a follow-up in **Operator** (turn Wi-Fi on, then the
+  Bluetooth screen the agent opens because Android won't let it flip that switch
+  itself) and a question about the screen in **Monitor**. They are ordinary
+  chats — open them, carry them on, or delete them — and both the drawer row and
+  a line above the transcript say they're samples, so a demonstration is never
+  mistaken for something you said. Seeding happens once per install and only
+  into an empty list: upgrading keeps the chats you have, and deleting the
+  samples is final.
 - **The assistant can now answer questions about Gotcha itself.** There was a
   tool for the company behind the app (`about_samosa_ai`) but none for the app,
   so "what can you do?" and "which setting do I change to read replies aloud?"

--- a/app/src/androidTest/java/com/gotcha/AssistiveBallTest.kt
+++ b/app/src/androidTest/java/com/gotcha/AssistiveBallTest.kt
@@ -78,7 +78,8 @@ class AssistiveBallTest {
 
         composeRule.onNodeWithTag("chat_input").assertExists()
 
-        // The toggle lives in Settings ▸ Assistive Ball: drawer, category, switch.
+        // The toggle lives in Settings ▸ Assistive Ball and Wake Word: drawer,
+        // category, switch.
         composeRule.onNode(hasContentDescription("Open menu")).performClick()
         composeRule.waitForIdle()
         composeRule.onNodeWithText("Settings").performClick()

--- a/app/src/androidTest/java/com/gotcha/ChatRoundTripTest.kt
+++ b/app/src/androidTest/java/com/gotcha/ChatRoundTripTest.kt
@@ -1,5 +1,6 @@
 package com.gotcha
 
+import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isEnabled
@@ -17,7 +18,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.gotcha.testutil.MOCK_REPLY_OK
 import com.gotcha.testutil.MockLlm
 import com.gotcha.testutil.TestSeed
+import com.gotcha.ui.STARTER_PROMPTS
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -86,6 +89,40 @@ class ChatRoundTripTest {
         val request = mockLlm.server.takeRequest()
         assertTrue(request.path?.endsWith("/chat/completions") == true)
         assertTrue(request.body.readUtf8().contains("test-model"))
+    }
+
+    @Test
+    fun starterPrompt_fillsComposerWithoutSending() {
+        mockLlm.start()
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        TestSeed.seedConfigured(context, baseUrl = mockLlm.baseUrl, model = "test-model")
+
+        scenario = ActivityScenario.launch(MainActivity::class.java)
+        composeRule.waitForIdle()
+
+        // Which three are on offer is drawn per session, so the test follows the
+        // screen rather than assuming a particular chip is there.
+        composeRule.onNodeWithTag("starter_prompts").assertExists()
+        val shown = STARTER_PROMPTS.first { prompt ->
+            composeRule.onAllNodes(hasTestTag("starter_prompt_${prompt.label}"))
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeRule.onNodeWithTag("starter_prompt_${shown.label}").performClick()
+        composeRule.waitForIdle()
+
+        // Filled, not sent: the template is in the composer, the transcript is
+        // still empty, and nothing went to the LLM.
+        composeRule.onNodeWithTag("chat_input").assert(hasText(shown.template))
+        assertTrue(
+            "tapping a starter must not open the transcript",
+            composeRule.onAllNodes(hasTestTag("message_list")).fetchSemanticsNodes().isEmpty()
+        )
+        assertEquals(
+            "tapping a starter must not send anything to the LLM",
+            0,
+            mockLlm.server.requestCount
+        )
     }
 
     @Test

--- a/app/src/androidTest/java/com/gotcha/SampleChatsFlowTest.kt
+++ b/app/src/androidTest/java/com/gotcha/SampleChatsFlowTest.kt
@@ -1,0 +1,144 @@
+package com.gotcha
+
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.gotcha.data.SampleChatSeeder
+import com.gotcha.data.SampleChats
+import com.gotcha.data.SettingsRepository
+import com.gotcha.testutil.MockLlm
+import com.gotcha.testutil.TestSeed
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+/**
+ * The seeded sample chats, end to end: they appear in the drawer of a fresh
+ * install, they say they are samples both there and inside, and deleting one
+ * is final.
+ *
+ * Every test starts by putting the app back into its first-run state — an empty
+ * chats directory and an unset seeding flag — because the flag is exactly what
+ * stops this from happening twice, and an earlier test in the same run will
+ * already have tripped it.
+ */
+@RunWith(AndroidJUnit4::class)
+class SampleChatsFlowTest {
+
+    @get:Rule
+    val composeRule = createEmptyComposeRule()
+
+    private var scenario: ActivityScenario<MainActivity>? = null
+    private val mockLlm = MockLlm()
+    private val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+
+    @Before
+    fun setup() {
+        resetToFirstRun()
+        mockLlm.start()
+        TestSeed.seedConfigured(context, baseUrl = mockLlm.baseUrl, model = "test-model")
+    }
+
+    @After
+    fun tearDown() {
+        scenario?.close()
+        mockLlm.shutdown()
+        resetToFirstRun()
+    }
+
+    private fun resetToFirstRun() {
+        File(context.filesDir, "chats").listFiles()?.forEach { it.delete() }
+        SettingsRepository(context).prefs.edit()
+            .remove(SampleChatSeeder.SEEDED_KEY)
+            .commit()
+    }
+
+    private fun launch() {
+        scenario = ActivityScenario.launch(MainActivity::class.java)
+        composeRule.waitForIdle()
+    }
+
+    private fun openDrawer() {
+        composeRule.onNodeWithContentDescription("Open menu").performClick()
+        composeRule.waitForIdle()
+    }
+
+    private fun titles() = SampleChats.all().map { it.title }
+
+    private fun awaitSampleRows() {
+        composeRule.waitUntil(timeoutMillis = 10_000) {
+            titles().all { title ->
+                composeRule.onAllNodes(hasText(title)).fetchSemanticsNodes().isNotEmpty()
+            }
+        }
+    }
+
+    @Test
+    fun freshInstall_showsBothSamplesInTheDrawer() {
+        launch()
+        openDrawer()
+        awaitSampleRows()
+
+        titles().forEach { composeRule.onNodeWithText(it).assertExists() }
+        // Both rows say where they came from, not just one.
+        assertTrue(
+            "every seeded row must be labelled a sample",
+            composeRule.onAllNodes(hasText("Sample chat")).fetchSemanticsNodes().size >= titles().size
+        )
+    }
+
+    @Test
+    fun openingASample_showsTheNoticeAboveTheTranscript() {
+        launch()
+        openDrawer()
+        awaitSampleRows()
+
+        composeRule.onNodeWithText(titles().first()).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithTag("sample_chat_notice").assertExists()
+        // And it is a real transcript, not an empty chat wearing a label.
+        composeRule.onNodeWithTag("message_list").assertExists()
+    }
+
+    @Test
+    fun aDeletedSampleDoesNotComeBack() {
+        launch()
+        openDrawer()
+        awaitSampleRows()
+
+        // Delete every sample, confirming each time.
+        repeat(titles().size) {
+            composeRule.onAllNodes(hasContentDescription("Delete chat")).onFirst().performClick()
+            composeRule.waitForIdle()
+            composeRule.onNodeWithText("Delete").performClick()
+            composeRule.waitForIdle()
+        }
+        scenario?.close()
+        scenario = null
+
+        // A relaunch is the moment seeding would run again if the flag were not
+        // already set — this is the regression the flag exists to prevent.
+        launch()
+        openDrawer()
+        composeRule.waitForIdle()
+        titles().forEach { title ->
+            assertTrue(
+                "deleted sample '$title' came back after a relaunch",
+                composeRule.onAllNodes(hasText(title)).fetchSemanticsNodes().isEmpty()
+            )
+        }
+    }
+}

--- a/app/src/main/assets/app/about-gotcha.md
+++ b/app/src/main/assets/app/about-gotcha.md
@@ -1,0 +1,151 @@
+# About Gotcha
+
+Gotcha is the app you are running inside. It is an on-device Android copilot: it
+holds a conversation, and it drives the real device through a catalog of 100+
+tools — calls, SMS, contacts, calendar, alarms, files, media, notifications, a
+Linux shell, and full screen automation through the accessibility service.
+
+Use this document to answer "what can you do?", "why can't you do X?", and
+"which setting do I change to get Y?". Read the settings paths out of here
+rather than guessing them or navigating the Settings UI to find out.
+
+## Copilot modes
+
+**Monitor** is read-only. It can look and plan but cannot change anything: read
+the screen and notifications, find contacts, read recent SMS and the call log,
+list calendar events, read files, grep and glob, search the web, check battery,
+storage, location and app usage, list alarms and timers, read health data, and
+open an app. It cannot send, delete, write, tap or automate.
+
+**Operator** is the full catalog: everything Monitor has, plus placing calls,
+sending SMS and email, writing and deleting files, creating and editing calendar
+events and alarms, taking photos, recording audio, changing device settings,
+running shell and Termux commands, driving the screen, and delegating to
+sub-agents.
+
+The mode switch is in the chat screen and can be changed at any time, including
+mid-conversation.
+
+## What Gotcha can do
+
+- **Phone and messaging** — place a call, open the dialer without calling, read
+  the call log, find and add contacts, send and read SMS.
+- **Calendar** — list, create, edit and delete events, and check availability.
+- **Clock** — set and edit alarms and timers, list them, snooze, dismiss.
+- **Files** — list, read, write, edit surgically, grep, glob, and report storage.
+- **Documents and media** — parse and edit PDFs, edit audio and video, convert
+  audio formats (via Termux ffmpeg), take photos, record audio, transcribe audio
+  files, and synthesize single-voice or two-host podcasts.
+- **Screen automation** — read the screen, tap, long-press, swipe, type, press
+  keys, perform global actions, and hand a whole in-app journey to the App
+  Navigator sub-agent.
+- **Notifications** — read them, dismiss them, control media playback, report
+  what is now playing.
+- **Device control** — Wi-Fi, torch, volume, ringer mode, Do Not Disturb,
+  brightness, wallpaper, vibration, clipboard, app launch and uninstall, app and
+  data usage, location.
+- **System access** — shell commands, root commands and secure-settings writes
+  on a rooted device, and full Linux user-space through Termux.
+- **Web** — search and fetch pages.
+- **Health** — on-device, read-only summaries and records via Health Connect.
+- **Connectors** — Email (IMAP), Google (BYO OAuth), Microsoft (Outlook,
+  Calendar, To Do), Notion, and Home Assistant.
+- **Skills** — bundled and community operational guidance, searchable and
+  injected automatically when the matching app is in front.
+
+## Where the settings are
+
+Everything below is reached from **Settings** in the navigation drawer.
+
+| Setting | What it controls |
+| --- | --- |
+| Personal Info | Name, occupation, background, reply style, location, preferred currency and language |
+| Language | App display language, AI reply language, voice language, STT language |
+| AI | Hub for the two pages below |
+| AI > AI Configuration | LLM provider, API key, Base URL, main and navigator models, API timeout, max context tokens, max tool rounds, max repeated tool calls, max navigation tool calls, max consecutive delegations, cache and debug-screenshot clearing |
+| AI > Speech (TTS / STT) | TTS and STT provider, base URL, key and model, voice selection, podcast host voices, auto-read replies aloud, transcription language override |
+| Permissions | Every runtime and special-access permission, grouped: Communications, Contacts, Calendar, Media & Storage, Location, Device Control, Notifications, System Access, Health |
+| Termux (Linux shell) | Guided setup for the Linux shell used by `run_termux_command` and audio conversion |
+| Skills / Plugins | Built-in skills, importing community skills by URL, allowed community skill hosts |
+| Proactive Assistance | Master switch for proactive offers, OTP/code detection, auto-copy OTP, and what may be scanned (screen content, notifications, clipboard) |
+| Assistive Ball and Wake Word | The floating ball over other apps, hands-free voice calls, the "Hey Gotcha" wake word, when it listens, and detection sensitivity |
+| Appearance | Theme |
+| Notifications | Reply chime, vibration, and server messages |
+| About | Samosa AI, other products, legal, contact |
+| About > About Samosa AI | Mission, products, pricing, developers |
+| About > Legal | Terms, disclaimer, data retention |
+
+Two more rows sit on the Settings list itself: **Feature Tour**, which replays
+the guided setup one step at a time, and **Send Feedback**.
+
+**Connectors are not in Settings.** They live in the navigation drawer next to
+Settings, on their own Connectors screen.
+
+## Permissions and prerequisites
+
+Some tools need a grant that cannot be requested from inside a chat turn. When
+one is missing the tools are withheld, but the possibility is not: say what is
+missing, where to turn it on, and offer to try again afterwards.
+
+| Needs | Unlocks | Granted at |
+| --- | --- | --- |
+| The accessibility service | Screen reading, tap, long-press, swipe, typing, key presses, global actions, App Navigator | Settings > Permissions (opens Android's accessibility screen) |
+| Notification access | Reading and dismissing notifications, media control, now playing | Settings > Permissions |
+| Device admin | Lock screen, disable camera, password policy | Settings > Permissions |
+| Root | Root commands and secure-settings writes | A rooted device; `check_root` reports the truth |
+| Termux | Termux commands, audio conversion, pulling files out of Termux | Install Termux from F-Droid, then Settings > Termux (Linux shell) |
+| Health Connect | Health summaries and records | Settings > Permissions > Health |
+| Display over other apps | The overlay tools and the Assistive Ball | Settings > Permissions |
+
+Runtime permissions (phone, SMS, contacts, calendar, camera, microphone,
+location, storage) show the normal Android dialog when toggled on in Settings >
+Permissions. Special-access permissions open a system settings screen for a
+one-time setup instead.
+
+## Safety model
+
+Tools are organised in capability tiers, permissions are asked for up front, and
+sensitive actions pass a confirmation gate. Shell commands run against a
+deny-list, actions are recorded in an append-only audit log, and settings
+screens that could be changed silently are marked confirm-first — the agent asks
+before opening them, because screen text, notifications and email all reach the
+model's context and could carry an injected instruction.
+
+## Common questions
+
+**"Set up a model."** Settings > AI > AI Configuration: API key, Base URL
+(including `/v1/`), and model name. Any OpenAI-compatible `/chat/completions`
+endpoint with tool calling works, or sign in to Samosa AI for starter credits.
+
+**"Enable the floating ball / wake word."** Settings > Assistive Ball and Wake
+Word. The ball needs the display-over-other-apps permission; the wake word
+listens from inside the ball's service, and "When to listen" controls whether
+that happens with the screen on, off, or always.
+
+**"Get Termux working."** Install Termux from F-Droid, then Settings > Termux
+(Linux shell) for the guided setup. Each command runs in a separate shell, so
+`cd` and `export` do not carry over between calls.
+
+**"Read replies aloud."** Settings > AI > Speech (TTS / STT) > Auto-read replies
+aloud.
+
+**"Stop Gotcha scanning my screen."** Settings > Proactive Assistance, which has
+a master switch plus individual toggles for screen content, notifications and
+clipboard.
+
+**"Why can't you do that?"** Check the permission table above — the missing
+piece is almost always a capability that has not been granted yet, or Monitor
+mode being on when the request needs Operator.
+
+## More
+
+Full documentation is online: getting started, copilot modes, the tool catalog,
+architecture, safety and permissions, and the FAQ.
+
+- https://samosa-ai.com/gotcha/docs
+- https://samosa-ai.com/gotcha/docs/tool-catalog
+- https://samosa-ai.com/gotcha/docs/safety-permissions
+
+For the company behind Gotcha, its other products, pricing, contact details and
+the terms and privacy summary, call `about_samosa_ai` instead. The authoritative
+legal text is bundled in the app under Settings > About > Legal.

--- a/app/src/main/assets/legal/privacy-data-retention.md
+++ b/app/src/main/assets/legal/privacy-data-retention.md
@@ -147,9 +147,9 @@ backend that transmits data to a third-party AI provider.
 10. OPTIONAL WAKE WORD ("Hey Gotcha")
 
    10.1 The wake-word feature is opt-in. When turned on in Settings
-        (Settings → Assistive Ball → "Wake word: Hey Gotcha"), the App keeps a
-        microphone-type foreground service alive while the Assistive Ball is on
-        and no voice call is in progress.
+        (Settings → Assistive Ball and Wake Word → "Wake word: Hey Gotcha"), the
+        App keeps a microphone-type foreground service alive while the Assistive
+        Ball is on and no voice call is in progress.
 
    10.2 The wake-word listener processes all microphone audio **on-device**
         using the bundled OpenWakeWord models (Apache 2.0, see

--- a/app/src/main/java/com/gotcha/agent/AgentEngine.kt
+++ b/app/src/main/java/com/gotcha/agent/AgentEngine.kt
@@ -73,6 +73,13 @@ class AgentEngine(
     var tokenCount: Int = 0
 
     /**
+     * True while the bound session is one of the chats seeded on first run.
+     * Carried through every save so a sample the user carries on with stays
+     * labelled as one — its opening exchange is still not something they said.
+     */
+    var sessionIsSample: Boolean = false
+
+    /**
      * Stable key for the provider's server-side prompt KV cache
      * (`prompt_cache_key` / `X-Session-Id`), independent of [sessionId] which
      * also serves as per-session file identity. Defaults to [sessionId] when
@@ -304,7 +311,8 @@ class AgentEngine(
                 tokenCount = tokenCount,
                 displayMessages = displayMessagesProvider(),
                 agentMode = agentModeProvider()?.name,
-                runSummaries = runSummaries.toList()
+                runSummaries = runSummaries.toList(),
+                isSample = sessionIsSample
             )
         )
         // Rename the chat dir in place now that the real title is known.

--- a/app/src/main/java/com/gotcha/agent/ChatViewModel.kt
+++ b/app/src/main/java/com/gotcha/agent/ChatViewModel.kt
@@ -104,6 +104,12 @@ data class ChatUiState(
     val isConfigured: Boolean = false,
     val activeSessionId: String? = null,
     val activeAgent: AgentMode = AgentMode.MONITOR,
+    /**
+     * True while the open chat is one of the samples seeded on first run, so the
+     * transcript can say so above the first bubble. Nothing else depends on it:
+     * a sample is continued, renamed and deleted like any other chat.
+     */
+    val viewingSample: Boolean = false,
     /** Id of the session with an in-progress run, or null when nothing is running. */
     val runningSessionId: String? = null,
     /** Title of the running session, for the "return to running chat" banner. */
@@ -272,6 +278,7 @@ class ChatViewModel(application: Application) : AndroidViewModel(application), A
             _uiState.update { it.copy(activeSessionId = agentEngine.sessionId) }
             updateContextUsage()
             migrateChatDirsIfNeeded()
+            com.gotcha.data.SampleChatSeeder.seedIfNeeded(historyRepository, settingsRepository.prefs)
             refreshSessions()
         }
     }
@@ -1107,6 +1114,7 @@ class ChatViewModel(application: Application) : AndroidViewModel(application), A
             // and saveCurrentSession() would persist the stale list into the
             // new chat file.
             agentEngine.restoreRunSummaries(emptyList())
+            agentEngine.sessionIsSample = false
             agentEngine.setupWorkingDir(create = false)
             engineTranscript = emptyList()
             engineAgent = defaultAgent
@@ -1115,7 +1123,8 @@ class ChatViewModel(application: Application) : AndroidViewModel(application), A
             it.copy(
                 messages = emptyList(),
                 activeSessionId = newId,
-                activeAgent = defaultAgent
+                activeAgent = defaultAgent,
+                viewingSample = false
             )
         }
         applyContextUsage(0)
@@ -1177,7 +1186,8 @@ class ChatViewModel(application: Application) : AndroidViewModel(application), A
                     it.copy(
                         activeSessionId = id,
                         activeAgent = engineAgent,
-                        messages = engineTranscript
+                        messages = engineTranscript,
+                        viewingSample = _sessions.value.firstOrNull { s -> s.id == id }?.isSample == true
                     )
                 }
                 applyContextUsage(agentEngine.tokenCount)
@@ -1197,6 +1207,7 @@ class ChatViewModel(application: Application) : AndroidViewModel(application), A
                 agentEngine.tokenCount = session.tokenCount
                 agentEngine.restoreTitle(if (session.isFallbackTitle()) null else session.title)
                 agentEngine.restoreRunSummaries(session.runSummaries)
+                agentEngine.sessionIsSample = session.isSample
                 agentEngine.setupWorkingDir()
                 engineTranscript = session.displayMessages
                 engineAgent = restoredAgent
@@ -1210,6 +1221,7 @@ class ChatViewModel(application: Application) : AndroidViewModel(application), A
                     it.copy(
                         activeSessionId = session.id,
                         activeAgent = restoredAgent,
+                        viewingSample = session.isSample,
                         messages = session.displayMessages,
                         // Clear engine-scoped transient UI for the viewed (non-running) chat.
                         activity = null,
@@ -1224,6 +1236,7 @@ class ChatViewModel(application: Application) : AndroidViewModel(application), A
                     it.copy(
                         activeSessionId = session.id,
                         activeAgent = restoredAgent,
+                        viewingSample = session.isSample,
                         activity = null,
                         subAgentRunning = null,
                         subAgentCurrentAction = null

--- a/app/src/main/java/com/gotcha/data/ChatHistoryRepository.kt
+++ b/app/src/main/java/com/gotcha/data/ChatHistoryRepository.kt
@@ -29,7 +29,15 @@ data class ChatSession(
      * Structured records of completed runs (the "share your moment" raw data),
      * newest last. Bounded at capture time so this can't grow unbounded.
      */
-    val runSummaries: List<RunSummary> = emptyList()
+    val runSummaries: List<RunSummary> = emptyList(),
+    /**
+     * True for the chats seeded on first run to demonstrate what Gotcha can be
+     * asked for. Marked in the drawer and above the transcript so a sample is
+     * never mistaken for something the user said, but otherwise an ordinary
+     * session: openable, continuable and deletable. Defaulted so every chat
+     * written before samples existed decodes as a real one.
+     */
+    val isSample: Boolean = false
 )
 
 /**
@@ -74,10 +82,18 @@ class ChatHistoryRepository internal constructor(private val chatsDir: File) {
         }
     }
 
-    suspend fun saveSession(session: ChatSession) = withContext(Dispatchers.IO) {
+    /**
+     * Writes [session], stamping it as modified now. Pass [touch] = false to keep
+     * the session's own [ChatSession.lastModified] — seeded sample chats carry
+     * crafted timestamps that decide their order in the drawer, and a save-time
+     * stamp would collapse them all into the same millisecond.
+     */
+    suspend fun saveSession(session: ChatSession, touch: Boolean = true) = withContext(Dispatchers.IO) {
         try {
             val file = File(chatsDir, "${session.id}.json")
-            file.writeText(json.encodeToString(serializer, session.copy(lastModified = System.currentTimeMillis())))
+            val toWrite =
+                if (touch) session.copy(lastModified = System.currentTimeMillis()) else session
+            file.writeText(json.encodeToString(serializer, toWrite))
         } catch (_: Exception) {
             // Best-effort
         }

--- a/app/src/main/java/com/gotcha/data/SampleChatSeeder.kt
+++ b/app/src/main/java/com/gotcha/data/SampleChatSeeder.kt
@@ -1,0 +1,40 @@
+package com.gotcha.data
+
+import android.content.SharedPreferences
+import android.util.Log
+
+/**
+ * Puts [SampleChats] on disk the first time Gotcha runs with an empty chat list.
+ *
+ * Seeding happens at most once per install, and only into a list that has
+ * nothing in it: an existing user upgrading into this version keeps the chat
+ * list they had, and a user who deletes the samples never sees them come back.
+ * Both of those are the same rule — the flag is written whether or not anything
+ * was actually seeded, so "have we done this?" is answered once and for all.
+ */
+internal object SampleChatSeeder {
+
+    const val SEEDED_KEY = "seeded_sample_chats_v1"
+
+    /**
+     * Returns true when samples were written. Best-effort: a failure here must
+     * not stop the app from opening, so it is logged and the flag left unset,
+     * which lets the next launch try again against a still-empty list.
+     */
+    suspend fun seedIfNeeded(repository: ChatHistoryRepository, prefs: SharedPreferences): Boolean {
+        if (prefs.getBoolean(SEEDED_KEY, false)) return false
+        return try {
+            val seed = repository.listSessions().isEmpty()
+            if (seed) {
+                // touch = false: the crafted timestamps are what order the two
+                // samples in the drawer, and a save-time stamp would flatten them.
+                SampleChats.all().forEach { repository.saveSession(it, touch = false) }
+            }
+            prefs.edit().putBoolean(SEEDED_KEY, true).apply()
+            seed
+        } catch (e: Exception) {
+            Log.w("Gotcha", "seedIfNeeded: failed to seed sample chats", e)
+            false
+        }
+    }
+}

--- a/app/src/main/java/com/gotcha/data/SampleChats.kt
+++ b/app/src/main/java/com/gotcha/data/SampleChats.kt
@@ -1,0 +1,120 @@
+package com.gotcha.data
+
+import com.gotcha.agent.MessageKind
+import com.gotcha.agent.UiMessage
+import com.gotcha.llm.ChatMessage
+import kotlinx.serialization.json.JsonPrimitive
+
+/**
+ * The chats seeded into an empty chat list on first run.
+ *
+ * A fresh install opened on nothing at all, so the one thing a first-time user
+ * could not find out was what Gotcha is for. These two transcripts answer that
+ * by showing it: a device action with a follow-up (Operator) and a question
+ * about the screen (Monitor) — the two halves of the agent selector.
+ *
+ * They are ordinary sessions, not a special screen: openable, continuable and
+ * deletable like any other, and marked [ChatSession.isSample] so the drawer and
+ * the transcript header can say where they came from.
+ */
+internal object SampleChats {
+
+    /** Stable ids: re-seeding can only ever overwrite these, never fork copies. */
+    const val DEVICE_ACTION_ID = "sample-device-action"
+    const val SCREEN_QA_ID = "sample-screen-qa"
+
+    /**
+     * Both samples, oldest first, timestamped just before [now] so the first
+     * chat the user actually starts sorts above them in the drawer.
+     */
+    fun all(now: Long = System.currentTimeMillis()): List<ChatSession> = listOf(
+        deviceAction(now - TWO_MINUTES),
+        screenQa(now - ONE_MINUTE)
+    )
+
+    /**
+     * Operator: the agent drives the device. The follow-up is the honest half of
+     * the story — Android does not let an app flip Bluetooth, so the agent opens
+     * the screen and hands over, which is worth seeing before it happens for real.
+     */
+    private fun deviceAction(lastModified: Long): ChatSession {
+        val exchanges = listOf(
+            "Turn on Wi-Fi" to "Wi-Fi is on.",
+            "Now turn Bluetooth off" to
+                "I've opened the Bluetooth screen for you. Android doesn't let an app flip " +
+                "that switch itself, so tap it there and it's done."
+        )
+        return sample(
+            id = DEVICE_ACTION_ID,
+            title = "Turn on Wi-Fi",
+            agentMode = "OPERATOR",
+            lastModified = lastModified,
+            exchanges = exchanges,
+            display = listOf(
+                ui(0, MessageKind.USER, exchanges[0].first),
+                ui(1, MessageKind.TOOL, "toggle_wifi: Wi-Fi turned on (was off, now on)."),
+                ui(2, MessageKind.ASSISTANT, exchanges[0].second),
+                ui(3, MessageKind.USER, exchanges[1].first),
+                ui(4, MessageKind.TOOL, "open_setting: Opened Bluetooth."),
+                ui(5, MessageKind.ASSISTANT, exchanges[1].second)
+            )
+        )
+    }
+
+    /** Monitor: nothing is changed, the agent only looks and answers. */
+    private fun screenQa(lastModified: Long): ChatSession {
+        val exchanges = listOf(
+            "What's on my screen?" to
+                "You're on a flight booking page — a Berlin → Lisbon search for 14 March, " +
+                "with the cheapest fare at the top at €89 and a Continue button under it. " +
+                "Ask me to compare the options or read out any part of it."
+        )
+        return sample(
+            id = SCREEN_QA_ID,
+            title = "What's on my screen?",
+            agentMode = "MONITOR",
+            lastModified = lastModified,
+            exchanges = exchanges,
+            display = listOf(
+                ui(0, MessageKind.USER, exchanges[0].first),
+                ui(1, MessageKind.TOOL, "read_screen: Read the screen (31 elements)."),
+                ui(2, MessageKind.ASSISTANT, exchanges[0].second)
+            )
+        )
+    }
+
+    /**
+     * The on-screen transcript ([display]) carries the tool bubbles, because
+     * that is what a real run looks like. The LLM-shaped history carries only
+     * the user/assistant text of [exchanges] — a fabricated `tool_calls` entry
+     * with no matching id would make the provider reject the very first request
+     * if the user carried the sample on, and the text alone is enough context
+     * for them to do so.
+     */
+    private fun sample(
+        id: String,
+        title: String,
+        agentMode: String,
+        lastModified: Long,
+        exchanges: List<Pair<String, String>>,
+        display: List<UiMessage>
+    ) = ChatSession(
+        id = id,
+        title = title,
+        lastModified = lastModified,
+        messages = exchanges.flatMap { (user, assistant) ->
+            listOf(
+                ChatMessage(role = "user", content = JsonPrimitive(user)),
+                ChatMessage(role = "assistant", content = JsonPrimitive(assistant))
+            )
+        },
+        displayMessages = display,
+        agentMode = agentMode,
+        isSample = true
+    )
+
+    private fun ui(id: Long, kind: MessageKind, text: String) = UiMessage(id, kind, text)
+
+    private const val ONE_MINUTE = 60_000L
+    private const val TWO_MINUTES = 120_000L
+}

--- a/app/src/main/java/com/gotcha/tools/AppInfoTool.kt
+++ b/app/src/main/java/com/gotcha/tools/AppInfoTool.kt
@@ -1,0 +1,30 @@
+package com.gotcha.tools
+
+import android.content.Context
+
+/**
+ * Answers questions about Gotcha itself — what it can do, where each setting
+ * lives, and which permission a tool is waiting on.
+ *
+ * The company analogue is [CompanyInfoTool], and the reasoning is the same: the
+ * content is a bundled asset, so the answer works offline and never drifts with
+ * the network. The difference is what a wrong answer costs here. Without this
+ * the agent either invents a settings path or spends several rounds driving the
+ * Settings UI to rediscover one, and the question ("which setting do I change
+ * to…") is one of the most common things a user asks the assistant it is
+ * running inside.
+ */
+class AppInfoTool(private val context: Context) {
+
+    fun aboutGotcha(): ToolResult = try {
+        val text = context.assets.open(ABOUT_ASSET)
+            .use { it.readBytes().toString(Charsets.UTF_8) }
+        ToolResult.ok(text)
+    } catch (e: Exception) {
+        ToolResult.error("Could not read Gotcha info: ${e.message}")
+    }
+
+    companion object {
+        const val ABOUT_ASSET = "app/about-gotcha.md"
+    }
+}

--- a/app/src/main/java/com/gotcha/tools/ToolDefinitions.kt
+++ b/app/src/main/java/com/gotcha/tools/ToolDefinitions.kt
@@ -55,6 +55,21 @@ object ToolDefinitions {
         schema { putJsonObject("properties") {} }
     )
 
+    val aboutGotcha = tool(
+        "about_gotcha",
+        "Get information about Gotcha — this app — from its bundled handbook: what it can do, " +
+            "Monitor vs Operator mode, the exact path to every setting (AI models and API keys, " +
+            "speech, language, permissions, Termux, skills, proactive assistance, the assistive " +
+            "ball and wake word, appearance, notifications), which permission or capability each " +
+            "group of tools needs and where the user turns it on, and the safety model. Call this " +
+            "for ANY question about the app's own features, limits or settings — 'what can you " +
+            "do', 'which setting do I change to…', 'why can't you do that', 'how do I set up a " +
+            "model / the wake word / Termux'. Answer from this rather than guessing from memory, " +
+            "and rather than reading or driving the Settings screens to rediscover a path. " +
+            "For the company, its other products, pricing or contact details, use about_samosa_ai.",
+        schema { putJsonObject("properties") {} }
+    )
+
     val updateUserProfile = tool(
         "update_user_profile",
         "Update the user's stored personal profile in Settings (occupation, background, " +
@@ -2945,6 +2960,7 @@ object ToolDefinitions {
 
     val all: List<ToolDefinition> = listOf(
         aboutSamosaAi,
+        aboutGotcha,
         updateUserProfile,
         dialNumber, getStorageInfo, getBatteryInfo, listFiles, readFile, writeFile,
         openApp, setBrightness, toggleWifi, openSetting,

--- a/app/src/main/java/com/gotcha/tools/ToolExecutor.kt
+++ b/app/src/main/java/com/gotcha/tools/ToolExecutor.kt
@@ -62,6 +62,7 @@ class ToolExecutor(
     private val clipboardTool = ClipboardTool(appContext)
     private val mediaCaptureTool = MediaCaptureTool(appContext)
     private val companyInfoTool = CompanyInfoTool(appContext)
+    private val appInfoTool = AppInfoTool(appContext)
 
     // Tier 3 tools
     private val webSearchTool = WebSearchTool()
@@ -215,6 +216,7 @@ class ToolExecutor(
             "get_storage_info" -> storageTool.getStorageInfo()
             "get_battery_info" -> systemTool.getBatteryInfo()
             "about_samosa_ai" -> companyInfoTool.aboutSamosaAi()
+            "about_gotcha" -> appInfoTool.aboutGotcha()
             "edit" -> editTool.edit(
                 path = args.requireString("path") ?: return missing("path"),
                 oldString = args.requireString("oldString") ?: return missing("oldString"),

--- a/app/src/main/java/com/gotcha/tools/ToolRegistry.kt
+++ b/app/src/main/java/com/gotcha/tools/ToolRegistry.kt
@@ -92,7 +92,7 @@ object ToolRegistry {
         "check_root", "search_skills",
         "get_health_summary", "get_health_records",
         "get_now_playing",
-        "about_samosa_ai"
+        "about_samosa_ai", "about_gotcha"
     )
 
     /**

--- a/app/src/main/java/com/gotcha/ui/AppDrawer.kt
+++ b/app/src/main/java/com/gotcha/ui/AppDrawer.kt
@@ -124,6 +124,17 @@ fun AppDrawerContent(
                                     maxLines = 1,
                                     overflow = TextOverflow.Ellipsis
                                 )
+                                // The one thing that distinguishes a seeded chat
+                                // from one the user held: said on the row rather
+                                // than only inside, so the list itself is honest.
+                                if (session.isSample) {
+                                    Text(
+                                        "Sample chat",
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.primary,
+                                        maxLines = 1
+                                    )
+                                }
                                 if (usage != null) {
                                     // Tabular figures: this counter ticks while a
                                     // reply streams, and proportional digits make

--- a/app/src/main/java/com/gotcha/ui/AssistiveBallScreen.kt
+++ b/app/src/main/java/com/gotcha/ui/AssistiveBallScreen.kt
@@ -36,8 +36,10 @@ import com.gotcha.data.WakeWordListeningMode
 import android.provider.Settings as AndroidSettings
 
 /**
- * The Assistive Ball page: one switch that starts or stops the floating overlay,
- * plus the short version of what the ball does once it is on.
+ * The Assistive Ball and Wake Word page: a switch that starts or stops the
+ * floating overlay, the short version of what the ball does once it is on, and
+ * the "Hey Gotcha" wake word — which lives here because its listener runs inside
+ * the ball's service and cannot outlive it.
  *
  * The switch is not a stored preference the page owns — it drives the
  * [com.gotcha.service.AssistiveBallService] through the host, which persists
@@ -112,21 +114,23 @@ fun AssistiveBallScreen(
                 "Turn on Hey Gotcha wake word"
             }
         )
+        // Stated whether or not the ball is on: with the ball on, the toggle
+        // works and nothing else would explain why it stops later.
+        Text(
+            "Says \"Hey Gotcha\" — the bundled OpenWakeWord model runs on-device, but " +
+                "only while the Assistive Ball is on and no call is active. The " +
+                "listener lives inside the ball's service, so switching the ball off " +
+                "switches the wake word off too. Keep microphone permission enabled.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
         if (!ballEnabled) {
             Text(
-                "The wake word requires the Assistive Ball to be on — turn on " +
-                    "\"Show Assistive Ball\" to use it.",
+                "Turn on \"Show Assistive Ball\" above to use it.",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
-        Text(
-            "Says \"Hey Gotcha\" — the bundled OpenWakeWord model runs on-device while " +
-                "the assistive ball is on and no call is active. Keep microphone " +
-                "permission enabled.",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
         if (wakeWordEnabled) {
             Spacer(modifier = Modifier.height(8.dp))
             Text(

--- a/app/src/main/java/com/gotcha/ui/ChatScreen.kt
+++ b/app/src/main/java/com/gotcha/ui/ChatScreen.kt
@@ -319,6 +319,30 @@ fun ChatScreen(
                         selected = state.activeAgent,
                         onSelect = onSetAgent
                     )
+                    // Starters are an offer to fill the composer, so they are
+                    // only shown when the composer can actually be used: no API
+                    // key means typing is disabled, and a run in another chat
+                    // blocks sending from here.
+                    if (state.isConfigured && !otherChatRunning) {
+                        // Re-drawn per session rather than per recomposition, so
+                        // the three on offer don't reshuffle under a rotation.
+                        val starters = rememberSaveable(
+                            state.activeSessionId,
+                            saver = StarterPromptLabelsSaver
+                        ) {
+                            STARTER_PROMPTS.shuffled().take(STARTER_PROMPT_COUNT)
+                        }
+                        Spacer(modifier = Modifier.height(24.dp))
+                        StarterPromptRow(
+                            prompts = starters,
+                            onPick = { prompt ->
+                                // Fill, never send: the template is a draft the
+                                // user is expected to edit first.
+                                input = prompt.template
+                                inputWasVoice = false
+                            }
+                        )
+                    }
                 }
             } else {
                 LazyColumn(

--- a/app/src/main/java/com/gotcha/ui/ChatScreen.kt
+++ b/app/src/main/java/com/gotcha/ui/ChatScreen.kt
@@ -349,6 +349,9 @@ fun ChatScreen(
                     state = listState,
                     modifier = Modifier.weight(1f).fillMaxWidth().testTag("message_list")
                 ) {
+                    if (state.viewingSample) {
+                        item(key = "sample_notice") { SampleChatNotice() }
+                    }
                     items(state.messages, key = { it.id }) { message ->
                         // Only what arrives after the chat is open animates, and
                         // each id only ever animates once — `add` is false the
@@ -1032,5 +1035,31 @@ private fun AgentModeOption(
                 fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal
             )
         }
+    }
+}
+
+/**
+ * Sits above the first bubble of a chat seeded on first run. The transcript is
+ * written in the user's voice, so without this line it would read as something
+ * they said and Gotcha did — the notice is what keeps a demonstration from
+ * passing itself off as history.
+ */
+@Composable
+private fun SampleChatNotice() {
+    Surface(
+        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.10f),
+        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        shape = RoundedCornerShape(12.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp, vertical = 8.dp)
+            .testTag("sample_chat_notice")
+    ) {
+        Text(
+            "Sample chat — this one ships with Gotcha to show what it can do. " +
+                "Carry it on, or delete it from the drawer.",
+            style = MaterialTheme.typography.labelMedium,
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp)
+        )
     }
 }

--- a/app/src/main/java/com/gotcha/ui/SettingsCommon.kt
+++ b/app/src/main/java/com/gotcha/ui/SettingsCommon.kt
@@ -147,8 +147,10 @@ enum class SettingsPage(
         "settings_proactive_row"
     ),
     ASSISTIVE_BALL(
-        "Assistive Ball",
-        "Floating ball over other apps, hands-free calls",
+        // The wake word listens from inside the ball's service, so it is not a
+        // page of its own — the title says so to make it findable.
+        "Assistive Ball and Wake Word",
+        "Floating ball over other apps, hands-free calls, \"Hey Gotcha\"",
         "settings_assistive_ball_row"
     ),
     APPEARANCE(

--- a/app/src/main/java/com/gotcha/ui/StarterPrompt.kt
+++ b/app/src/main/java/com/gotcha/ui/StarterPrompt.kt
@@ -1,0 +1,144 @@
+package com.gotcha.ui
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+/**
+ * One tap-to-fill suggestion on the empty home screen.
+ *
+ * [label] is what the chip says; [template] is what lands in the composer. They
+ * are deliberately different — the chip has to stay short enough to sit three to
+ * a screen, while the template is a first draft of a real prompt. Tapping fills
+ * the composer and stops there: the user edits and sends, so a template may
+ * carry an unfilled `…` where a name or a message belongs.
+ */
+internal data class StarterPrompt(val label: String, val template: String)
+
+/**
+ * The starters offered on an empty chat. Between them they demo the three things
+ * people most often don't realise Gotcha can do — drive the device, answer
+ * questions about what's on screen or on disk, and handle messages.
+ *
+ * Four of the seven (screen, both filesystem ones, notifications) are read-only,
+ * so they answer in Monitor as well as Operator. The two device actions need
+ * Operator; the chip does not switch mode on the user's behalf, the selector
+ * directly above it does.
+ */
+internal val STARTER_PROMPTS = listOf(
+    StarterPrompt(
+        label = "Turn on Wi-Fi",
+        template = "Open settings and turn on Wi-Fi"
+    ),
+    StarterPrompt(
+        label = "Set an alarm",
+        template = "Set an alarm for 7am tomorrow"
+    ),
+    StarterPrompt(
+        label = "Read my screen",
+        template = "What's on my screen?"
+    ),
+    StarterPrompt(
+        label = "Find big files",
+        template = "Find the largest files in my Downloads folder and tell me what's safe to delete"
+    ),
+    StarterPrompt(
+        label = "Summarise a PDF",
+        template = "Read the most recent PDF in my Downloads and summarise it"
+    ),
+    StarterPrompt(
+        label = "Send a WhatsApp",
+        template = "Send a WhatsApp to … saying …"
+    ),
+    StarterPrompt(
+        label = "Catch me up",
+        template = "Catch me up on my unread notifications"
+    )
+)
+
+/** How many of [STARTER_PROMPTS] a single home screen offers. */
+internal const val STARTER_PROMPT_COUNT = 3
+
+/**
+ * rememberSaveable saver for the drawn starters. Only the labels are stored —
+ * they are unique, and the prompts themselves are a compile-time list, so a
+ * restore is a lookup. A label that no longer exists (the list changed across an
+ * app update, with saved state from the old one) simply drops out.
+ */
+internal val StarterPromptLabelsSaver = listSaver<List<StarterPrompt>, String>(
+    save = { prompts -> prompts.map { it.label } },
+    restore = { labels ->
+        labels.mapNotNull { label -> STARTER_PROMPTS.firstOrNull { it.label == label } }
+    }
+)
+
+/**
+ * The tap-to-fill chip row under the agent selector on the home screen.
+ *
+ * Styled like the *unchosen* half of [AgentModeSelector] — hairline outline, no
+ * fill, dimmed ink — for the reason spelled out there: Material's own chips mark
+ * themselves with `secondaryContainer`, which every glass skin leaves
+ * translucent. These are suggestions, not the screen's main event, so they stay
+ * quieter than the mode selector above them and the composer below.
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+internal fun StarterPromptRow(
+    prompts: List<StarterPrompt>,
+    onPick: (StarterPrompt) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val scheme = MaterialTheme.colorScheme
+    Column(
+        modifier = modifier.testTag("starter_prompts"),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            "Try",
+            style = MaterialTheme.typography.labelMedium,
+            color = scheme.onSurfaceVariant
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        FlowRow(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            prompts.forEach { prompt ->
+                Surface(
+                    onClick = { onPick(prompt) },
+                    shape = CircleShape,
+                    color = Color.Transparent,
+                    contentColor = scheme.onSurfaceVariant.copy(alpha = 0.75f),
+                    border = BorderStroke(1.dp, scheme.outlineVariant.copy(alpha = 0.6f)),
+                    modifier = Modifier.testTag("starter_prompt_${prompt.label}")
+                ) {
+                    Text(
+                        prompt.label,
+                        style = MaterialTheme.typography.labelLarge,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp)
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/gotcha/data/ChatHistoryRepositoryTest.kt
+++ b/app/src/test/java/com/gotcha/data/ChatHistoryRepositoryTest.kt
@@ -54,6 +54,31 @@ class ChatHistoryRepositoryTest {
     }
 
     @Test
+    fun `the sample marking survives a round-trip and defaults to false`() = runBlocking {
+        val dir = tmp.newFolder("chats")
+        val repo = ChatHistoryRepository(dir)
+        repo.saveSession(session("seeded").copy(isSample = true))
+        assertTrue(repo.loadSession("seeded")!!.isSample)
+        assertFalse(repo.loadSession("seeded")!!.title.isBlank())
+
+        // A chat written before samples existed has no such field at all.
+        File(dir, "legacy.json").writeText(
+            """{"id":"legacy","title":"Old","lastModified":0,"messages":[]}"""
+        )
+        assertFalse(repo.loadSession("legacy")!!.isSample)
+    }
+
+    @Test
+    fun `saving without touch keeps the session's own timestamp`() = runBlocking {
+        val repo = ChatHistoryRepository(tmp.newFolder("chats"))
+        repo.saveSession(session("kept").copy(lastModified = 4_200L), touch = false)
+        assertEquals(4_200L, repo.loadSession("kept")!!.lastModified)
+
+        repo.saveSession(session("stamped").copy(lastModified = 4_200L))
+        assertTrue(repo.loadSession("stamped")!!.lastModified > 4_200L)
+    }
+
+    @Test
     fun `deleteSession removes the backing file`() = runBlocking {
         val dir = tmp.newFolder("calls")
         val repo = ChatHistoryRepository(dir)

--- a/app/src/test/java/com/gotcha/data/SampleChatSeederTest.kt
+++ b/app/src/test/java/com/gotcha/data/SampleChatSeederTest.kt
@@ -1,0 +1,98 @@
+package com.gotcha.data
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Seeding is a one-shot, and the cases that matter are the ones where it must
+ * NOT happen: an upgrading user with chats of their own, and a user who deleted
+ * the samples and does not want them back.
+ *
+ * Robolectric is here only for [SharedPreferences]; the repository uses its
+ * internal File constructor against a temporary folder.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class SampleChatSeederTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private lateinit var prefs: SharedPreferences
+
+    @Before
+    fun setup() {
+        prefs = ApplicationProvider.getApplicationContext<Context>()
+            .getSharedPreferences("sample_chat_seeder_test", Context.MODE_PRIVATE)
+        prefs.edit().clear().commit()
+    }
+
+    private fun repo() = ChatHistoryRepository(tmp.newFolder())
+
+    @Test
+    fun `seeds the samples into an empty chat list`() = runBlocking {
+        val repo = repo()
+        assertTrue(SampleChatSeeder.seedIfNeeded(repo, prefs))
+        val seeded = repo.listSessions()
+        assertEquals(SampleChats.all().map { it.id }.toSet(), seeded.map { it.id }.toSet())
+        assertTrue(seeded.all { it.isSample })
+        assertTrue(prefs.getBoolean(SampleChatSeeder.SEEDED_KEY, false))
+    }
+
+    @Test
+    fun `seeded samples keep their crafted order`() = runBlocking {
+        val repo = repo()
+        SampleChatSeeder.seedIfNeeded(repo, prefs)
+        // listSessions sorts newest first, so the drawer shows the screen Q&A
+        // above the device action — the save must not have restamped both.
+        assertEquals(
+            listOf(SampleChats.SCREEN_QA_ID, SampleChats.DEVICE_ACTION_ID),
+            repo.listSessions().map { it.id }
+        )
+    }
+
+    @Test
+    fun `a second run seeds nothing`() = runBlocking {
+        val repo = repo()
+        SampleChatSeeder.seedIfNeeded(repo, prefs)
+        assertFalse(SampleChatSeeder.seedIfNeeded(repo, prefs))
+        assertEquals(SampleChats.all().size, repo.listSessions().size)
+    }
+
+    @Test
+    fun `deleted samples do not come back`() = runBlocking {
+        val repo = repo()
+        SampleChatSeeder.seedIfNeeded(repo, prefs)
+        repo.listSessions().forEach { repo.deleteSession(it.id) }
+        assertFalse(SampleChatSeeder.seedIfNeeded(repo, prefs))
+        assertTrue(repo.listSessions().isEmpty())
+    }
+
+    @Test
+    fun `an upgrading user with chats is never seeded`() = runBlocking {
+        val repo = repo()
+        repo.saveSession(
+            ChatSession(id = "mine", title = "My chat", lastModified = 0L, messages = emptyList())
+        )
+        assertFalse(SampleChatSeeder.seedIfNeeded(repo, prefs))
+        assertEquals(listOf("mine"), repo.listSessions().map { it.id })
+        // The flag is still written, so emptying the list later does not
+        // suddenly turn an established install into a fresh one.
+        assertTrue(prefs.getBoolean(SampleChatSeeder.SEEDED_KEY, false))
+        repo.deleteSession("mine")
+        assertFalse(SampleChatSeeder.seedIfNeeded(repo, prefs))
+        assertTrue(repo.listSessions().isEmpty())
+    }
+}

--- a/app/src/test/java/com/gotcha/data/SampleChatsTest.kt
+++ b/app/src/test/java/com/gotcha/data/SampleChatsTest.kt
@@ -1,0 +1,134 @@
+package com.gotcha.data
+
+import com.gotcha.agent.MessageKind
+import com.gotcha.tools.AgentMode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * [SampleChats] is hand-written content that the app persists and then replays
+ * as if it were a real transcript. These are the invariants that replay relies
+ * on — most importantly that continuing a sample sends a history the provider
+ * will accept.
+ */
+class SampleChatsTest {
+
+    private val samples = SampleChats.all(now = 1_000_000L)
+
+    @Test
+    fun `ships one or two samples with stable unique ids`() {
+        assertTrue("Expected 1-2 samples, got ${samples.size}", samples.size in 1..2)
+        assertEquals(samples.size, samples.map { it.id }.distinct().size)
+        assertEquals(
+            listOf(SampleChats.DEVICE_ACTION_ID, SampleChats.SCREEN_QA_ID).sorted(),
+            samples.map { it.id }.sorted()
+        )
+    }
+
+    @Test
+    fun `every sample is marked as one and has a title`() {
+        samples.forEach { sample ->
+            assertTrue("Unmarked sample: ${sample.id}", sample.isSample)
+            assertTrue("Blank title in ${sample.id}", sample.title.isNotBlank())
+        }
+    }
+
+    @Test
+    fun `samples are dated before now so a real chat sorts above them`() {
+        val now = 1_000_000L
+        SampleChats.all(now).forEach { sample ->
+            assertTrue("${sample.id} is not in the past", sample.lastModified < now)
+        }
+        // And they are ordered relative to each other, so the drawer can't shuffle.
+        assertEquals(
+            SampleChats.all(now).map { it.lastModified }.distinct().size,
+            samples.size
+        )
+    }
+
+    @Test
+    fun `each sample shows a short exchange, opened by the user`() {
+        samples.forEach { sample ->
+            assertTrue("${sample.id} has no transcript", sample.displayMessages.isNotEmpty())
+            assertEquals(
+                "${sample.id} must open with the user",
+                MessageKind.USER,
+                sample.displayMessages.first().kind
+            )
+            assertEquals(
+                "${sample.id} must end with the assistant",
+                MessageKind.ASSISTANT,
+                sample.displayMessages.last().kind
+            )
+            val userTurns = sample.displayMessages.count { it.kind == MessageKind.USER }
+            assertTrue("${sample.id} shows $userTurns exchanges, expected 1-2", userTurns in 1..2)
+            assertTrue(
+                "${sample.id} has a blank bubble",
+                sample.displayMessages.all { it.text.isNotBlank() }
+            )
+        }
+    }
+
+    @Test
+    fun `display message ids are unique and ordered`() {
+        // The transcript is restored verbatim and keyed by id in the LazyColumn,
+        // and ChatViewModel resumes numbering from the maximum.
+        samples.forEach { sample ->
+            val ids = sample.displayMessages.map { it.id }
+            assertEquals("Duplicate ids in ${sample.id}", ids.size, ids.distinct().size)
+            assertEquals("Unordered ids in ${sample.id}", ids.sorted(), ids)
+        }
+    }
+
+    @Test
+    fun `history is plain alternating text with no orphan tool calls`() {
+        samples.forEach { sample ->
+            val roles = sample.messages.map { it.role }
+            assertEquals(
+                "${sample.id} must alternate user/assistant",
+                List(roles.size) { if (it % 2 == 0) "user" else "assistant" },
+                roles
+            )
+            sample.messages.forEach { message ->
+                assertTrue("Empty history message in ${sample.id}", message.hasText)
+                // A fabricated tool call has no result to match it, and the
+                // provider rejects the whole request if the user carries on.
+                assertNull("Fabricated tool_calls in ${sample.id}", message.toolCalls)
+                assertNull("Fabricated tool_call_id in ${sample.id}", message.toolCallId)
+            }
+        }
+    }
+
+    @Test
+    fun `history matches what the transcript shows the user saying`() {
+        samples.forEach { sample ->
+            assertEquals(
+                "${sample.id}: history and transcript disagree",
+                sample.displayMessages.filter { it.kind == MessageKind.USER }.map { it.text },
+                sample.messages.filter { it.role == "user" }.map { it.textContent }
+            )
+        }
+    }
+
+    @Test
+    fun `agent mode is a real mode and both modes are demonstrated`() {
+        val modes = samples.map { sample ->
+            val raw = requireNotNull(sample.agentMode) { "${sample.id} has no agent mode" }
+            AgentMode.valueOf(raw)
+        }
+        assertEquals("Samples should show both halves of the selector", 2, modes.distinct().size)
+    }
+
+    @Test
+    fun `samples start with a clean slate`() {
+        // Seeded chats were never run, so there is nothing to count or share:
+        // a non-zero token count would show a context readout in the drawer for
+        // a conversation that never cost anything.
+        samples.forEach { sample ->
+            assertEquals(0, sample.tokenCount)
+            assertTrue(sample.runSummaries.isEmpty())
+        }
+    }
+}

--- a/app/src/test/java/com/gotcha/tools/AppInfoToolTest.kt
+++ b/app/src/test/java/com/gotcha/tools/AppInfoToolTest.kt
@@ -1,0 +1,99 @@
+package com.gotcha.tools
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.gotcha.ui.SettingsPage
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * `about_gotcha`.
+ *
+ * The asset shipping at all is the first thing to check, as with
+ * [CompanyInfoToolTest]. The second is drift, which is the risk specific to this
+ * document: it names settings pages and capabilities that the code can rename
+ * underneath it, and a stale settings path is worse than none — the agent states
+ * it with confidence and sends the user somewhere that no longer exists. So the
+ * assertions below are made against the enums themselves rather than against
+ * copies of their strings.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [30, 34])
+class AppInfoToolTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val tool = AppInfoTool(context)
+
+    @Test
+    fun `about_gotcha reads the bundled asset`() {
+        val result = tool.aboutGotcha()
+
+        assertTrue(result.message, result.success)
+        assertTrue("expected substantial content, got ${result.message.length} chars", result.message.length > 500)
+    }
+
+    @Test
+    fun `every settings page the app can open is documented`() {
+        val text = tool.aboutGotcha().message
+
+        SettingsPage.entries.forEach { page ->
+            assertTrue(
+                "the handbook does not mention the '${page.title}' settings page, so the agent " +
+                    "cannot tell the user how to reach it",
+                text.contains(page.title)
+            )
+        }
+    }
+
+    @Test
+    fun `every gated capability is documented with the tools it unlocks`() {
+        val text = tool.aboutGotcha().message
+
+        // The label reads as a sentence fragment ("it needs <label>"), so match on its
+        // distinguishing noun rather than the whole phrase.
+        val subjects = mapOf(
+            Capability.ACCESSIBILITY to "accessibility service",
+            Capability.NOTIFICATION_LISTENER to "Notification access",
+            Capability.DEVICE_ADMIN to "Device admin",
+            Capability.ROOT to "Root",
+            Capability.TERMUX to "Termux",
+            Capability.HEALTH_CONNECT to "Health Connect",
+            Capability.OVERLAY to "Display over other apps"
+        )
+        assertTrue(
+            "a Capability was added or removed without updating this test or the handbook",
+            subjects.keys == Capability.entries.toSet()
+        )
+        subjects.forEach { (capability, subject) ->
+            assertTrue(
+                "the handbook does not document '$subject', which gates ${capability.tools.size} tool(s)",
+                text.contains(subject)
+            )
+        }
+    }
+
+    @Test
+    fun `both copilot modes are explained`() {
+        val text = tool.aboutGotcha().message
+
+        assertTrue(text.contains("Monitor"))
+        assertTrue(text.contains("Operator"))
+    }
+
+    /**
+     * The two info tools must stay in their own lanes: this one exists so the
+     * agent stops guessing at app behaviour, not so it can paraphrase the legal
+     * documents that [CompanyInfoTool] already refuses to stand in for.
+     */
+    @Test
+    fun `company and legal questions are handed to the other tool`() {
+        val text = tool.aboutGotcha().message
+
+        assertTrue(text.contains("about_samosa_ai"))
+        assertFalse("the handbook must not restate the agreements", text.contains("BY INSTALLING"))
+    }
+}

--- a/app/src/test/java/com/gotcha/ui/StarterPromptsTest.kt
+++ b/app/src/test/java/com/gotcha/ui/StarterPromptsTest.kt
@@ -1,0 +1,52 @@
+package com.gotcha.ui
+
+import androidx.compose.runtime.saveable.SaverScope
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * [STARTER_PROMPTS] is a hand-edited list that the home screen draws from
+ * blindly. These are the invariants that drawing relies on.
+ */
+class StarterPromptsTest {
+
+    @Test
+    fun `offers enough starters to draw from`() {
+        assertTrue(
+            "The home screen draws $STARTER_PROMPT_COUNT starters per session, " +
+                "so the list must hold at least that many",
+            STARTER_PROMPTS.size >= STARTER_PROMPT_COUNT
+        )
+        assertTrue("Expected a spread of starters to draw from", STARTER_PROMPTS.size >= 5)
+    }
+
+    @Test
+    fun `every starter has a label and a template`() {
+        STARTER_PROMPTS.forEach { prompt ->
+            assertTrue("Blank label in $prompt", prompt.label.isNotBlank())
+            assertTrue("Blank template in $prompt", prompt.template.isNotBlank())
+            // The chip has to sit three to a row on a phone.
+            assertTrue(
+                "Label too long to fit a chip: '${prompt.label}'",
+                prompt.label.length <= 20
+            )
+        }
+    }
+
+    @Test
+    fun `labels are unique`() {
+        // The saver restores a drawn starter by its label, and the chips are
+        // test-tagged by it, so duplicates would make both ambiguous.
+        val labels = STARTER_PROMPTS.map { it.label }
+        assertEquals(labels.size, labels.distinct().size)
+    }
+
+    @Test
+    fun `saver round-trips a drawn set`() {
+        val drawn = STARTER_PROMPTS.take(STARTER_PROMPT_COUNT)
+        val scope = SaverScope { true }
+        val saved = requireNotNull(with(StarterPromptLabelsSaver) { scope.save(drawn) })
+        assertEquals(drawn, StarterPromptLabelsSaver.restore(saved))
+    }
+}

--- a/app/src/test/resources/feature-test-coverage.json
+++ b/app/src/test/resources/feature-test-coverage.json
@@ -23,6 +23,14 @@
       "notes": "the bundled asset ships and still contains the company, product and contact facts the tool promises"
     },
     {
+      "tool": "about_gotcha",
+      "tier": "ROBOLECTRIC",
+      "tests": [
+        "com.gotcha.tools.AppInfoToolTest"
+      ],
+      "notes": "the bundled handbook ships and still documents every SettingsPage and every gated Capability, checked against the enums so a rename fails the build"
+    },
+    {
       "tool": "get_storage_info",
       "tier": "ROBOLECTRIC",
       "tests": [

--- a/docs/FEATURE_TEST_COVERAGE.md
+++ b/docs/FEATURE_TEST_COVERAGE.md
@@ -14,12 +14,12 @@ Every tool the assistant can call is listed below, together with how it is verif
 | Tier | Tools | What it means |
 |---|---:|---|
 | `UNIT` | 24 | Plain JVM unit test — no Android framework needed. |
-| `ROBOLECTRIC` | 27 | JVM test against Robolectric's Android framework, often across several API levels. |
+| `ROBOLECTRIC` | 28 | JVM test against Robolectric's Android framework, often across several API levels. |
 | `INSTRUMENTED` | 0 | Runs on a real device or emulator (`app/src/androidTest`). |
 | `MANUAL_ONLY` | 64 | No automated test — verified by hand, see the checklist below. |
-| **Total** | **115** | |
+| **Total** | **116** | |
 
-**51 of 115** tools are covered by an automated test; the remaining 64 are manual-QA-only with a recorded reason.
+**52 of 116** tools are covered by an automated test; the remaining 64 are manual-QA-only with a recorded reason.
 
 ## Foreground tools (act on the screen)
 
@@ -107,6 +107,7 @@ Every tool the assistant can call is listed below, together with how it is verif
 
 | Tool | Tier | Tests / reason |
 |---|---|---|
+| `about_gotcha` | `ROBOLECTRIC` | `AppInfoToolTest` — the bundled handbook ships and still documents every SettingsPage and every gated Capability, checked against the enums so a rename fails the build |
 | `about_samosa_ai` | `ROBOLECTRIC` | `CompanyInfoToolTest` — the bundled asset ships and still contains the company, product and contact facts the tool promises |
 | `ask_final_answer` | `MANUAL_ONLY` | Only reachable from inside a sub-agent loop with a live LLM connection. |
 | `check_availability` | `UNIT` | `CalendarWindowTest` — free/busy window arithmetic |


### PR DESCRIPTION
Four independent changes that were sitting unpushed on `remote-worker`.

## Starter prompts on the empty chat — Closes #80

A new chat was a greeting and an empty composer, which told a first-time user nothing about what Gotcha can be asked for. Three suggestion chips now sit under the agent selector on the home screen, drawn per session from seven starters covering device actions, screen Q&A, the filesystem and messaging.

- Tapping one **fills the composer and stops there** — the template is a draft with its blanks left visible (`Send a WhatsApp to … saying …`), so the user reads, edits and sends it themselves. Nothing is sent on a tap.
- A chip does **not** change the agent mode. The two device actions need Operator, the other five answer in Monitor, and choosing between them stays the selector's job — silently widening what the copilot may do from a tap on a suggestion is not a boundary this should cross.
- Shown only when the composer is actually usable: hidden without an API key, and hidden while a run is in flight in another chat.
- The drawn three are held in `rememberSaveable` keyed on the session, so rotation doesn't reshuffle them.

New: `app/src/main/java/com/gotcha/ui/StarterPrompt.kt`. Wired into the `isHome` branch of `ChatScreen.kt`.

## Wake word named in the assistive-ball setting — Closes #77

The `Hey Gotcha` wake word has always lived on the assistive-ball page — its listener runs inside the ball's service and cannot outlive it — but the settings row said only `Assistive Ball`, so nothing told you where the wake word was or why it switched itself off. The row now names both, and the page states the dependency whether the ball is on or off. The enum constant, test tag and stored preference key are unchanged, so nothing persisted or asserted moves.

## An `about_gotcha` tool for app and settings guidance — Closes #84

There was a company-info tool backing Settings > About (`about_samosa_ai`) but nothing the agent could call about the app it runs inside. So "what can you do?" and "which setting do I change to read replies aloud?" were answered either from the model's memory or by driving the Settings UI to rediscover a path — both of which produce a confident answer pointing somewhere that doesn't exist.

`AppInfoTool` mirrors `CompanyInfoTool` exactly: a bundled asset, read offline, no parameters. The handbook it reads (`assets/app/about-gotcha.md`) covers the capability areas, Monitor vs Operator and what each may touch, the exact path to every settings page, which capability each group of tools waits on and where the user grants it, the safety model, and the common "how do I set up a model / the wake word / Termux" answers. It closes by handing company, pricing and legal questions back to `about_samosa_ai` rather than paraphrasing documents it shouldn't stand in for.

- **Read-only, so Monitor has it too** — added to `baseMonitorTools` alongside `about_samosa_ai`. No capability tier, no confirmation gate, no new permission: it reads one bundled file.
- **The handbook is checked against the code, not against copies of its strings.** `AppInfoToolTest` asserts every `SettingsPage.title` and every `Capability` appears, so renaming a settings page fails the build instead of quietly leaving the agent with a stale path. It also fails if a `Capability` is added without the handbook documenting it.
- `docs/FEATURE_TEST_COVERAGE.md` regenerated with `-PupdateCoverageDocs=true` (115 → 116 tools, 52 automated).

New: `app/src/main/java/com/gotcha/tools/AppInfoTool.kt`, `app/src/main/assets/app/about-gotcha.md`, `app/src/test/java/com/gotcha/tools/AppInfoToolTest.kt`.

## Two sample chats on a fresh install — Closes #82

A fresh install opened on an empty chat list, which told a first-time user nothing about what Gotcha can be asked for. Two transcripts are now seeded on first run: a device action with a follow-up in Operator (turn Wi-Fi on, then the Bluetooth screen the agent opens because Android won't let it flip that switch itself), and a question about the screen in Monitor — the two halves of the agent selector.

- They are ordinary sessions, not a special screen: openable, continuable and deletable like any other, marked in the drawer row and above the transcript so a demonstration is never mistaken for something the user said. The mark is carried through saves too, so carrying a sample on doesn't quietly turn its opening exchange into the user's own words.
- The seeded history holds only the user/assistant text. The tool bubbles are in the on-screen transcript alone, because a fabricated tool call has no result to match it and the provider would reject the first request from a sample the user continued.
- Seeding runs at most once per install and only into a list with nothing in it, so an upgrading user keeps the chats they have and a deleted sample stays deleted. `saveSession` grows a `touch` flag for it: the crafted timestamps are what order the two samples, and the save-time stamp would flatten them into the same millisecond.
- Covered by unit tests plus an on-device flow test (`SampleChatsFlowTest`) verified on an API 36 emulator: app opening onto the two labelled rows, and a relaunch after deleting them.

New: `app/src/main/java/com/gotcha/data/SampleChatSeeder.kt`, `app/src/main/java/com/gotcha/data/SampleChats.kt`, `app/src/androidTest/java/com/gotcha/SampleChatsFlowTest.kt`.

## Verification

- `detekt`, `lintDebug`, `assembleDebug`, `compileDebugAndroidTestKotlin` — all pass clean on the merged tree.
- New `StarterPromptsTest` (list invariants + saver round-trip) passes. New `AppInfoToolTest` passes across API 30 and 34.
- New `ChatRoundTripTest.starterPrompt_fillsComposerWithoutSending` — taps whichever chip was drawn, asserts the composer holds the template while the transcript stays empty and nothing reached the LLM. **Compiled but not executed: no device or emulator was available.** Worth a run before merge.
- Sample-chat seeding: `SampleChatSeederTest`, `SampleChatsTest`, `ChatHistoryRepositoryTest` (unit) plus `SampleChatsFlowTest` (device, verified on an API 36 emulator — all three pass).
- The full `testDebugUnitTest` suite fails locally, but identically on a clean tree without these changes, and in a different class each run (`AppUpdateManagerRobolectricTest`, then `PodcastToolTest`). Confirmed again for the `about_gotcha` work by re-running the failing test against a stashed tree — same failure, so it is pre-existing flakiness unrelated to this PR. Probably deserves its own issue.

Not yet verified on a device: how the three-across chip row wraps with long labels on a narrow screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)